### PR TITLE
feat: add create_asset and update_asset tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This MCP server provides many tools including the following:
 - [`get_anomaly`](https://developer.doit.com/reference/getanomaly): Get details about a specific anomaly by ID
 - [`list_assets`](https://developer.doit.com/reference/listassets): Returns a list of all available customer assets such as Google Cloud billing accounts, G Suite/Workspace subscriptions, etc.
 - [`get_asset`](https://developer.doit.com/reference/getasset): Returns details of a specific customer asset by ID, including properties such as customer domain, subscription, and reseller information
+- [`create_asset`](https://developer.doit.com/reference/createasset): Creates a new customer asset (e.g., an AWS account)
+- [`update_asset`](https://developer.doit.com/reference/idofasset): Updates an existing asset, such as adding or removing licenses
 - [`trigger_cloud_flow`](https://developer.doit.com/reference/triggercloudflow): Triggers a CloudFlow by its flow ID, optionally passing a JSON payload as the request body
 - [`find_cloud_diagrams`](https://developer.doit.com/reference/findclouddiagrams): Returns diagram URLs matching the provided resource IDs from the DoiT Cloud Diagrams API
 - [`list_reports`](https://developer.doit.com/reference/listreports): Lists Cloud Analytics reports that your account has access to

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This MCP server provides many tools including the following:
 - [`list_assets`](https://developer.doit.com/reference/listassets): Returns a list of all available customer assets such as Google Cloud billing accounts, G Suite/Workspace subscriptions, etc.
 - [`get_asset`](https://developer.doit.com/reference/getasset): Returns details of a specific customer asset by ID, including properties such as customer domain, subscription, and reseller information
 - [`create_asset`](https://developer.doit.com/reference/createasset): Creates a new customer asset (e.g., an AWS account)
-- [`update_asset`](https://developer.doit.com/reference/idofasset): Updates an existing asset, such as adding or removing licenses
+- [`update_asset`](https://developer.doit.com/reference/updateasset): Updates an existing asset, such as adding or removing licenses
 - [`trigger_cloud_flow`](https://developer.doit.com/reference/triggercloudflow): Triggers a CloudFlow by its flow ID, optionally passing a JSON payload as the request body
 - [`find_cloud_diagrams`](https://developer.doit.com/reference/findclouddiagrams): Returns diagram URLs matching the provided resource IDs from the DoiT Cloud Diagrams API
 - [`list_reports`](https://developer.doit.com/reference/listreports): Lists Cloud Analytics reports that your account has access to

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -62,10 +62,14 @@ import {
   updateAllocationTool,
 } from "../../src/tools/allocations.js";
 import {
+  CreateAssetArgumentsSchema,
+  createAssetTool,
   GetAssetArgumentsSchema,
   getAssetTool,
   ListAssetsArgumentsSchema,
   listAssetsTool,
+  UpdateAssetArgumentsSchema,
+  updateAssetTool,
 } from "../../src/tools/assets.js";
 import {
   CreateAlertArgumentsSchema,
@@ -362,6 +366,8 @@ export class DoitMCPAgent extends McpAgent {
     // Assets tools
     this.registerTool(listAssetsTool, ListAssetsArgumentsSchema);
     this.registerTool(getAssetTool, GetAssetArgumentsSchema);
+    this.registerTool(createAssetTool, CreateAssetArgumentsSchema);
+    this.registerTool(updateAssetTool, UpdateAssetArgumentsSchema);
 
     // CloudFlow tools
     this.registerTool(triggerCloudFlowTool, TriggerCloudFlowArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -63,8 +63,10 @@ vi.mock(import("../tools/allocations.js"), async (importOriginal) => ({
 }));
 vi.mock(import("../tools/assets.js"), async (importOriginal) => ({
     ...(await importOriginal()),
+    handleCreateAssetRequest: vi.fn(),
     handleGetAssetRequest: vi.fn(),
     handleListAssetsRequest: vi.fn(),
+    handleUpdateAssetRequest: vi.fn(),
 }));
 vi.mock(import("../tools/alerts.js"), async (importOriginal) => ({
     ...(await importOriginal()),
@@ -139,6 +141,7 @@ import {
     handleCloudIncidentRequest,
     handleCloudIncidentsRequest,
     handleCreateAllocationRequest,
+    handleCreateAssetRequest,
     handleCreateLabelRequest,
     handleDimensionRequest,
     handleDimensionsRequest,
@@ -158,6 +161,7 @@ import {
     handleRunQueryRequest,
     handleTriggerCloudFlowRequest,
     handleUpdateAllocationRequest,
+    handleUpdateAssetRequest,
     handleUpdateLabelRequest,
     handleUpdateReportRequest,
     handleValidateUserRequest,
@@ -177,7 +181,7 @@ import {
     updateAnnotationTool,
 } from "../tools/annotations.js";
 import { anomaliesTool, anomalyTool } from "../tools/anomalies.js";
-import { getAssetTool, listAssetsTool } from "../tools/assets.js";
+import { createAssetTool, getAssetTool, listAssetsTool, updateAssetTool } from "../tools/assets.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "../tools/budgets.js";
 import { findCloudDiagramsTool } from "../tools/cloudDiagrams.js";
 import { triggerCloudFlowTool } from "../tools/cloudflow.js";
@@ -279,6 +283,8 @@ describe("ListToolsRequestSchema handler", () => {
                 updateAllocationTool,
                 listAssetsTool,
                 getAssetTool,
+                createAssetTool,
+                updateAssetTool,
                 listAlertsTool,
                 getAlertTool,
                 createAlertTool,
@@ -636,6 +642,13 @@ describe("CallToolRequestSchema handler", () => {
         ],
         ["list_assets", "list_assets", { pageToken: "next-page" }, handleListAssetsRequest],
         ["get_asset", "get_asset", { id: "asset-123" }, handleGetAssetRequest],
+        [
+            "create_asset",
+            "create_asset",
+            { type: "amazon-web-services", accountName: "Test" },
+            handleCreateAssetRequest,
+        ],
+        ["update_asset", "update_asset", { id: "asset-123", quantity: 5 }, handleUpdateAssetRequest],
         ["list_alerts", "list_alerts", { sortBy: "name", sortOrder: "asc" }, handleListAlertsRequest],
         ["get_alert", "get_alert", { id: "alert-123" }, handleGetAlertRequest],
         ["create_label", "create_label", { name: "Test", color: "blue" }, handleCreateLabelRequest],

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,7 +41,16 @@ import {
     updateAnnotationTool,
 } from "./tools/annotations.js";
 import { anomaliesTool, anomalyTool, handleAnomaliesRequest, handleAnomalyRequest } from "./tools/anomalies.js";
-import { getAssetTool, handleGetAssetRequest, handleListAssetsRequest, listAssetsTool } from "./tools/assets.js";
+import {
+    createAssetTool,
+    getAssetTool,
+    handleCreateAssetRequest,
+    handleGetAssetRequest,
+    handleListAssetsRequest,
+    handleUpdateAssetRequest,
+    listAssetsTool,
+    updateAssetTool,
+} from "./tools/assets.js";
 import {
     createBudgetTool,
     getBudgetTool,
@@ -144,6 +153,8 @@ export function createServer() {
                 updateAllocationTool,
                 listAssetsTool,
                 getAssetTool,
+                createAssetTool,
+                updateAssetTool,
                 listAlertsTool,
                 getAlertTool,
                 createAlertTool,
@@ -277,8 +288,10 @@ export {
     handleListAlertsRequest,
     handleListAllocationsRequest,
     handleListAnnotationsRequest,
+    handleCreateAssetRequest,
     handleGetAssetRequest,
     handleListAssetsRequest,
+    handleUpdateAssetRequest,
     handleListBudgetsRequest,
     handleListInvoicesRequest,
     handleListLabelsRequest,

--- a/src/tools/__tests__/assets.test.ts
+++ b/src/tools/__tests__/assets.test.ts
@@ -220,6 +220,7 @@ describe("handleCreateAssetRequest", () => {
 
         expect(makeDoitRequest).toHaveBeenCalledWith(expect.stringContaining(`${CREATE_ASSET_URL}?`), mockToken, {
             method: "POST",
+            appendParams: false,
             customerContext: undefined,
         });
         expect(makeDoitRequest).toHaveBeenCalledWith(
@@ -253,6 +254,7 @@ describe("handleCreateAssetRequest", () => {
         await handleCreateAssetRequest({ customerContext: "customer-123" }, mockToken);
         expect(makeDoitRequest).toHaveBeenCalledWith(expect.any(String), mockToken, {
             method: "POST",
+            appendParams: false,
             customerContext: "customer-123",
         });
     });

--- a/src/tools/__tests__/assets.test.ts
+++ b/src/tools/__tests__/assets.test.ts
@@ -317,6 +317,7 @@ describe("handleUpdateAssetRequest", () => {
         expect(makeDoitRequest).toHaveBeenCalledWith(`${ASSETS_BASE_URL}/asset-1`, mockToken, {
             method: "PATCH",
             body: { quantity: 10 },
+            appendParams: false,
             customerContext: undefined,
         });
 
@@ -331,6 +332,7 @@ describe("handleUpdateAssetRequest", () => {
         expect(makeDoitRequest).toHaveBeenCalledWith(expect.any(String), mockToken, {
             method: "PATCH",
             body: { quantity: 5 },
+            appendParams: false,
             customerContext: "customer-123",
         });
     });

--- a/src/tools/__tests__/assets.test.ts
+++ b/src/tools/__tests__/assets.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
 import {
     ASSETS_BASE_URL,
+    CREATE_ASSET_URL,
     DEFAULT_MAX_RESULTS_ASSETS,
+    handleCreateAssetRequest,
     handleGetAssetRequest,
     handleListAssetsRequest,
+    handleUpdateAssetRequest,
 } from "../assets.js";
 
 vi.mock("../../utils/util.js", async (importOriginal) => {
@@ -200,6 +203,203 @@ describe("handleGetAssetRequest", () => {
         const response = await handleGetAssetRequest({ id: "   " }, mockToken);
         expect(response).toEqual({
             content: [{ type: "text", text: expect.stringContaining("Asset ID is required") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+});
+
+describe("handleCreateAssetRequest", () => {
+    const mockToken = "test-token";
+
+    const mockCreateResponse = { accountID: "new-account-123" };
+
+    it("should call makeDoitRequest with POST and query params including defaults", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockCreateResponse);
+        const response = await handleCreateAssetRequest({}, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(expect.stringContaining(`${CREATE_ASSET_URL}?`), mockToken, {
+            method: "POST",
+            customerContext: undefined,
+        });
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("type=amazon-web-services"),
+            mockToken,
+            expect.any(Object)
+        );
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("mode=New"),
+            mockToken,
+            expect.any(Object)
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.accountID).toBe("new-account-123");
+    });
+
+    it("should include rootEmail in query params when provided", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockCreateResponse);
+        await handleCreateAssetRequest({ rootEmail: "admin@example.com" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("rootEmail=admin%40example.com"),
+            mockToken,
+            expect.any(Object)
+        );
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockCreateResponse);
+        await handleCreateAssetRequest({ customerContext: "customer-123" }, mockToken);
+        expect(makeDoitRequest).toHaveBeenCalledWith(expect.any(String), mockToken, {
+            method: "POST",
+            customerContext: "customer-123",
+        });
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const response = await handleCreateAssetRequest({}, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("asset") }],
+            isError: true,
+        });
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+        const response = await handleCreateAssetRequest({}, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when rootEmail is not a valid email", async () => {
+        const response = await handleCreateAssetRequest({ rootEmail: "not-an-email" }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("valid email") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return error when type is an empty string", async () => {
+        const response = await handleCreateAssetRequest({ type: "" }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("non-empty") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+});
+
+describe("handleUpdateAssetRequest", () => {
+    const mockToken = "test-token";
+
+    const mockUpdateResponse = {
+        id: "asset-1",
+        properties: {
+            customerDomain: "example.com",
+            customerID: "cust-123",
+            reseller: "doit",
+            subscription: { id: "sub-1", status: "ACTIVE" },
+        },
+        type: "commitment",
+    };
+
+    it("should call makeDoitRequest with PATCH, correct URL, and body without id", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockUpdateResponse);
+        const response = await handleUpdateAssetRequest({ id: "asset-1", quantity: 10 }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${ASSETS_BASE_URL}/asset-1`, mockToken, {
+            method: "PATCH",
+            body: { quantity: 10 },
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.id).toBe("asset-1");
+        expect(parsed.type).toBe("commitment");
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockUpdateResponse);
+        await handleUpdateAssetRequest({ id: "asset-1", quantity: 5, customerContext: "customer-123" }, mockToken);
+        expect(makeDoitRequest).toHaveBeenCalledWith(expect.any(String), mockToken, {
+            method: "PATCH",
+            body: { quantity: 5 },
+            customerContext: "customer-123",
+        });
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+        const response = await handleUpdateAssetRequest({ id: "asset-1", quantity: 10 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("asset") }],
+            isError: true,
+        });
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+        const response = await handleUpdateAssetRequest({ id: "asset-1", quantity: 10 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when id is missing", async () => {
+        const response = await handleUpdateAssetRequest({ quantity: 10 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Required") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return error when id is empty string", async () => {
+        const response = await handleUpdateAssetRequest({ id: "", quantity: 10 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Asset ID is required") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return error when id is whitespace only", async () => {
+        const response = await handleUpdateAssetRequest({ id: "   ", quantity: 10 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Asset ID is required") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return error when quantity is missing", async () => {
+        const response = await handleUpdateAssetRequest({ id: "asset-1" }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Required") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return error when quantity is negative", async () => {
+        const response = await handleUpdateAssetRequest({ id: "asset-1", quantity: -5 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("positive") }],
+            isError: true,
+        });
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should return error when quantity is zero", async () => {
+        const response = await handleUpdateAssetRequest({ id: "asset-1", quantity: 0 }, mockToken);
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("positive") }],
             isError: true,
         });
         expect(makeDoitRequest).not.toHaveBeenCalled();

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -201,6 +201,7 @@ export async function handleUpdateAssetRequest(args: any, token: string) {
         const data = await makeDoitRequest<UpdateAssetResponse>(url, token, {
             method: "PATCH",
             body,
+            appendParams: false,
             customerContext,
         });
 

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -155,6 +155,7 @@ export async function handleCreateAssetRequest(args: any, token: string) {
 
         const data = await makeDoitRequest<CreateAssetResponse>(url, token, {
             method: "POST",
+            appendParams: false,
             customerContext,
         });
 

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { AssetDetailed, ListAssetsResponse } from "../types/assets.js";
+import type { AssetDetailed, CreateAssetResponse, ListAssetsResponse, UpdateAssetResponse } from "../types/assets.js";
 import { zodToMcpInputSchema } from "../utils/schemaHelpers.js";
 import {
     createErrorResponse,
@@ -11,6 +11,7 @@ import {
 } from "../utils/util.js";
 
 export const ASSETS_BASE_URL = `${DOIT_API_BASE}/billing/v1/assets`;
+export const CREATE_ASSET_URL = `${DOIT_API_BASE}/billing/v1/createAsset`;
 export const DEFAULT_MAX_RESULTS_ASSETS = "100";
 export const MAX_MAX_RESULTS_ASSETS = 249;
 
@@ -107,5 +108,108 @@ export async function handleGetAssetRequest(args: any, token: string) {
     } catch (error) {
         if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
         return handleGeneralError(error, "handling get asset request");
+    }
+}
+
+// Schema and metadata for create asset
+export const CreateAssetArgumentsSchema = z.object({
+    type: z
+        .string()
+        .min(1, "Asset type must be non-empty if provided.")
+        .optional()
+        .default("amazon-web-services")
+        .describe('Asset type. For example, "amazon-web-services" (default).'),
+    mode: z
+        .string()
+        .min(1, "Asset mode must be non-empty if provided.")
+        .optional()
+        .default("New")
+        .describe('Asset mode (default: "New").'),
+    accountName: z
+        .string()
+        .min(1, "Account name must be non-empty if provided.")
+        .optional()
+        .default("Account name")
+        .describe('The desired name of the account (default: "Account name").'),
+    rootEmail: z.string().email("Must be a valid email address.").optional().describe("The root account email."),
+});
+
+export const createAssetTool = {
+    name: "create_asset",
+    description: "Creates a new customer asset (e.g., an AWS account) via the DoiT API. Returns the new account ID.",
+    inputSchema: zodToMcpInputSchema(CreateAssetArgumentsSchema),
+};
+
+export async function handleCreateAssetRequest(args: any, token: string) {
+    try {
+        const parsed = CreateAssetArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const params = new URLSearchParams();
+        params.append("type", parsed.type);
+        params.append("mode", parsed.mode);
+        params.append("accountName", parsed.accountName);
+        if (parsed.rootEmail) params.append("rootEmail", parsed.rootEmail);
+
+        const url = `${CREATE_ASSET_URL}?${params}`;
+
+        const data = await makeDoitRequest<CreateAssetResponse>(url, token, {
+            method: "POST",
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to create asset");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling create asset request");
+    }
+}
+
+// Schema and metadata for update asset
+export const UpdateAssetArgumentsSchema = z.object({
+    id: z
+        .string()
+        .transform((val) => val.trim())
+        .pipe(z.string().min(1, "Asset ID is required and cannot be empty."))
+        .describe("The ID of the asset to update."),
+    quantity: z
+        .number()
+        .int()
+        .positive("Quantity must be a positive integer.")
+        .describe("The new license quantity for the asset (required)."),
+});
+
+export const updateAssetTool = {
+    name: "update_asset",
+    description:
+        "Updates an existing customer asset (such as G Suite/Workspace or Office 365 subscription) to add or remove licenses.",
+    inputSchema: zodToMcpInputSchema(UpdateAssetArgumentsSchema),
+};
+
+export async function handleUpdateAssetRequest(args: any, token: string) {
+    try {
+        const parsed = UpdateAssetArgumentsSchema.parse(args);
+        const { customerContext } = args;
+        const { id, ...body } = parsed;
+        const url = `${ASSETS_BASE_URL}/${encodeURIComponent(id)}`;
+
+        const data = await makeDoitRequest<UpdateAssetResponse>(url, token, {
+            method: "PATCH",
+            body,
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to update asset");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling update asset request");
     }
 }

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -58,3 +58,13 @@ export type ListAssetsResponse = {
     pageToken?: string;
     rowCount: number;
 };
+
+export type CreateAssetResponse = {
+    accountID: string;
+};
+
+export type UpdateAssetResponse = {
+    id: string;
+    properties: AssetProperties;
+    type: string;
+};

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DebugLevel, debugLog, formatEnumValues, toSnakeCase } from "../util.js";
+import { appendUrlParameters, DebugLevel, debugLog, formatEnumValues, makeDoitRequest, toSnakeCase } from "../util.js";
+
+const ORIGINAL_ENV = { ...process.env };
 
 beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env = { ...ORIGINAL_ENV };
 });
 
 afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    process.env = { ...ORIGINAL_ENV };
 });
 
 describe("DebugLevel enum", () => {
@@ -132,5 +137,65 @@ describe("formatEnumValues", () => {
 
     it("works with plain arrays", () => {
         expect(formatEnumValues(["a", "b", "c"])).toBe("a, b, c");
+    });
+});
+
+describe("appendUrlParameters", () => {
+    it("adds maxResults and customerContext", () => {
+        const url = appendUrlParameters("https://example.com/test?foo=bar", "customer-123");
+        expect(url).toContain("foo=bar");
+        expect(url).toContain("maxResults=40");
+        expect(url).toContain("customerContext=customer-123");
+    });
+
+    it("uses CUSTOMER_CONTEXT from the environment when no explicit value is passed", () => {
+        process.env.CUSTOMER_CONTEXT = "env-customer";
+        const url = appendUrlParameters("https://example.com/test");
+        expect(url).toContain("customerContext=env-customer");
+    });
+});
+
+describe("makeDoitRequest", () => {
+    it("keeps customerContext when appendParams is false", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: new Headers(),
+            json: vi.fn().mockResolvedValue({ ok: true }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await makeDoitRequest("https://example.com/test?foo=bar", "token-123", {
+            method: "POST",
+            appendParams: false,
+            customerContext: "customer-123",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://example.com/test?foo=bar&customerContext=customer-123&mcp=true",
+            expect.objectContaining({ method: "POST" })
+        );
+    });
+
+    it("does not add maxResults when appendParams is false", async () => {
+        process.env.CUSTOMER_CONTEXT = "env-customer";
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: new Headers(),
+            json: vi.fn().mockResolvedValue({ ok: true }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await makeDoitRequest("https://example.com/test?foo=bar", "token-123", {
+            appendParams: false,
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://example.com/test?foo=bar&customerContext=env-customer&mcp=true",
+            expect.objectContaining({ method: "GET" })
+        );
     });
 });

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -141,22 +141,21 @@ describe("formatEnumValues", () => {
 });
 
 describe("appendUrlParameters", () => {
-    it("adds maxResults and customerContext", () => {
-        const url = appendUrlParameters("https://example.com/test?foo=bar", "customer-123");
+    it("adds maxResults to a URL with existing query params", () => {
+        const url = appendUrlParameters("https://example.com/test?foo=bar");
         expect(url).toContain("foo=bar");
         expect(url).toContain("maxResults=40");
-        expect(url).toContain("customerContext=customer-123");
     });
 
-    it("uses CUSTOMER_CONTEXT from the environment when no explicit value is passed", () => {
-        process.env.CUSTOMER_CONTEXT = "env-customer";
-        const url = appendUrlParameters("https://example.com/test");
-        expect(url).toContain("customerContext=env-customer");
+    it("does not add maxResults if already present", () => {
+        const url = appendUrlParameters("https://example.com/test?maxResults=10");
+        expect(url).toBe("https://example.com/test?maxResults=10");
     });
 });
 
 describe("makeDoitRequest", () => {
     it("keeps customerContext when appendParams is false", async () => {
+        process.env.CUSTOMER_CONTEXT = "customer-123";
         const fetchMock = vi.fn().mockResolvedValue({
             ok: true,
             status: 200,

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -19,7 +19,12 @@ import {
     handleUpdateAnnotationRequest,
 } from "../tools/annotations.js";
 import { handleAnomaliesRequest, handleAnomalyRequest } from "../tools/anomalies.js";
-import { handleGetAssetRequest, handleListAssetsRequest } from "../tools/assets.js";
+import {
+    handleCreateAssetRequest,
+    handleGetAssetRequest,
+    handleListAssetsRequest,
+    handleUpdateAssetRequest,
+} from "../tools/assets.js";
 import {
     handleCreateBudgetRequest,
     handleGetBudgetRequest,
@@ -136,6 +141,12 @@ export async function executeToolHandler(
                 break;
             case "get_asset":
                 result = await handleGetAssetRequest(args, token);
+                break;
+            case "create_asset":
+                result = await handleCreateAssetRequest(args, token);
+                break;
+            case "update_asset":
+                result = await handleUpdateAssetRequest(args, token);
                 break;
             case "trigger_cloud_flow":
                 result = await handleTriggerCloudFlowRequest(args, token);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -155,7 +155,7 @@ export function appendUrlParameters(baseUrl: string): string {
  * @param options Additional request options
  * @param options.method HTTP method (GET, POST, etc.)
  * @param options.body Request body for POST/PUT requests
- * @param options.appendParams Whether to append default maxResults parameter (default: true). customerContext, mcp, and sse are always appended regardless of this flag.
+ * @param options.appendParams Whether to append the default maxResults query parameter (default: true). This flag only controls maxResults: customerContext is appended when provided in options or via process.env.CUSTOMER_CONTEXT, mcp is always appended, and sse is appended only when process.env.CUSTOMER_CONTEXT is not set.
  * @returns The parsed JSON response or null on error
  */
 export async function makeDoitRequest<T>(

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -155,7 +155,7 @@ export function appendUrlParameters(baseUrl: string): string {
  * @param options Additional request options
  * @param options.method HTTP method (GET, POST, etc.)
  * @param options.body Request body for POST/PUT requests
- * @param options.appendParams Whether to append URL parameters (maxResults and customerContext)
+ * @param options.appendParams Whether to append default maxResults parameter (default: true). customerContext, mcp, and sse are always appended regardless of this flag.
  * @returns The parsed JSON response or null on error
  */
 export async function makeDoitRequest<T>(

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -129,11 +129,11 @@ export function handleGeneralError(error: any, context: string): ReturnType<type
 }
 
 /**
- * Helper function to append customer context to URL if available
+ * Helper function to append default query parameters (maxResults) to a URL.
  * @param baseUrl The base URL to append parameters to
- * @returns URL with maxResults and optional customerContext parameters
+ * @returns URL with maxResults parameter added (if not already present)
  */
-export function appendUrlParameters(baseUrl: string, customerContextId?: string): string {
+export function appendUrlParameters(baseUrl: string): string {
     // Check if the URL already has query parameters
     const separator = baseUrl.includes("?") ? "&" : "?";
     let url = baseUrl;
@@ -141,13 +141,6 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
     // Only add maxResults if it's not already in the URL
     if (!baseUrl.includes("maxResults=")) {
         url += `${separator}maxResults=40`;
-    }
-
-    const customerContext = customerContextId || process.env.CUSTOMER_CONTEXT;
-
-    if (customerContext) {
-        // Use & as separator since we know the URL now has parameters
-        url += `&customerContext=${customerContext}`;
     }
 
     return url;
@@ -184,8 +177,7 @@ export async function makeDoitRequest<T>(
         Accept: "application/json",
     };
 
-    const resolvedCustomerContext = customerContext || process.env.CUSTOMER_CONTEXT;
-    let requestUrl = appendParams ? appendUrlParameters(url, customerContext) : url;
+    let requestUrl = appendParams ? appendUrlParameters(url) : url;
 
     try {
         const requestOptions: RequestInit = {
@@ -200,7 +192,8 @@ export async function makeDoitRequest<T>(
         }
 
         const urlObject = new URL(requestUrl);
-        if (resolvedCustomerContext && !urlObject.searchParams.has("customerContext")) {
+        const resolvedCustomerContext = customerContext || process.env.CUSTOMER_CONTEXT;
+        if (resolvedCustomerContext) {
             urlObject.searchParams.set("customerContext", resolvedCustomerContext);
         }
         urlObject.searchParams.set("mcp", "true");

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -184,6 +184,7 @@ export async function makeDoitRequest<T>(
         Accept: "application/json",
     };
 
+    const resolvedCustomerContext = customerContext || process.env.CUSTOMER_CONTEXT;
     let requestUrl = appendParams ? appendUrlParameters(url, customerContext) : url;
 
     try {
@@ -198,13 +199,16 @@ export async function makeDoitRequest<T>(
             debugLog("API request body: ", DebugLevel.TRACE, requestOptions.body);
         }
 
-        // add mcp params to the url
-        requestUrl += `&mcp=true`;
-
+        const urlObject = new URL(requestUrl);
+        if (resolvedCustomerContext && !urlObject.searchParams.has("customerContext")) {
+            urlObject.searchParams.set("customerContext", resolvedCustomerContext);
+        }
+        urlObject.searchParams.set("mcp", "true");
         if (!process.env.CUSTOMER_CONTEXT) {
             // request from the sse server
-            requestUrl += `&sse=true`;
+            urlObject.searchParams.set("sse", "true");
         }
+        requestUrl = urlObject.toString();
 
         debugLog("API request URL: ", DebugLevel.VERBOSE, requestUrl);
         const response = await fetch(requestUrl, requestOptions);

--- a/test/integration/fixtures/billing.ts
+++ b/test/integration/fixtures/billing.ts
@@ -63,3 +63,21 @@ export const assetDetailedFixture = {
         },
     },
 };
+
+export const createAssetFixture = {
+    accountID: "new-account-123",
+};
+
+export const updateAssetFixture = {
+    id: "asset-1",
+    properties: {
+        customerDomain: "example.com",
+        customerID: "cust-123",
+        reseller: "doit",
+        subscription: {
+            id: "sub-1",
+            status: "ACTIVE",
+        },
+    },
+    type: "commitment",
+};

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -29,7 +29,14 @@ import {
     updateReportFixture,
 } from "./analytics.js";
 import { anomaliesFixture, anomalyFixture } from "./anomalies.js";
-import { assetDetailedFixture, assetsFixture, invoiceFixture, invoicesFixture } from "./billing.js";
+import {
+    assetDetailedFixture,
+    assetsFixture,
+    createAssetFixture,
+    invoiceFixture,
+    invoicesFixture,
+    updateAssetFixture,
+} from "./billing.js";
 import { cloudDiagramsFixture } from "./cloudDiagrams.js";
 import { cloudflowTriggerFixture } from "./cloudflow.js";
 import { cloudIncidentFixture, cloudIncidentsFixture } from "./cloudIncidents.js";
@@ -72,6 +79,8 @@ export const fixtures = {
     invoice: invoiceFixture,
     assets: assetsFixture,
     assetDetailed: assetDetailedFixture,
+    createAsset: createAssetFixture,
+    updateAsset: updateAssetFixture,
 
     tickets: ticketsFixture,
 

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -131,6 +131,12 @@ export const mockedDoitApiHandlers = [
     }),
 
     // Assets
+    http.post(`${API_BASE}/billing/v1/createAsset`, () => {
+        return HttpResponse.json(fixtures.createAsset);
+    }),
+    http.patch(`${API_BASE}/billing/v1/assets/:id`, () => {
+        return HttpResponse.json(fixtures.updateAsset);
+    }),
     http.get(`${API_BASE}/billing/v1/assets/:id`, ({ params }) => {
         if (params.id === "asset-1") {
             return HttpResponse.json(fixtures.assetDetailed);

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -30,6 +30,7 @@ describe("MCP Tools Integration", () => {
                 "create_alert",
                 "create_allocation",
                 "create_annotation",
+                "create_asset",
                 "create_budget",
                 "create_label",
                 "create_report",
@@ -68,6 +69,7 @@ describe("MCP Tools Integration", () => {
                 "update_alert",
                 "update_allocation",
                 "update_annotation",
+                "update_asset",
                 "update_budget",
                 "update_label",
                 "update_report",
@@ -517,6 +519,31 @@ describe("MCP Tools Integration", () => {
             expect(parsed.properties.customerDomain).toBe("example.com");
             expect(parsed.properties.customerID).toBe("cust-123");
             expect(parsed.properties.subscription.status).toBe("ACTIVE");
+        });
+    });
+
+    describe("create_asset", () => {
+        it("creates an asset and returns accountID", async () => {
+            const result = await client.callTool({
+                name: "create_asset",
+                arguments: { type: "amazon-web-services", accountName: "Test Account" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.accountID).toBe("new-account-123");
+        });
+    });
+
+    describe("update_asset", () => {
+        it("updates an asset and returns updated data", async () => {
+            const result = await client.callTool({
+                name: "update_asset",
+                arguments: { id: "asset-1", quantity: 10 },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("asset-1");
+            expect(parsed.type).toBe("commitment");
         });
     });
 


### PR DESCRIPTION
currently blocked by: https://doitintl.atlassian.net/browse/CMP-40849

add create_asset and update_asset tools with request handlers and tests

- Introduced `create_asset` tool to create new customer assets (e.g., AWS accounts) and `update_asset` tool to modify existing assets, including license adjustments.
- Implemented request handlers and input schemas for both tools, ensuring proper validation and error handling.
- Updated README documentation to include new tools and their usage.
- Added comprehensive tests to verify functionality and error handling for asset creation and updates.