### PR TITLE
feat: add ask_ava_sync tool for querying cloud cost insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This MCP server provides many tools including the following:
 - [`update_annotation`](https://developer.doit.com/reference/updateannotation): Updates an existing annotation by ID
 - [`list_commitments`](https://developer.doit.com/reference/listcommitments): Returns a list of commitments (reserved capacity or spend agreements) with cloud providers
 - [`get_commitment`](https://developer.doit.com/reference/getcommitment): Returns details of a specific commitment by ID, including periods and attainment data
-- [`ask_ava_sync`](https://developer.doit.com/reference/askavasync): Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, or optimization opportunities. Note: AVA may take over 60 seconds to respond.
+- [`ask_ava_sync`](https://developer.doit.com/reference/askavasync): Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, or optimization opportunities. Note: AVA can take a long time to respond for complex questions.
 - [`list_organizations`](https://developer.doit.com/reference/listorganizations): Returns a list of organizations accessible to the authenticated user
 - [`list_platforms`](https://developer.doit.com/reference/listplatforms): Returns a list of all available platforms
 - [`list_users`](https://developer.doit.com/reference/listusers): Returns a list of all users in the organization

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This MCP server provides many tools including the following:
 - [`update_annotation`](https://developer.doit.com/reference/updateannotation): Updates an existing annotation by ID
 - [`list_commitments`](https://developer.doit.com/reference/listcommitments): Returns a list of commitments (reserved capacity or spend agreements) with cloud providers
 - [`get_commitment`](https://developer.doit.com/reference/getcommitment): Returns details of a specific commitment by ID, including periods and attainment data
-- [`ask_ava_sync`](https://developer.doit.com/reference/askavasynch): Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, or optimization opportunities. Note: AVA may take over 60 seconds to respond.
+- [`ask_ava_sync`](https://developer.doit.com/reference/askavasync): Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, or optimization opportunities. Note: AVA may take over 60 seconds to respond.
 - [`list_organizations`](https://developer.doit.com/reference/listorganizations): Returns a list of organizations accessible to the authenticated user
 - [`list_platforms`](https://developer.doit.com/reference/listplatforms): Returns a list of all available platforms
 - [`list_users`](https://developer.doit.com/reference/listusers): Returns a list of all users in the organization

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This MCP server provides many tools including the following:
 - [`update_annotation`](https://developer.doit.com/reference/updateannotation): Updates an existing annotation by ID
 - [`list_commitments`](https://developer.doit.com/reference/listcommitments): Returns a list of commitments (reserved capacity or spend agreements) with cloud providers
 - [`get_commitment`](https://developer.doit.com/reference/getcommitment): Returns details of a specific commitment by ID, including periods and attainment data
+- [`ask_ava_sync`](https://developer.doit.com/reference/askavasynch): Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, or optimization opportunities. Note: AVA may take over 60 seconds to respond.
 - [`list_organizations`](https://developer.doit.com/reference/listorganizations): Returns a list of organizations accessible to the authenticated user
 - [`list_platforms`](https://developer.doit.com/reference/listplatforms): Returns a list of all available platforms
 - [`list_users`](https://developer.doit.com/reference/listusers): Returns a list of all users in the organization

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -18,6 +18,7 @@ import {
   anomaliesTool,
   anomalyTool,
 } from "../../src/tools/anomalies.js";
+import { AskAvaSyncArgumentsSchema, askAvaSyncTool } from "../../src/tools/ava.js";
 import {
   CreateReportArgumentsSchema,
   GetReportConfigArgumentsSchema,
@@ -571,6 +572,9 @@ export class DoitMCPAgent extends McpAgent {
     // Commitment Manager tools
     this.registerTool(listCommitmentsTool, ListCommitmentsArgumentsSchema);
     this.registerTool(getCommitmentTool, GetCommitmentArgumentsSchema);
+
+    // AVA tools
+    this.registerTool(askAvaSyncTool, AskAvaSyncArgumentsSchema);
 
     // Change Customer tool (requires special handling)
     if (this.props.isDoitUser === "true") {

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -29,6 +29,10 @@ vi.mock(import("../tools/anomalies.js"), async (importOriginal) => ({
     handleAnomaliesRequest: vi.fn(),
     handleAnomalyRequest: vi.fn(),
 }));
+vi.mock(import("../tools/ava.js"), async (importOriginal) => ({
+    ...(await importOriginal()),
+    handleAskAvaSyncRequest: vi.fn(),
+}));
 vi.mock(import("../tools/reports.js"), async (importOriginal) => ({
     ...(await importOriginal()),
     handleReportsRequest: vi.fn(),
@@ -165,6 +169,7 @@ import {
     createServer,
     handleAnomaliesRequest,
     handleAnomalyRequest,
+    handleAskAvaSyncRequest,
     handleAssignObjectsToLabelRequest,
     handleCloudIncidentRequest,
     handleCloudIncidentsRequest,
@@ -218,6 +223,7 @@ import {
 } from "../tools/annotations.js";
 import { anomaliesTool, anomalyTool } from "../tools/anomalies.js";
 import { getAssetTool, listAssetsTool } from "../tools/assets.js";
+import { askAvaSyncTool } from "../tools/ava.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "../tools/budgets.js";
 import { findCloudDiagramsTool } from "../tools/cloudDiagrams.js";
 import { triggerCloudFlowTool } from "../tools/cloudflow.js";
@@ -376,6 +382,7 @@ describe("ListToolsRequestSchema handler", () => {
                 updateAnnotationTool,
                 listCommitmentsTool,
                 getCommitmentTool,
+                askAvaSyncTool,
             ],
         });
     });
@@ -760,6 +767,7 @@ describe("CallToolRequestSchema handler", () => {
         ],
         ["list_commitments", "list_commitments", {}, handleListCommitmentsRequest],
         ["get_commitment", "get_commitment", { id: "commitment-1" }, handleGetCommitmentRequest],
+        ["ask_ava_sync", "ask_ava_sync", { question: "What is my spend?" }, handleAskAvaSyncRequest],
     ];
 
     it.each(toolRoutingCases)("routes %s to the correct handler", async (_label, toolName, args, handler) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ import {
 } from "./tools/annotations.js";
 import { anomaliesTool, anomalyTool, handleAnomaliesRequest, handleAnomalyRequest } from "./tools/anomalies.js";
 import { getAssetTool, handleGetAssetRequest, handleListAssetsRequest, listAssetsTool } from "./tools/assets.js";
+import { askAvaSyncTool, handleAskAvaSyncRequest } from "./tools/ava.js";
 import {
     createBudgetTool,
     getBudgetTool,
@@ -227,6 +228,7 @@ export function createServer() {
                 updateAnnotationTool,
                 listCommitmentsTool,
                 getCommitmentTool,
+                askAvaSyncTool,
             ],
         };
     });
@@ -310,6 +312,7 @@ export {
     formatZodError,
     handleAnomaliesRequest,
     handleAnomalyRequest,
+    handleAskAvaSyncRequest,
     handleAssignObjectsToLabelRequest,
     handleCloudIncidentRequest,
     handleCloudIncidentsRequest,

--- a/src/tools/__tests__/ava.test.ts
+++ b/src/tools/__tests__/ava.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeDoitRequest } from "../../utils/util.js";
+import { AVA_BASE_URL, handleAskAvaSyncRequest } from "../ava.js";
+
+vi.mock("../../utils/util.js", async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, makeDoitRequest: vi.fn() };
+});
+
+beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+const mockToken = "test-token";
+
+describe("handleAskAvaSyncRequest", () => {
+    it("should call makeDoitRequest with POST and question, returning the answer", async () => {
+        const mockResponse = {
+            answer: "Based on your cloud spending, your biggest cost driver is compute.",
+        };
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+        const response = await handleAskAvaSyncRequest({ question: "What is my biggest cost?" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${AVA_BASE_URL}/askSync`,
+            mockToken,
+            expect.objectContaining({
+                method: "POST",
+                body: expect.objectContaining({ question: "What is my biggest cost?", ephemeral: true }),
+                customerContext: undefined,
+            })
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.answer).toBe("Based on your cloud spending, your biggest cost driver is compute.");
+    });
+
+    it("should include conversationId and answerId when ephemeral is false", async () => {
+        const mockResponse = {
+            answer: "Follow-up answer here.",
+            conversationId: "conv-abc123",
+            answerId: "ans-xyz456",
+        };
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+        const response = await handleAskAvaSyncRequest(
+            { question: "Tell me more", conversationId: "conv-abc123", ephemeral: false },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${AVA_BASE_URL}/askSync`,
+            mockToken,
+            expect.objectContaining({
+                body: expect.objectContaining({ ephemeral: false, conversationId: "conv-abc123" }),
+            })
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.conversationId).toBe("conv-abc123");
+        expect(parsed.answerId).toBe("ans-xyz456");
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ answer: "OK" });
+
+        await handleAskAvaSyncRequest({ question: "What is my spend?", customerContext: "customer-123" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ customerContext: "customer-123" })
+        );
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleAskAvaSyncRequest({ question: "What is my spend?" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("failed or timed out") }],
+            isError: true,
+        });
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleAskAvaSyncRequest({ question: "What is my spend?" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
+    });
+
+    it("should return Zod validation error when question is missing", async () => {
+        const response = await handleAskAvaSyncRequest({}, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Invalid arguments") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when conversationId is provided with ephemeral: true (the default)", async () => {
+        const response = await handleAskAvaSyncRequest(
+            { question: "Tell me more", conversationId: "conv-abc123" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("conversationId") }],
+            isError: true,
+        });
+    });
+});

--- a/src/tools/__tests__/ava.test.ts
+++ b/src/tools/__tests__/ava.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
-import { AVA_BASE_URL, handleAskAvaSyncRequest } from "../ava.js";
+import { AVA_BASE_URL, AVA_DEFAULT_TIMEOUT_MS, handleAskAvaSyncRequest } from "../ava.js";
 
 vi.mock("../../utils/util.js", async (importOriginal) => {
     const actual = await importOriginal();
@@ -16,6 +16,44 @@ afterEach(() => {
 });
 
 const mockToken = "test-token";
+
+describe("AVA_TIMEOUT_MS parsing", () => {
+    afterEach(() => {
+        delete process.env.AVA_TIMEOUT_MS;
+    });
+
+    it.each([
+        ["empty string", ""],
+        ["non-numeric", "abc"],
+        ["NaN string", "NaN"],
+        ["negative number", "-5"],
+        ["zero", "0"],
+    ])(`falls back to ${AVA_DEFAULT_TIMEOUT_MS} for invalid value: %s`, async (_label, value) => {
+        process.env.AVA_TIMEOUT_MS = value;
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ answer: "OK" });
+
+        await handleAskAvaSyncRequest({ question: "test" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ timeoutMs: AVA_DEFAULT_TIMEOUT_MS })
+        );
+    });
+
+    it("uses the env var value when it is a valid positive number", async () => {
+        process.env.AVA_TIMEOUT_MS = "30000";
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ answer: "OK" });
+
+        await handleAskAvaSyncRequest({ question: "test" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ timeoutMs: 30_000 })
+        );
+    });
+});
 
 describe("handleAskAvaSyncRequest", () => {
     it("should call makeDoitRequest with POST and question, returning the answer", async () => {
@@ -105,6 +143,19 @@ describe("handleAskAvaSyncRequest", () => {
 
         expect(response).toEqual({
             content: [{ type: "text", text: expect.stringContaining("Invalid arguments") }],
+            isError: true,
+        });
+    });
+
+    it("should return timeout-specific error when makeDoitRequest throws TimeoutError", async () => {
+        const timeoutError = new DOMException("signal timed out", "TimeoutError");
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(timeoutError);
+
+        const response = await handleAskAvaSyncRequest({ question: "What is my spend?" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalled();
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("did not respond within the time limit") }],
             isError: true,
         });
     });

--- a/src/tools/ava.ts
+++ b/src/tools/ava.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { zodToMcpInputSchema } from "../utils/schemaHelpers.js";
+import {
+    createErrorResponse,
+    createSuccessResponse,
+    DOIT_API_BASE,
+    formatZodError,
+    handleGeneralError,
+    makeDoitRequest,
+} from "../utils/util.js";
+
+export const AVA_BASE_URL = `${DOIT_API_BASE}/ava/v1`;
+
+export const AskAvaSyncArgumentsSchema = z
+    .object({
+        question: z
+            .string()
+            .describe("The question to ask AVA about the user's DoiT account, cloud costs, or infrastructure."),
+        conversationId: z
+            .string()
+            .optional()
+            .describe(
+                "ID of a prior non-ephemeral conversation to continue. Requires ephemeral to be set to false — cannot be used with ephemeral: true (the default)."
+            ),
+        ephemeral: z
+            .boolean()
+            .optional()
+            .default(true)
+            .describe(
+                "When true (default), the conversation is not persisted and no conversationId or answerId is returned. Set to false to receive conversationId and answerId in the response, which are needed for follow-up questions or submitting feedback."
+            ),
+    })
+    .refine((data) => !(data.conversationId !== undefined && data.ephemeral !== false), {
+        message:
+            "conversationId cannot be used when ephemeral is true. Set ephemeral to false to continue a conversation.",
+        path: ["conversationId"],
+    });
+
+export const askAvaSyncTool = {
+    name: "ask_ava_sync",
+    description:
+        "Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, anomalies, or optimization opportunities. AVA has access to the customer's billing data, usage patterns, and DoiT-specific features. Use this for DoiT or cloud-specific questions only — not for general-purpose AI queries. By default the conversation is ephemeral (stateless). Set ephemeral to false to receive a conversationId and answerId for follow-up questions or feedback. Note: AVA may take over 60 seconds to respond — some MCP clients may time out before receiving a response.",
+    inputSchema: zodToMcpInputSchema(AskAvaSyncArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Asking AVA...",
+        "openai/toolInvocation/invoked": "AVA responded",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export async function handleAskAvaSyncRequest(args: any, token: string) {
+    try {
+        const { question, conversationId, ephemeral } = AskAvaSyncArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const data = await makeDoitRequest(`${AVA_BASE_URL}/askSync`, token, {
+            method: "POST",
+            body: { question, conversationId, ephemeral },
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse(
+                "AVA request failed or timed out. Try simplifying your question or try again later."
+            );
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(formatZodError(error));
+        }
+        return handleGeneralError(error, "handling ask AVA sync request");
+    }
+}

--- a/src/tools/ava.ts
+++ b/src/tools/ava.ts
@@ -11,6 +11,14 @@ import {
 
 export const AVA_BASE_URL = `${DOIT_API_BASE}/ava/v1`;
 
+export const AVA_DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
+
+function parseTimeoutMs(envValue: string | undefined, fallback: number): number {
+    if (envValue === undefined) return fallback;
+    const parsed = Number(envValue);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export const AskAvaSyncArgumentsSchema = z
     .object({
         question: z
@@ -39,7 +47,7 @@ export const AskAvaSyncArgumentsSchema = z
 export const askAvaSyncTool = {
     name: "ask_ava_sync",
     description:
-        "Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, anomalies, or optimization opportunities. AVA has access to the customer's billing data, usage patterns, and DoiT-specific features. Use this for DoiT or cloud-specific questions only — not for general-purpose AI queries. By default the conversation is ephemeral (stateless). Set ephemeral to false to receive a conversationId and answerId for follow-up questions or feedback. Note: AVA may take over 60 seconds to respond — some MCP clients may time out before receiving a response.",
+        "Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, anomalies, or optimization opportunities. AVA has access to the customer's billing data, usage patterns, and DoiT-specific features. Use this for DoiT or cloud-specific questions only — not for general-purpose AI queries. Note: AVA can take a long time to respond for complex questions. If it does not respond in time, a clear error is returned with guidance to retry or simplify the question.",
     inputSchema: zodToMcpInputSchema(AskAvaSyncArgumentsSchema),
     annotations: {
         readOnlyHint: true,
@@ -62,6 +70,7 @@ export async function handleAskAvaSyncRequest(args: any, token: string) {
             method: "POST",
             body: { question, conversationId, ephemeral },
             customerContext,
+            timeoutMs: parseTimeoutMs(process.env.AVA_TIMEOUT_MS, AVA_DEFAULT_TIMEOUT_MS),
         });
 
         if (!data) {
@@ -74,6 +83,11 @@ export async function handleAskAvaSyncRequest(args: any, token: string) {
     } catch (error) {
         if (error instanceof z.ZodError) {
             return createErrorResponse(formatZodError(error));
+        }
+        if (error instanceof DOMException && error.name === "TimeoutError") {
+            return createErrorResponse(
+                "AVA did not respond within the time limit. Try a simpler or more specific question, or try again later."
+            );
         }
         return handleGeneralError(error, "handling ask AVA sync request");
     }

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DebugLevel, debugLog, formatEnumValues, toSnakeCase } from "../util.js";
+import { DebugLevel, debugLog, formatEnumValues, makeDoitRequest, toSnakeCase } from "../util.js";
 
 beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -132,5 +132,34 @@ describe("formatEnumValues", () => {
 
     it("works with plain arrays", () => {
         expect(formatEnumValues(["a", "b", "c"])).toBe("a, b, c");
+    });
+});
+
+describe("makeDoitRequest timeout", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("should throw TimeoutError when fetch does not respond within timeoutMs", async () => {
+        // Simulate a fetch that hangs but correctly aborts when the signal fires
+        vi.stubGlobal("fetch", (_url: string, init?: RequestInit) => {
+            return new Promise((_resolve, reject) => {
+                init?.signal?.addEventListener("abort", () => {
+                    reject(new DOMException("signal timed out", "TimeoutError"));
+                });
+            });
+        });
+
+        await expect(
+            makeDoitRequest("https://api.doit.com/test", "test-token", { timeoutMs: 50 })
+        ).rejects.toMatchObject({ name: "TimeoutError" });
+    });
+
+    it("should return null and not throw when fetch rejects with a non-timeout error", async () => {
+        vi.stubGlobal("fetch", () => Promise.reject(new Error("Network error")));
+
+        const result = await makeDoitRequest("https://api.doit.com/test", "test-token");
+
+        expect(result).toBeNull();
     });
 });

--- a/src/utils/demoData.ts
+++ b/src/utils/demoData.ts
@@ -605,6 +605,13 @@ export function getDemoResponse(url: string, method: string, body?: any): unknow
         return { email: DEMO_USER.email, domain: DEMO_USER.domain };
     }
 
+    // POST /ava/v1/askSync
+    if (path.includes("/ava/v1/askSync") && POST) {
+        return {
+            answer: "Based on Acme Corp's cloud spending, your top cost driver is compute in us-central1, accounting for 42% of your monthly GCP spend. Consider purchasing 1-year committed use discounts for your steady-state workloads to reduce costs by up to 37%. Your AWS spend is concentrated in EC2 (us-east-1), where Reserved Instances could provide similar savings.",
+        };
+    }
+
     // POST /analytics/v1/reports/query — used by both cloud overview (internal)
     // and run_query (standalone). Differentiate by group dimensions in body.
     if (path.includes("/analytics/v1/reports/query") && POST) {

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -20,6 +20,7 @@ import {
 } from "../tools/annotations.js";
 import { handleAnomaliesRequest, handleAnomalyRequest } from "../tools/anomalies.js";
 import { handleGetAssetRequest, handleListAssetsRequest } from "../tools/assets.js";
+import { handleAskAvaSyncRequest } from "../tools/ava.js";
 import {
     handleCreateBudgetRequest,
     handleGetBudgetRequest,
@@ -290,6 +291,9 @@ export async function executeToolHandler(
                 break;
             case "get_commitment":
                 result = await handleGetCommitmentRequest(args, token);
+                break;
+            case "ask_ava_sync":
+                result = await handleAskAvaSyncRequest(args, token);
                 break;
             default:
                 return createErrorResponse(`Unknown tool: ${toolName}`);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -168,7 +168,11 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
 
 /**
  * Helper function for making DoiT API requests.
- * On error, logs the error and returns null.
+ * On most errors, logs the error and returns null.
+ *
+ * Exception: when `timeoutMs` is set and the request exceeds that duration, the function
+ * re-throws a `DOMException` with `name === "TimeoutError"` instead of returning null.
+ * Callers that pass `timeoutMs` must handle this case explicitly.
  *
  * @param url The API endpoint URL
  * @param token The authentication token
@@ -176,6 +180,7 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
  * @param options.method HTTP method (GET, POST, etc.)
  * @param options.body Request body for POST/PUT requests
  * @param options.appendParams Whether to append URL parameters (maxResults and customerContext)
+ * @param options.timeoutMs If set, aborts the request after this many milliseconds and throws TimeoutError
  * @returns The parsed JSON response or null on error
  */
 export async function makeDoitRequest<T>(
@@ -187,9 +192,17 @@ export async function makeDoitRequest<T>(
         appendParams?: boolean;
         customerContext?: string;
         parseResponse?: boolean;
+        timeoutMs?: number;
     } = {}
 ): Promise<T | null> {
-    const { method = "GET", body = undefined, appendParams = true, customerContext, parseResponse = true } = options;
+    const {
+        method = "GET",
+        body = undefined,
+        appendParams = true,
+        customerContext,
+        parseResponse = true,
+        timeoutMs,
+    } = options;
 
     // Demo mode: return canned data without hitting the real API.
     // The auth flow in app.ts gates demo_key login behind the DEMO_MODE_ENABLED env var.
@@ -215,6 +228,10 @@ export async function makeDoitRequest<T>(
             method,
             headers,
         };
+
+        if (timeoutMs !== undefined) {
+            requestOptions.signal = AbortSignal.timeout(timeoutMs);
+        }
 
         // Add body for non-GET requests if provided
         if (method !== "GET" && body !== undefined) {
@@ -253,6 +270,10 @@ export async function makeDoitRequest<T>(
         }
         return (await response.json()) as T;
     } catch (error) {
+        if (error instanceof DOMException && error.name === "TimeoutError") {
+            console.error(`DoiT API ${method} request timed out after ${timeoutMs}ms`);
+            throw error;
+        }
         console.error(`Error making DoiT API ${method} request:`, error);
         return null;
     }

--- a/test/integration/fixtures/ava.ts
+++ b/test/integration/fixtures/ava.ts
@@ -1,0 +1,9 @@
+export const avaAskSyncFixture = {
+    answer: "Based on your cloud spending patterns, your biggest cost driver is compute resources in us-central1. Consider using committed use discounts to reduce costs by up to 57%.",
+};
+
+export const avaAskSyncWithConversationFixture = {
+    answer: "To elaborate on the committed use discounts: they require a 1 or 3-year commitment for a specific amount of resources.",
+    conversationId: "conv-abc123",
+    answerId: "ans-xyz456",
+};

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -32,6 +32,7 @@ import {
     updateReportFixture,
 } from "./analytics.js";
 import { anomaliesFixture, anomalyFixture } from "./anomalies.js";
+import { avaAskSyncFixture, avaAskSyncWithConversationFixture } from "./ava.js";
 import { assetDetailedFixture, assetsFixture, invoiceFixture, invoicesFixture } from "./billing.js";
 import { cloudDiagramsFixture } from "./cloudDiagrams.js";
 import { cloudflowTriggerFixture } from "./cloudflow.js";
@@ -133,4 +134,7 @@ export const fixtures = {
 
     commitment: commitmentFixture,
     commitments: commitmentsFixture,
+
+    avaAskSync: avaAskSyncFixture,
+    avaAskSyncWithConversation: avaAskSyncWithConversationFixture,
 };

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -300,4 +300,13 @@ export const mockedDoitApiHandlers = [
     http.get(`${API_BASE}/analytics/v1/commitment-manager`, () => {
         return HttpResponse.json(fixtures.commitments);
     }),
+
+    // AVA
+    http.post(`${API_BASE}/ava/v1/askSync`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        if (body?.ephemeral === false) {
+            return HttpResponse.json(fixtures.avaAskSyncWithConversation);
+        }
+        return HttpResponse.json(fixtures.avaAskSync);
+    }),
 ];

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -30,6 +30,7 @@ describe("MCP Tools Integration", () => {
 
             expect(names).toEqual(
                 [
+                    "ask_ava_sync",
                     "assign_objects_to_label",
                     "compare_spend",
                     "cost_breakdown",
@@ -1401,6 +1402,41 @@ describe("MCP Tools Integration", () => {
             const result = await client.callTool({ name: "get_commitment", arguments: {} });
             const text = getTextContent(result);
             expect(text.toLowerCase()).toContain("required");
+        });
+    });
+
+    describe("ask_ava_sync", () => {
+        it("returns an answer from AVA (ephemeral by default)", async () => {
+            const result = await client.callTool({
+                name: "ask_ava_sync",
+                arguments: { question: "What is my biggest cloud cost?" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.answer).toContain("compute resources");
+            expect(parsed.conversationId).toBeUndefined();
+            expect(parsed.answerId).toBeUndefined();
+        });
+
+        it("returns conversationId and answerId when ephemeral is false", async () => {
+            const result = await client.callTool({
+                name: "ask_ava_sync",
+                arguments: { question: "Tell me more", ephemeral: false },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.answer).toBeDefined();
+            expect(parsed.conversationId).toBe("conv-abc123");
+            expect(parsed.answerId).toBe("ans-xyz456");
+        });
+
+        it("returns error for missing question", async () => {
+            const result = await client.callTool({
+                name: "ask_ava_sync",
+                arguments: {},
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("Invalid arguments");
         });
     });
 

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { HttpResponse, http } from "msw";
+import { delay, HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestClient, getTextContent } from "../helpers.js";
 import { mswServer } from "../setup.js";
@@ -1437,6 +1437,26 @@ describe("MCP Tools Integration", () => {
             });
             const text = getTextContent(result);
             expect(text).toContain("Invalid arguments");
+        });
+
+        it("returns timeout-specific error when AVA does not respond in time", async () => {
+            process.env.AVA_TIMEOUT_MS = "100";
+            mswServer.use(
+                http.post("https://api.doit.com/ava/v1/askSync", async () => {
+                    await delay("infinite");
+                    return HttpResponse.json({});
+                })
+            );
+            try {
+                const result = await client.callTool({
+                    name: "ask_ava_sync",
+                    arguments: { question: "What is my spend?" },
+                });
+                const text = getTextContent(result);
+                expect(text).toContain("did not respond within the time limit");
+            } finally {
+                delete process.env.AVA_TIMEOUT_MS;
+            }
         });
     });
 


### PR DESCRIPTION
- Introduced `ask_ava_sync` tool to allow users to ask DoiT AVA about their cloud spending and optimization opportunities.
- Implemented input validation and error handling for the tool.
- Updated README to include documentation for the new tool.
- Added integration and unit tests to ensure functionality and reliability.
- Mocked API responses for testing purposes.

This feature enhances user experience by providing direct access to cloud cost insights through AVA.