### PR TITLE
feat: add list_tools regression for invite_user and DataHub tools

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -386,6 +386,29 @@ describe("ListToolsRequestSchema handler", () => {
             ],
         });
     });
+
+    /** Mutating tools that previously lacked MCP hints: destructive annotations and ask-to-confirm copy in descriptions. */
+    it("list_tools: user, invite, and DataHub mutating tools expose destructive hints and confirmation guidance", async () => {
+        const handler = setRequestHandlerMock.mock.calls.find((call) => call[0] === ListToolsRequestSchema)?.[1];
+        const { tools } = await handler();
+        const names = [
+            "update_user",
+            "invite_user",
+            "create_datahub_dataset",
+            "update_datahub_dataset",
+            "send_datahub_events",
+        ] as const;
+        for (const name of names) {
+            const tool = tools.find((t: { name: string }) => t.name === name);
+            expect(tool, name).toBeDefined();
+            expect(tool.annotations).toEqual({
+                readOnlyHint: false,
+                destructiveHint: true,
+                openWorldHint: true,
+            });
+            expect(tool.description).toMatch(/Ask the user to confirm/i);
+        }
+    });
 });
 
 describe("ListPromptsRequestSchema handler", () => {

--- a/src/tools/datahubDatasets.ts
+++ b/src/tools/datahubDatasets.ts
@@ -127,8 +127,18 @@ export const CreateDatahubDatasetArgumentsSchema = z.object({
 export const createDatahubDatasetTool = {
     name: "create_datahub_dataset",
     description:
-        "Creates a new DataHub dataset in the DoiT platform. A dataset requires a name and can optionally include a description.",
+        "Use this when the user wants to create a new DataHub dataset. Ask the user to confirm the dataset name and description before executing. Do NOT use this for viewing datasets (use list_datahub_datasets) or sending events (use send_datahub_events).",
     inputSchema: zodToMcpInputSchema(CreateDatahubDatasetArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Creating DataHub dataset...",
+        "openai/toolInvocation/invoked": "DataHub dataset created",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
 export async function handleCreateDatahubDatasetRequest(args: any, token: string) {
@@ -175,8 +185,18 @@ export const UpdateDatahubDatasetArgumentsSchema = UpdateDatahubDatasetBaseSchem
 export const updateDatahubDatasetTool = {
     name: "update_datahub_dataset",
     description:
-        "Updates an existing DataHub dataset in the DoiT platform. The dataset name is required to identify the dataset. Only the description can be changed; at least a description must be provided.",
+        "Use this when the user wants to modify an existing DataHub dataset's description. The dataset name is required to identify the dataset; only the description can be changed. Ask the user to confirm the changes before executing. Do NOT use this for creating datasets (use create_datahub_dataset) or listing datasets (use list_datahub_datasets).",
     inputSchema: zodToMcpInputSchema(UpdateDatahubDatasetArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Updating DataHub dataset...",
+        "openai/toolInvocation/invoked": "DataHub dataset updated",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
 export async function handleUpdateDatahubDatasetRequest(args: any, token: string) {

--- a/src/tools/datahubEvents.ts
+++ b/src/tools/datahubEvents.ts
@@ -72,8 +72,18 @@ export const SendDatahubEventsArgumentsSchema = z.object({
 export const sendDatahubEventsTool = {
     name: "send_datahub_events",
     description:
-        "Sends one or more DataHub events for ingestion into the DoiT platform. Each event requires a provider name and an RFC 3339 timestamp, and can optionally include dimensions and metrics. Accepts 1 to 50,000 events per call. Data becomes available in Cloud Analytics within ~15 minutes.",
+        "Use this when the user wants to send DataHub events for ingestion (1–50,000 events per call). Each event requires a provider name and an RFC 3339 timestamp, and can optionally include dimensions and metrics. Ask the user to confirm the event count and provider details before executing. Data becomes available in Cloud Analytics within ~15 minutes. Do NOT use this for creating datasets (use create_datahub_dataset) or viewing datasets (use list_datahub_datasets).",
     inputSchema: zodToMcpInputSchema(SendDatahubEventsArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Sending DataHub events...",
+        "openai/toolInvocation/invoked": "DataHub events sent",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
 export async function handleSendDatahubEventsRequest(args: any, token: string) {

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -99,8 +99,19 @@ export const UpdateUserArgumentsSchema = UpdateUserBaseSchema.refine(
 
 export const updateUserTool = {
     name: "update_user",
-    description: "Updates user information such as name, job function, phone, language, and role in the DoiT platform.",
+    description:
+        "Use this when the user wants to update a user's information such as name, job function, phone, language, or role. Ask the user to confirm the changes before executing. Do NOT use this for inviting new users (use invite_user) or listing users (use list_users).",
     inputSchema: zodToMcpInputSchema(UpdateUserArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Updating user...",
+        "openai/toolInvocation/invoked": "User updated",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
 export const InviteUserArgumentsSchema = z.object({
@@ -121,8 +132,19 @@ export const InviteUserArgumentsSchema = z.object({
 
 export const inviteUserTool = {
     name: "invite_user",
-    description: "Invites a new user to the organization by email, optionally assigning a role and organization.",
+    description:
+        "Use this when the user wants to invite a new person to the organization. Ask the user to confirm the email, role, and organization before executing. Do NOT use this for updating existing users (use update_user) or listing users (use list_users).",
     inputSchema: zodToMcpInputSchema(InviteUserArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Inviting user...",
+        "openai/toolInvocation/invoked": "User invited",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
 export async function handleUpdateUserRequest(args: any, token: string) {


### PR DESCRIPTION
MCP list_tools handler so update_user, invite_user, create_datahub_dataset, update_datahub_dataset, and send_datahub_events keep the same destructive/open-world annotations.