### PR TITLE
fix: add organization_tag dimension type to MCP server schemas

### DIFF
--- a/src/tools/__tests__/dimension.test.ts
+++ b/src/tools/__tests__/dimension.test.ts
@@ -133,6 +133,33 @@ Type: datetime`;
             });
         });
 
+        it("should accept organization_tag dimension type", async () => {
+            const mockArgs = { type: "organization_tag", id: "aws-org/customer" };
+            const mockApiResponse = {
+                id: "aws-org/customer",
+                label: "Customer",
+                type: "organization_tag",
+                values: [{ value: "Acme Corp" }],
+            };
+            (makeDoitRequest as vi.Mock).mockResolvedValue(mockApiResponse);
+
+            const response = await handleDimensionRequest(mockArgs, mockToken);
+
+            expect(makeDoitRequest).toHaveBeenCalledWith(
+                "https://api.doit.com/analytics/v1/dimension?type=organization_tag&id=aws-org%2Fcustomer",
+                mockToken,
+                { appendParams: true, method: "GET" }
+            );
+            expect(response).toEqual({
+                content: [
+                    {
+                        type: "text",
+                        text: expect.stringContaining("aws-org/customer"),
+                    },
+                ],
+            });
+        });
+
         it("should handle ZodError for invalid arguments", async () => {
             const mockArgs = { type: "invalid-type", id: "service_description" }; // Invalid type enum
             const response = await handleDimensionRequest(mockArgs, mockToken);

--- a/src/tools/allocations.ts
+++ b/src/tools/allocations.ts
@@ -24,6 +24,7 @@ const ALLOCATION_COMPONENT_TYPES = [
     "attribution_group",
     "gke",
     "gke_label",
+    "organization_tag",
 ] as const;
 
 const ALLOCATION_COMPONENT_MODES = ["is", "contains", "starts_with", "ends_with"] as const;

--- a/src/tools/dimension.ts
+++ b/src/tools/dimension.ts
@@ -25,6 +25,7 @@ export const DimensionArgumentsSchema = z.object({
             "attribution_group",
             "gke",
             "gke_label",
+            "organization_tag",
         ])
         .describe("Dimension type"),
     id: z.string().describe("Dimension id"),
@@ -64,6 +65,7 @@ export const dimensionTool = {
                     "attribution_group",
                     "gke",
                     "gke_label",
+                    "organization_tag",
                 ],
                 description: "Dimension type",
             },

--- a/src/types/alerts.ts
+++ b/src/types/alerts.ts
@@ -17,6 +17,7 @@ export const ALERT_SCOPE_TYPE_VALUES = [
     "allocation_rule",
     "gke",
     "gke_label",
+    "organization_tag",
 ] as const;
 export const ALERT_SCOPE_MODE_VALUES = ["is", "starts_with", "ends_with", "contains", "regexp"] as const;
 
@@ -38,7 +39,8 @@ export type AlertScopeType =
     | "allocation"
     | "allocation_rule"
     | "gke"
-    | "gke_label";
+    | "gke_label"
+    | "organization_tag";
 
 export type AlertScopeMode = "is" | "starts_with" | "ends_with" | "contains" | "regexp";
 

--- a/src/types/budgets.ts
+++ b/src/types/budgets.ts
@@ -18,6 +18,7 @@ export const SCOPE_TYPE_VALUES = [
     "allocation_rule",
     "gke",
     "gke_label",
+    "organization_tag",
 ] as const;
 export const CURRENCY_VALUES = [
     "USD",

--- a/src/types/reports.ts
+++ b/src/types/reports.ts
@@ -12,6 +12,7 @@ export const DIMENSION_TYPE_VALUES = [
     "allocation_rule",
     "gke",
     "gke_label",
+    "organization_tag",
 ] as const;
 
 export const FILTER_MODE_VALUES = ["is", "starts_with", "ends_with", "contains", "regexp"] as const;
@@ -109,5 +110,6 @@ export const ORIGIN_TYPE_VALUES = [
     "attribution_group",
     "gke",
     "gke_label",
+    "organization_tag",
     "unallocated",
 ] as const;

--- a/src/utils/__tests__/schema.test.ts
+++ b/src/utils/__tests__/schema.test.ts
@@ -231,6 +231,7 @@ describe("zodToMcpInputSchema", () => {
             "attribution_group",
             "gke",
             "gke_label",
+            "organization_tag",
         ] as const;
 
         const zodSchema = z.object({


### PR DESCRIPTION
## Summary

- Adds `organization_tag` as a valid dimension type across all MCP server tool schemas (reports, alerts, budgets, allocations, get_dimension)
- This was an omission from the initial implementation — the DoiT API and CLI support `organization_tag` (e.g. `aws-org/customer`) but the MCP server rejected it due to missing enum values
- Adds unit test coverage for the `organization_tag` dimension type in `get_dimension`

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 663 tests pass (`npm test`)
- [ ] Manual verification: use MCP `run_query` tool with a dimension of type `organization_tag` and id `aws-org/customer`