### PR TITLE
Added mode to the run query tool, this makes it easier to search for …

### DIFF
--- a/src/tools/reports.ts
+++ b/src/tools/reports.ts
@@ -215,6 +215,21 @@ export const runQueryTool = {
               },
             },
           },
+          sortDimensions: {
+            type: "string",
+            enum: ['asc', 'desc'],
+            description: "Sort order for dimensions (asc or desc)",
+          },
+          advancedAnalysis: {
+            type: "object",
+            description: "Advanced analysis configuration",
+            properties: {
+              forecast: { type: "boolean" },
+              notTrending: { type: "boolean" },
+              trendingDown: { type: "boolean" },
+              trendingUp: { type: "boolean" }
+            },
+          },
           timeRange: {
             type: "object",
             description: "The time range for the report",
@@ -269,6 +284,11 @@ export const runQueryTool = {
                   items: { type: "string" },
                   description: "Values to filter on",
                 },
+                mode: {
+                  type: "string",
+                  enum: ['contains', 'is', 'is not', 'starts withs', 'does not contain', 'matches regex', 'does not match regex'],
+                  description: "Filter mode (contains, is, is not, starts with, does not contain, matches regex, does not match regex)",
+                }
               },
             },
           },
@@ -297,6 +317,11 @@ export const runQueryTool = {
                 },
               },
             },
+          },
+          sortGroups: {
+            type: "string",
+            enum: ['asc', 'desc'],
+            description: "Sor order for groups (asc or desc)"
           },
           layout: {
             type: "string",


### PR DESCRIPTION
This is to help the agent to run queries for a report. I experienced many scnearios where the agent couldnt figure out the exact name of the service to use in the filter.  Adding the mode allows for better flexibility.

Enhanced Filter Modes:
   • mode: Added comprehensive filter mode options including:
     • contains
     • is / is not
     • starts with
     • does not contain
     • matches regex / does not match regex

This makes it easier to search and filter services without being exact in the name of the service. This reduces an additional call to dimensions endpoint, and in many cases the model cant figure out the exact name to search. 

Added also the following for completeness of what the report config can accept:

Sort Controls:
   • sortDimensions: Added ability to sort dimensions in ascending or descending order
   • sortGroups: Added ability to sort groups in ascending or descending order

Advanced Analysis Options:
   • advancedAnalysis:
     • forecast: Boolean to enable forecasting
     • notTrending: Boolean to identify non-trending data
     • trendingDown: Boolean to identify downward trends
     • trendingUp: Boolean to identify upward trends