### PR TITLE
feat: enhance DoitMCPAgent and widget resource handling

### DIFF
--- a/doit-mcp-server/src/app.ts
+++ b/doit-mcp-server/src/app.ts
@@ -13,9 +13,10 @@ import type { OAuthHelpers } from "@cloudflare/workers-oauth-provider";
 import { handleValidateUserRequest } from "../../src/tools/validateUser";
 import { decodeJWT } from "../../src/utils/util";
 import { DEMO_TOKEN } from "../../src/utils/demoData";
+import type { DoitWorkerEnv } from "./runtimeEnv.js";
 import { WIDGET_HTML } from "./widgetHtml";
 
-export type Bindings = Env & {
+export type Bindings = DoitWorkerEnv & {
   OAUTH_PROVIDER: OAuthHelpers;
   OAUTH_KV: KVNamespace;
 };

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -198,6 +198,14 @@ import { type TrackingContext, runWithTracking } from "../../src/utils/util.js";
 import { adaptToolResponse } from "./responseAdapter.js";
 import { WIDGET_URI } from "./responseAdapter.js";
 import { promptsIncludingLegacyNames, resolvePromptMessages } from "../../src/prompts/index.js";
+import type { DoitWorkerEnv, UiDomainProvider } from "./runtimeEnv.js";
+import {
+  buildWidgetResourceContent,
+  classifyUiDomainProvider,
+  resolvePublicMcpUrl,
+  resolveWidgetFetchOrigin,
+  WIDGET_RESOURCE_MIME_TYPE,
+} from "./widgetResource.js";
 
 const KEEP_ALIVE_INTERVAL_MS = 120_000; // 2 minutes in milliseconds
 
@@ -212,6 +220,7 @@ const MCP_NOTIFICATIONS_PING = {
 const SSE_KEEP_ALIVE_MESSAGE = new TextEncoder().encode(
   `event: message\ndata: ${JSON.stringify(MCP_NOTIFICATIONS_PING)}\n\n`
 );
+const SESSION_UI_DOMAIN_PROVIDER_KEY = "sessionUiDomainProvider";
 
 // Context Storage Durable Object
 export class ContextStorage extends DurableObject {
@@ -240,47 +249,6 @@ export class ContextStorage extends DurableObject {
   }
 }
 
-/**
- * Generates the tiny loader stub cached by ChatGPT as widget HTML.
- * The stub fetches the real widget from GET /widget on every render, so
- * future widget updates require zero ChatGPT app re-registrations.
- *
- * The stub is intentionally minimal and stable — it should never need to change.
- * If workerUrl ever moves, bump WIDGET_URI and re-register once.
- */
-function buildWidgetStub(workerUrl: string): string {
-  const widgetUrl = `${workerUrl}/widget`;
-  return `<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<style>*{box-sizing:border-box}body{margin:0;padding:0;font-family:system-ui,sans-serif}</style>
-</head>
-<body>
-<div id="app"><p style="padding:16px;color:#888;font-size:0.8125rem">Loading…</p></div>
-<script type="module">
-(async()=>{
-  try{
-    const html=await fetch(${JSON.stringify(widgetUrl)},{cache:"no-store"}).then(r=>{if(!r.ok)throw r;return r.text()});
-    const doc=new DOMParser().parseFromString(html,"text/html");
-    for(const e of doc.querySelectorAll("style"))document.head.appendChild(document.adoptNode(e));
-    document.getElementById("app").textContent='';
-    for(const s of doc.querySelectorAll("script")){
-      const n=document.createElement("script");
-      if(s.type)n.type=s.type;
-      n.textContent=s.textContent;
-      document.head.appendChild(n);
-    }
-  }catch(err){
-    document.getElementById("app").innerHTML='<p style="padding:16px;color:#888;font-size:0.8125rem">Widget unavailable — check MCP server connectivity.</p>';
-    console.error("[doit-widget] load failed",err);
-  }
-})();
-</script>
-</body>
-</html>`;
-}
-
 export class DoitMCPAgent extends McpAgent {
   server = new McpServer(
     {
@@ -297,6 +265,7 @@ export class DoitMCPAgent extends McpAgent {
   // Per-instance MCP client info — stored on the DO instance, not a module global,
   // so there is no cross-session bleed between DO instances sharing the same isolate.
   private _mcpClientInfo: TrackingContext = {};
+  private _sessionUiDomainProvider?: UiDomainProvider;
 
   // Helper method to get the current token
   private getToken(): string {
@@ -305,7 +274,7 @@ export class DoitMCPAgent extends McpAgent {
 
   // Persist props to Context Storage Durable Object
   private async saveProps(): Promise<void> {
-    const env = this.env as Env;
+    const env = this.env as DoitWorkerEnv;
     const apiKey = this.props.apiKey as string;
     const customerContext = this.props.customerContext as string;
     if (apiKey && env?.CONTEXT_STORAGE) {
@@ -317,7 +286,7 @@ export class DoitMCPAgent extends McpAgent {
 
   // Load props from Context Storage Durable Object
   private async loadPersistedProps(): Promise<string | null> {
-    const env = this.env as Env;
+    const env = this.env as DoitWorkerEnv;
     const apiKey = this.props.apiKey as string;
     if (apiKey && env?.CONTEXT_STORAGE) {
       const id = env.CONTEXT_STORAGE.idFromName(apiKey);
@@ -330,6 +299,32 @@ export class DoitMCPAgent extends McpAgent {
       }
     }
     return (this.props.customerContext as string) || null;
+  }
+
+  private async persistSessionUiDomainProvider(
+    provider: UiDomainProvider
+  ): Promise<void> {
+    if (provider === "omit") {
+      return;
+    }
+
+    this._sessionUiDomainProvider = provider;
+    await this.ctx.storage.put(SESSION_UI_DOMAIN_PROVIDER_KEY, provider);
+  }
+
+  private async loadPersistedSessionUiDomainProvider(): Promise<
+    UiDomainProvider | undefined
+  > {
+    const provider = await this.ctx.storage.get<UiDomainProvider>(
+      SESSION_UI_DOMAIN_PROVIDER_KEY
+    );
+
+    if (provider === "claude" || provider === "openai") {
+      this._sessionUiDomainProvider = provider;
+      return provider;
+    }
+
+    return undefined;
   }
 
   // Generic callback factory for tools
@@ -422,18 +417,32 @@ export class DoitMCPAgent extends McpAgent {
     // takes no arguments and getClientVersion() only returns { name, version }. The SDK
     // computes the negotiated protocol version in _oninitialize() but discards it without
     // storing it. The STDIO path has direct access via InitializeRequest params; SSE does not.
-    this.server.server.oninitialized = () => {
+    this.server.server.oninitialized = async () => {
       const clientInfo = this.server.server.getClientVersion();
       this._mcpClientInfo = {
         mcpClient: clientInfo?.name,
         mcpClientVersion: clientInfo?.version,
       };
+      const provider = classifyUiDomainProvider(clientInfo?.name);
+      if (provider !== "omit") {
+        await this.persistSessionUiDomainProvider(provider);
+      }
+      console.log("[mcp] initialized client", {
+        ...this._mcpClientInfo,
+        sessionProvider: this._sessionUiDomainProvider,
+      });
     };
 
-    // Load persisted props first (no-op if apiKey not available yet)
-    await this.loadPersistedProps();
+    // Load persisted session state first so widget resource reads can still resolve a
+    // provider after DO hibernation, even before oninitialized runs again.
+    await Promise.all([
+      this.loadPersistedProps(),
+      this.loadPersistedSessionUiDomainProvider(),
+    ]);
 
-    console.log("After loading persisted props:", this.props.customerContext);
+    console.log("After loading persisted props:", this.props.customerContext, {
+      sessionProvider: this._sessionUiDomainProvider,
+    });
 
     // Save current props if they exist (for initial OAuth setup)
     if (this.props.apiKey && this.props.customerContext) {
@@ -457,31 +466,30 @@ export class DoitMCPAgent extends McpAgent {
     // The resource returns a tiny loader stub (~600 B) that fetches the real widget
     // HTML from GET /widget on every render. This means widget updates never require
     // ChatGPT app re-registration — only the served HTML at /widget changes.
-    const workerUrl = (this.env as any).WORKER_URL ?? "https://mcp.doit.com";
+    const env = this.env as DoitWorkerEnv;
+    const widgetFetchOrigin = resolveWidgetFetchOrigin(env);
+    const publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
     this.server.resource(
       "cloud-intelligence-widget",
       WIDGET_URI,
-      { mimeType: "text/html;profile=mcp-app" },
+      { mimeType: WIDGET_RESOURCE_MIME_TYPE },
       async () => {
-        console.log("[widget] resources/read called for", WIDGET_URI);
+        console.log("[widget] resources/read called for", WIDGET_URI, {
+          mcpClient: this._mcpClientInfo.mcpClient,
+          mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+          sessionProvider: this._sessionUiDomainProvider,
+          publicMcpUrl,
+        });
+        const resourceContent = await buildWidgetResourceContent({
+          widgetUri: WIDGET_URI,
+          mcpClient: this._mcpClientInfo.mcpClient,
+          sessionProvider: this._sessionUiDomainProvider,
+          widgetFetchOrigin,
+          publicMcpUrl,
+          env,
+        });
         return {
-          contents: [{
-            uri: WIDGET_URI,
-            mimeType: "text/html;profile=mcp-app",
-            text: buildWidgetStub(workerUrl),
-            _meta: {
-              ui: {
-                domain: workerUrl,
-                csp: {
-                  connectDomains: [
-                    "https://api.doit.com",
-                    "https://mcp.doit.com",
-                    "https://dci-mcp.ngrok.app",
-                  ],
-                },
-              },
-            },
-          } as any],
+          contents: [resourceContent as any],
         };
       }
     );
@@ -770,6 +778,7 @@ async function handleRequest(
   ctx: ExecutionContext
 ): Promise<Response> {
   const url = new URL(req.url);
+  const runtimeEnv = env as DoitWorkerEnv;
 
   // Serve OAuth discovery endpoints unauthenticated at ANY path prefix.
   // Per RFC 9728/8414, ChatGPT appends these well-known paths to the MCP server URL
@@ -783,7 +792,7 @@ async function handleRequest(
       url.pathname.endsWith("/.well-known/oauth-authorization-server")) {
     // PUBLIC_URL overrides everything — required for local dev via tunnel because
     // wrangler dev rewrites request.url and Host to the route pattern (mcp.doit.com).
-    const base = (env as any).PUBLIC_URL ||
+    const base = runtimeEnv.PUBLIC_URL ||
       (() => {
         const host = req.headers.get("host") || url.host;
         const isLocal = host.startsWith("localhost") || host.startsWith("127.0.0.1");

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -417,7 +417,7 @@ export class DoitMCPAgent extends McpAgent {
     // takes no arguments and getClientVersion() only returns { name, version }. The SDK
     // computes the negotiated protocol version in _oninitialize() but discards it without
     // storing it. The STDIO path has direct access via InitializeRequest params; SSE does not.
-    this.server.server.oninitialized = async () => {
+    this.server.server.oninitialized = () => {
       const clientInfo = this.server.server.getClientVersion();
       this._mcpClientInfo = {
         mcpClient: clientInfo?.name,
@@ -425,7 +425,12 @@ export class DoitMCPAgent extends McpAgent {
       };
       const provider = classifyUiDomainProvider(clientInfo?.name);
       if (provider !== "omit") {
-        await this.persistSessionUiDomainProvider(provider);
+        void this.persistSessionUiDomainProvider(provider).catch((error) => {
+          console.error(
+            "[mcp] failed to persist session UI domain provider",
+            error
+          );
+        });
       }
       console.log("[mcp] initialized client", {
         ...this._mcpClientInfo,

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -408,7 +408,9 @@ export class DoitMCPAgent extends McpAgent {
     // this.props at call-time (after props are set), so registration still works.
     this.props = (this.props ?? {}) as typeof this.props;
 
-    console.log("Initializing Doit MCP Agent", this.props.customerContext);
+    console.log("Initializing Doit MCP Agent", {
+      hasCustomerContext: Boolean(this.props.customerContext),
+    });
 
     // Capture MCP client identity for tracking query params.
     // Stored on the DO instance (_mcpClientInfo), not a module global, to avoid cross-session
@@ -445,7 +447,8 @@ export class DoitMCPAgent extends McpAgent {
       this.loadPersistedSessionUiDomainProvider(),
     ]);
 
-    console.log("After loading persisted props:", this.props.customerContext, {
+    console.log("After loading persisted props:", {
+      hasCustomerContext: Boolean(this.props.customerContext),
       sessionProvider: this._sessionUiDomainProvider,
     });
 

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -767,7 +767,14 @@ const oauthProvider = new OAuthProvider({
   clientRegistrationEndpoint: "/register",
   accessTokenTTL: 60 * 60 * 24 * 30, // 30 days in seconds (OAuthProvider uses seconds, not ms)
   tokenExchangeCallback: async ({ grantType, props }) => {
-    console.log("tokenExchangeCallback", grantType, props);
+    const logProps = props as
+      | Partial<Record<"apiKey" | "customerContext" | "isDoitUser", unknown>>
+      | undefined;
+    console.log("tokenExchangeCallback", grantType, {
+      hasApiKey: Boolean(logProps?.apiKey),
+      hasCustomerContext: Boolean(logProps?.customerContext),
+      isDoitUser: logProps?.isDoitUser,
+    });
     if (grantType === "refresh_token" || grantType === "authorization_code") {
       return {
         newProps: { ...props },

--- a/doit-mcp-server/src/responseAdapter.ts
+++ b/doit-mcp-server/src/responseAdapter.ts
@@ -197,7 +197,9 @@ export function narrate(toolName: string, data: unknown): string {
     return `Operation completed.`;
 }
 
-export const WIDGET_URI = "ui://doit/cloud-intelligence-v9.html";
+// Bump the resource URI when widget metadata semantics change so hosts do not
+// reuse stale cached metadata across provider-specific ui.domain rollouts.
+export const WIDGET_URI = "ui://doit/cloud-intelligence-v10.html";
 
 /**
  * Main adapter. Wraps a raw tool result into the Apps SDK three-field format.

--- a/doit-mcp-server/src/runtimeEnv.ts
+++ b/doit-mcp-server/src/runtimeEnv.ts
@@ -1,0 +1,12 @@
+export type UiDomainProvider = "claude" | "openai" | "omit";
+
+export interface RuntimeEnvVars {
+  WORKER_URL?: string;
+  PUBLIC_URL?: string;
+  PUBLIC_MCP_URL?: string;
+  UI_DOMAIN_PROVIDER?: UiDomainProvider;
+  CLAUDE_UI_DOMAIN?: string;
+  OPENAI_UI_DOMAIN?: string;
+}
+
+export type DoitWorkerEnv = Env & RuntimeEnvVars;

--- a/doit-mcp-server/src/runtimeEnv.ts
+++ b/doit-mcp-server/src/runtimeEnv.ts
@@ -4,7 +4,7 @@ export interface RuntimeEnvVars {
   WORKER_URL?: string;
   PUBLIC_URL?: string;
   PUBLIC_MCP_URL?: string;
-  UI_DOMAIN_PROVIDER?: UiDomainProvider;
+  UI_DOMAIN_PROVIDER?: string;
   CLAUDE_UI_DOMAIN?: string;
   OPENAI_UI_DOMAIN?: string;
 }

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -188,13 +188,17 @@ export async function resolveUiDomain(
   return { provider: "omit" };
 }
 
-export function buildWidgetConnectDomains(widgetFetchOrigin: string): string[] {
+export function buildWidgetConnectDomains(
+  widgetFetchOrigin: string,
+  publicMcpUrl?: string
+): string[] {
   return Array.from(
     new Set([
       "https://api.doit.com",
       "https://mcp.doit.com",
       "https://dci-mcp.ngrok.app",
       toOrigin(widgetFetchOrigin),
+      ...(publicMcpUrl ? [toOrigin(publicMcpUrl)] : []),
     ])
   );
 }
@@ -214,7 +218,10 @@ export async function buildWidgetResourceContent(
     domain?: string;
   } = {
     csp: {
-      connectDomains: buildWidgetConnectDomains(args.widgetFetchOrigin),
+      connectDomains: buildWidgetConnectDomains(
+        args.widgetFetchOrigin,
+        args.publicMcpUrl
+      ),
     },
   };
 

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -196,7 +196,6 @@ export function buildWidgetConnectDomains(
     new Set([
       "https://api.doit.com",
       "https://mcp.doit.com",
-      "https://dci-mcp.ngrok.app",
       toOrigin(widgetFetchOrigin),
       ...(publicMcpUrl ? [toOrigin(publicMcpUrl)] : []),
     ])

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -2,6 +2,7 @@ import type { RuntimeEnvVars, UiDomainProvider } from "./runtimeEnv.js";
 
 export const DEFAULT_WIDGET_FETCH_ORIGIN = "https://mcp.doit.com";
 export const WIDGET_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+type WebCryptoApi = (typeof import("node:crypto"))["webcrypto"];
 
 export interface ResolveUiDomainArgs {
   mcpClient?: string;
@@ -73,7 +74,11 @@ export function buildWidgetStub(widgetFetchOrigin: string): string {
 
 export async function computeClaudeDomain(serverUrl: string): Promise<string> {
   const data = new TextEncoder().encode(serverUrl);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const runtimeCrypto = (globalThis as typeof globalThis & {
+    crypto?: WebCryptoApi;
+  }).crypto;
+  const cryptoApi = runtimeCrypto ?? (await import("node:crypto")).webcrypto;
+  const hashBuffer = await cryptoApi.subtle.digest("SHA-256", data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const hashHex = hashArray
     .map((byte) => byte.toString(16).padStart(2, "0"))

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -4,6 +4,20 @@ export const DEFAULT_WIDGET_FETCH_ORIGIN = "https://mcp.doit.com";
 export const WIDGET_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 type WebCryptoApi = (typeof import("node:crypto"))["webcrypto"];
 
+function requireAbsoluteUrl(
+  value: string,
+  envName: "WORKER_URL" | "PUBLIC_MCP_URL"
+): string {
+  try {
+    new URL(value);
+    return value;
+  } catch {
+    throw new Error(
+      `[widget] ${envName} must be an absolute URL. Received ${JSON.stringify(value)}.`
+    );
+  }
+}
+
 export interface ResolveUiDomainArgs {
   mcpClient?: string;
   sessionProvider?: UiDomainProvider;
@@ -22,7 +36,9 @@ export interface BuildWidgetResourceContentArgs extends ResolveUiDomainArgs {
 export function resolveWidgetFetchOrigin(
   env: Pick<RuntimeEnvVars, "WORKER_URL">
 ): string {
-  return env.WORKER_URL ?? DEFAULT_WIDGET_FETCH_ORIGIN;
+  return env.WORKER_URL
+    ? requireAbsoluteUrl(env.WORKER_URL, "WORKER_URL")
+    : DEFAULT_WIDGET_FETCH_ORIGIN;
 }
 
 export function resolvePublicMcpUrl(
@@ -31,7 +47,11 @@ export function resolvePublicMcpUrl(
 ): string {
   // Claude-compatible hashes must use the exact public MCP endpoint string,
   // so config can override the /sse fallback when the host-facing URL differs.
-  return env.PUBLIC_MCP_URL ?? new URL("/sse", widgetFetchOrigin).toString();
+  if (env.PUBLIC_MCP_URL) {
+    return requireAbsoluteUrl(env.PUBLIC_MCP_URL, "PUBLIC_MCP_URL");
+  }
+
+  return new URL("/sse", requireAbsoluteUrl(widgetFetchOrigin, "WORKER_URL")).toString();
 }
 
 /**

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -1,0 +1,234 @@
+import type { RuntimeEnvVars, UiDomainProvider } from "./runtimeEnv.js";
+
+export const DEFAULT_WIDGET_FETCH_ORIGIN = "https://mcp.doit.com";
+export const WIDGET_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+export interface ResolveUiDomainArgs {
+  mcpClient?: string;
+  sessionProvider?: UiDomainProvider;
+  widgetFetchOrigin: string;
+  publicMcpUrl: string;
+  env: Pick<
+    RuntimeEnvVars,
+    "UI_DOMAIN_PROVIDER" | "CLAUDE_UI_DOMAIN" | "OPENAI_UI_DOMAIN"
+  >;
+}
+
+export interface BuildWidgetResourceContentArgs extends ResolveUiDomainArgs {
+  widgetUri: string;
+}
+
+export function resolveWidgetFetchOrigin(
+  env: Pick<RuntimeEnvVars, "WORKER_URL">
+): string {
+  return env.WORKER_URL ?? DEFAULT_WIDGET_FETCH_ORIGIN;
+}
+
+export function resolvePublicMcpUrl(
+  env: Pick<RuntimeEnvVars, "PUBLIC_MCP_URL">,
+  widgetFetchOrigin: string
+): string {
+  // Claude-compatible hashes must use the exact public MCP endpoint string,
+  // so config can override the /sse fallback when the host-facing URL differs.
+  return env.PUBLIC_MCP_URL ?? new URL("/sse", widgetFetchOrigin).toString();
+}
+
+/**
+ * Generates the tiny loader stub cached by ChatGPT as widget HTML.
+ * The stub fetches the real widget from GET /widget on every render, so
+ * future widget updates require zero ChatGPT app re-registrations.
+ */
+export function buildWidgetStub(widgetFetchOrigin: string): string {
+  const widgetUrl = new URL("/widget", widgetFetchOrigin).toString();
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>*{box-sizing:border-box}body{margin:0;padding:0;font-family:system-ui,sans-serif}</style>
+</head>
+<body>
+<div id="app"><p style="padding:16px;color:#888;font-size:0.8125rem">Loading…</p></div>
+<script type="module">
+(async()=>{
+  try{
+    const html=await fetch(${JSON.stringify(widgetUrl)},{cache:"no-store"}).then(r=>{if(!r.ok)throw r;return r.text()});
+    const doc=new DOMParser().parseFromString(html,"text/html");
+    for(const e of doc.querySelectorAll("style"))document.head.appendChild(document.adoptNode(e));
+    document.getElementById("app").textContent='';
+    for(const s of doc.querySelectorAll("script")){
+      const n=document.createElement("script");
+      if(s.type)n.type=s.type;
+      n.textContent=s.textContent;
+      document.head.appendChild(n);
+    }
+  }catch(err){
+    document.getElementById("app").innerHTML='<p style="padding:16px;color:#888;font-size:0.8125rem">Widget unavailable — check MCP server connectivity.</p>';
+    console.error("[doit-widget] load failed",err);
+  }
+})();
+</script>
+</body>
+</html>`;
+}
+
+export async function computeClaudeDomain(serverUrl: string): Promise<string> {
+  const data = new TextEncoder().encode(serverUrl);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+  return `${hashHex.slice(0, 32)}.claudemcpcontent.com`;
+}
+
+function getConfiguredProvider(
+  value?: RuntimeEnvVars["UI_DOMAIN_PROVIDER"]
+): UiDomainProvider | undefined {
+  if (!value) return undefined;
+
+  const normalized = value.toLowerCase();
+  if (normalized === "claude" || normalized === "openai" || normalized === "omit") {
+    return normalized;
+  }
+
+  return undefined;
+}
+
+function isClaudeLikeClient(client: string): boolean {
+  return (
+    client.includes("claude") ||
+    client.includes("cowork") ||
+    client.includes("anthropic")
+  );
+}
+
+function isOpenAiLikeClient(client: string): boolean {
+  return client.includes("chatgpt") || client.includes("openai");
+}
+
+export function classifyUiDomainProvider(mcpClient?: string): UiDomainProvider {
+  const client = mcpClient?.toLowerCase() ?? "";
+
+  if (isClaudeLikeClient(client)) {
+    return "claude";
+  }
+
+  if (isOpenAiLikeClient(client)) {
+    return "openai";
+  }
+
+  return "omit";
+}
+
+function toOrigin(urlOrOrigin: string): string {
+  try {
+    return new URL(urlOrOrigin).origin;
+  } catch {
+    return urlOrOrigin;
+  }
+}
+
+function getOpenAiDomain(
+  widgetFetchOrigin: string,
+  env: Pick<RuntimeEnvVars, "OPENAI_UI_DOMAIN">
+): string {
+  return env.OPENAI_UI_DOMAIN ?? toOrigin(widgetFetchOrigin);
+}
+
+async function resolveProviderUiDomain(
+  provider: UiDomainProvider,
+  args: Pick<
+    ResolveUiDomainArgs,
+    "widgetFetchOrigin" | "publicMcpUrl" | "env"
+  >
+): Promise<{ provider: UiDomainProvider; uiDomain?: string }> {
+  if (provider === "claude") {
+    return {
+      provider: "claude",
+      uiDomain:
+        args.env.CLAUDE_UI_DOMAIN ?? (await computeClaudeDomain(args.publicMcpUrl)),
+    };
+  }
+
+  if (provider === "openai") {
+    return {
+      provider: "openai",
+      uiDomain: getOpenAiDomain(args.widgetFetchOrigin, args.env),
+    };
+  }
+
+  return { provider: "omit" };
+}
+
+export async function resolveUiDomain(
+  args: ResolveUiDomainArgs
+): Promise<{ provider: UiDomainProvider; uiDomain?: string }> {
+  const configuredProvider = getConfiguredProvider(args.env.UI_DOMAIN_PROVIDER);
+  const hasCurrentClient = Boolean(args.mcpClient?.trim());
+
+  if (configuredProvider) {
+    return resolveProviderUiDomain(configuredProvider, args);
+  }
+
+  const runtimeProvider = classifyUiDomainProvider(args.mcpClient);
+  if (runtimeProvider !== "omit") {
+    return resolveProviderUiDomain(runtimeProvider, args);
+  }
+
+  if (!hasCurrentClient && args.sessionProvider && args.sessionProvider !== "omit") {
+    return resolveProviderUiDomain(args.sessionProvider, args);
+  }
+
+  return { provider: "omit" };
+}
+
+export function buildWidgetConnectDomains(widgetFetchOrigin: string): string[] {
+  return Array.from(
+    new Set([
+      "https://api.doit.com",
+      "https://mcp.doit.com",
+      "https://dci-mcp.ngrok.app",
+      toOrigin(widgetFetchOrigin),
+    ])
+  );
+}
+
+export async function buildWidgetResourceContent(
+  args: BuildWidgetResourceContentArgs
+): Promise<{
+  uri: string;
+  mimeType: string;
+  text: string;
+  _meta: Record<string, unknown>;
+}> {
+  const { provider, uiDomain } = await resolveUiDomain(args);
+
+  const uiMeta: {
+    csp: { connectDomains: string[] };
+    domain?: string;
+  } = {
+    csp: {
+      connectDomains: buildWidgetConnectDomains(args.widgetFetchOrigin),
+    },
+  };
+
+  if (uiDomain) {
+    uiMeta.domain = uiDomain;
+  }
+
+  const resourceMeta: Record<string, unknown> = {
+    ui: uiMeta,
+  };
+
+  if (provider === "openai" && uiDomain) {
+    resourceMeta["openai/widgetDomain"] = uiDomain;
+  }
+
+  return {
+    uri: args.widgetUri,
+    mimeType: WIDGET_RESOURCE_MIME_TYPE,
+    text: buildWidgetStub(args.widgetFetchOrigin),
+    _meta: resourceMeta,
+  };
+}

--- a/doit-mcp-server/wrangler.jsonc
+++ b/doit-mcp-server/wrangler.jsonc
@@ -66,7 +66,11 @@
    * Environment Variables
    * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
    */
-  "vars": { "WORKER_URL": "https://mcp.doit.com", "DEMO_MODE_ENABLED": "true" },
+  "vars": {
+    "WORKER_URL": "https://mcp.doit.com",
+    "PUBLIC_MCP_URL": "https://mcp.doit.com/sse",
+    "DEMO_MODE_ENABLED": "true"
+  },
   /**
    * Note: Use secrets to store sensitive data.
    * https://developers.cloudflare.com/workers/configuration/secrets/

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -18,9 +18,7 @@ describe("widget URL resolution", () => {
     });
 
     it("builds the default public MCP URL from the widget fetch origin", () => {
-        expect(resolvePublicMcpUrl({}, "https://widgets.example.com")).toBe(
-            "https://widgets.example.com/sse"
-        );
+        expect(resolvePublicMcpUrl({}, "https://widgets.example.com")).toBe("https://widgets.example.com/sse");
     });
 
     it("throws a clear error when WORKER_URL is not absolute", () => {
@@ -31,10 +29,7 @@ describe("widget URL resolution", () => {
 
     it("throws a clear error when PUBLIC_MCP_URL is not absolute", () => {
         expect(() =>
-            resolvePublicMcpUrl(
-                { PUBLIC_MCP_URL: "widgets.example.com/mcp" },
-                "https://widgets.example.com"
-            )
+            resolvePublicMcpUrl({ PUBLIC_MCP_URL: "widgets.example.com/mcp" }, "https://widgets.example.com")
         ).toThrow("[widget] PUBLIC_MCP_URL must be an absolute URL.");
     });
 });

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -164,6 +164,29 @@ describe("widget resource contract", () => {
         expect(meta["openai/widgetDomain"]).toBe("https://widgets.example.com");
     });
 
+    it("includes the public MCP origin in CSP when it differs from the widget fetch origin", async () => {
+        const content = await buildWidgetResourceContent({
+            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            mcpClient: "ChatGPT",
+            widgetFetchOrigin: "https://widgets.example.com",
+            publicMcpUrl: "https://mcp-alt.example.com/mcp",
+            env: {},
+        });
+
+        const meta = content._meta as {
+            ui: { domain?: string; csp: { connectDomains: string[] } };
+        };
+
+        expect(meta.ui.csp.connectDomains).toEqual(
+            expect.arrayContaining([
+                "https://api.doit.com",
+                "https://mcp.doit.com",
+                "https://widgets.example.com",
+                "https://mcp-alt.example.com",
+            ])
+        );
+    });
+
     it("omits the domain key entirely when the resolver omits ui.domain", async () => {
         const content = await buildWidgetResourceContent({
             widgetUri: "ui://doit/cloud-intelligence-v9.html",

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -5,10 +5,39 @@ import {
     buildWidgetStub,
     classifyUiDomainProvider,
     computeClaudeDomain,
+    resolvePublicMcpUrl,
     resolveUiDomain,
+    resolveWidgetFetchOrigin,
 } from "../../../doit-mcp-server/src/widgetResource.js";
 
 const EXPECTED_CLAUDE_DOMAIN = "2f32404e366572ee7f7f5f0eb625e6c4.claudemcpcontent.com";
+
+describe("widget URL resolution", () => {
+    it("falls back to the default widget fetch origin when WORKER_URL is unset", () => {
+        expect(resolveWidgetFetchOrigin({})).toBe("https://mcp.doit.com");
+    });
+
+    it("builds the default public MCP URL from the widget fetch origin", () => {
+        expect(resolvePublicMcpUrl({}, "https://widgets.example.com")).toBe(
+            "https://widgets.example.com/sse"
+        );
+    });
+
+    it("throws a clear error when WORKER_URL is not absolute", () => {
+        expect(() => resolveWidgetFetchOrigin({ WORKER_URL: "widgets.example.com" })).toThrow(
+            "[widget] WORKER_URL must be an absolute URL."
+        );
+    });
+
+    it("throws a clear error when PUBLIC_MCP_URL is not absolute", () => {
+        expect(() =>
+            resolvePublicMcpUrl(
+                { PUBLIC_MCP_URL: "widgets.example.com/mcp" },
+                "https://widgets.example.com"
+            )
+        ).toThrow("[widget] PUBLIC_MCP_URL must be an absolute URL.");
+    });
+});
 
 describe("computeClaudeDomain", () => {
     it("returns the Claude sandbox hostname for the public MCP URL", async () => {

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { WIDGET_URI } from "../../../doit-mcp-server/src/responseAdapter.js";
 import {
     buildWidgetResourceContent,
     buildWidgetStub,
@@ -127,7 +128,7 @@ describe("widget resource contract", () => {
 
     it("emits the OpenAI alias only for OpenAI clients", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v10.html",
+            widgetUri: WIDGET_URI,
             mcpClient: "ChatGPT",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",
@@ -139,6 +140,7 @@ describe("widget resource contract", () => {
             "openai/widgetDomain"?: string;
         };
 
+        expect(content.uri).toBe(WIDGET_URI);
         expect(meta.ui.domain).toBe("https://widgets.example.com");
         expect(meta["openai/widgetDomain"]).toBe("https://widgets.example.com");
         expect(meta.ui.csp.connectDomains).toEqual(
@@ -148,7 +150,7 @@ describe("widget resource contract", () => {
 
     it("uses a persisted OpenAI provider when the current request lacks mcpClient", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v10.html",
+            widgetUri: WIDGET_URI,
             sessionProvider: "openai",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",
@@ -166,7 +168,7 @@ describe("widget resource contract", () => {
 
     it("includes the public MCP origin in CSP when it differs from the widget fetch origin", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v10.html",
+            widgetUri: WIDGET_URI,
             mcpClient: "ChatGPT",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://mcp-alt.example.com/mcp",
@@ -189,7 +191,7 @@ describe("widget resource contract", () => {
 
     it("does not include the legacy ngrok host in CSP by default", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v10.html",
+            widgetUri: WIDGET_URI,
             mcpClient: "ChatGPT",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",
@@ -205,7 +207,7 @@ describe("widget resource contract", () => {
 
     it("omits the domain key entirely when the resolver omits ui.domain", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v10.html",
+            widgetUri: WIDGET_URI,
             mcpClient: "acme-mcp-client",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -187,6 +187,22 @@ describe("widget resource contract", () => {
         );
     });
 
+    it("does not include the legacy ngrok host in CSP by default", async () => {
+        const content = await buildWidgetResourceContent({
+            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            mcpClient: "ChatGPT",
+            widgetFetchOrigin: "https://widgets.example.com",
+            publicMcpUrl: "https://widgets.example.com/mcp",
+            env: {},
+        });
+
+        const meta = content._meta as {
+            ui: { domain?: string; csp: { connectDomains: string[] } };
+        };
+
+        expect(meta.ui.csp.connectDomains).not.toContain("https://dci-mcp.ngrok.app");
+    });
+
     it("omits the domain key entirely when the resolver omits ui.domain", async () => {
         const content = await buildWidgetResourceContent({
             widgetUri: "ui://doit/cloud-intelligence-v9.html",

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -127,7 +127,7 @@ describe("widget resource contract", () => {
 
     it("emits the OpenAI alias only for OpenAI clients", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            widgetUri: "ui://doit/cloud-intelligence-v10.html",
             mcpClient: "ChatGPT",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",
@@ -148,7 +148,7 @@ describe("widget resource contract", () => {
 
     it("uses a persisted OpenAI provider when the current request lacks mcpClient", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            widgetUri: "ui://doit/cloud-intelligence-v10.html",
             sessionProvider: "openai",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",
@@ -166,7 +166,7 @@ describe("widget resource contract", () => {
 
     it("includes the public MCP origin in CSP when it differs from the widget fetch origin", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            widgetUri: "ui://doit/cloud-intelligence-v10.html",
             mcpClient: "ChatGPT",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://mcp-alt.example.com/mcp",
@@ -189,7 +189,7 @@ describe("widget resource contract", () => {
 
     it("does not include the legacy ngrok host in CSP by default", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            widgetUri: "ui://doit/cloud-intelligence-v10.html",
             mcpClient: "ChatGPT",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",
@@ -205,7 +205,7 @@ describe("widget resource contract", () => {
 
     it("omits the domain key entirely when the resolver omits ui.domain", async () => {
         const content = await buildWidgetResourceContent({
-            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            widgetUri: "ui://doit/cloud-intelligence-v10.html",
             mcpClient: "acme-mcp-client",
             widgetFetchOrigin: "https://widgets.example.com",
             publicMcpUrl: "https://widgets.example.com/mcp",

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildWidgetResourceContent,
+    buildWidgetStub,
+    classifyUiDomainProvider,
+    computeClaudeDomain,
+    resolveUiDomain,
+} from "../../../doit-mcp-server/src/widgetResource.js";
+
+const EXPECTED_CLAUDE_DOMAIN = "2f32404e366572ee7f7f5f0eb625e6c4.claudemcpcontent.com";
+
+describe("computeClaudeDomain", () => {
+    it("returns the Claude sandbox hostname for the public MCP URL", async () => {
+        await expect(computeClaudeDomain("https://mcp.doit.com/sse")).resolves.toBe(EXPECTED_CLAUDE_DOMAIN);
+    });
+});
+
+describe("resolveUiDomain", () => {
+    it("classifies the Claude-family aliases seen in worker logs", () => {
+        expect(classifyUiDomainProvider("Anthropic/Toolbox")).toBe("claude");
+        expect(classifyUiDomainProvider("Anthropic/ClaudeAI")).toBe("claude");
+        expect(classifyUiDomainProvider("claude-ai")).toBe("claude");
+    });
+
+    it("classifies Claude-family clients and computes a Claude sandbox domain", async () => {
+        await expect(
+            resolveUiDomain({
+                mcpClient: "Claude Cowork",
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {},
+            })
+        ).resolves.toEqual({
+            provider: "claude",
+            uiDomain: EXPECTED_CLAUDE_DOMAIN,
+        });
+    });
+
+    it("classifies OpenAI clients and returns an origin-style domain", async () => {
+        await expect(
+            resolveUiDomain({
+                mcpClient: "ChatGPT",
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {},
+            })
+        ).resolves.toEqual({
+            provider: "openai",
+            uiDomain: "https://mcp.doit.com",
+        });
+    });
+
+    it("omits ui.domain when the client is undefined", async () => {
+        await expect(
+            resolveUiDomain({
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {},
+            })
+        ).resolves.toEqual({
+            provider: "omit",
+        });
+    });
+
+    it("falls back to the persisted session provider when mcpClient is unavailable", async () => {
+        await expect(
+            resolveUiDomain({
+                sessionProvider: "claude",
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {},
+            })
+        ).resolves.toEqual({
+            provider: "claude",
+            uiDomain: EXPECTED_CLAUDE_DOMAIN,
+        });
+    });
+
+    it("does not reuse a persisted provider when the current client is explicitly unknown", async () => {
+        await expect(
+            resolveUiDomain({
+                mcpClient: "acme-mcp-client",
+                sessionProvider: "claude",
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {},
+            })
+        ).resolves.toEqual({
+            provider: "omit",
+        });
+    });
+
+    it("omits ui.domain for unknown clients", async () => {
+        await expect(
+            resolveUiDomain({
+                mcpClient: "acme-mcp-client",
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {},
+            })
+        ).resolves.toEqual({
+            provider: "omit",
+        });
+    });
+
+    it("honors forced provider overrides for rollout and debugging", async () => {
+        await expect(
+            resolveUiDomain({
+                widgetFetchOrigin: "https://mcp.doit.com",
+                publicMcpUrl: "https://mcp.doit.com/sse",
+                env: {
+                    UI_DOMAIN_PROVIDER: "openai",
+                    OPENAI_UI_DOMAIN: "https://widgets.example.com",
+                },
+            })
+        ).resolves.toEqual({
+            provider: "openai",
+            uiDomain: "https://widgets.example.com",
+        });
+    });
+});
+
+describe("widget resource contract", () => {
+    it("keeps the widget stub pointed at the real widget fetch origin", () => {
+        expect(buildWidgetStub("https://widgets.example.com")).toContain('"https://widgets.example.com/widget"');
+    });
+
+    it("emits the OpenAI alias only for OpenAI clients", async () => {
+        const content = await buildWidgetResourceContent({
+            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            mcpClient: "ChatGPT",
+            widgetFetchOrigin: "https://widgets.example.com",
+            publicMcpUrl: "https://widgets.example.com/mcp",
+            env: {},
+        });
+
+        const meta = content._meta as {
+            ui: { domain?: string; csp: { connectDomains: string[] } };
+            "openai/widgetDomain"?: string;
+        };
+
+        expect(meta.ui.domain).toBe("https://widgets.example.com");
+        expect(meta["openai/widgetDomain"]).toBe("https://widgets.example.com");
+        expect(meta.ui.csp.connectDomains).toEqual(
+            expect.arrayContaining(["https://api.doit.com", "https://mcp.doit.com", "https://widgets.example.com"])
+        );
+    });
+
+    it("uses a persisted OpenAI provider when the current request lacks mcpClient", async () => {
+        const content = await buildWidgetResourceContent({
+            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            sessionProvider: "openai",
+            widgetFetchOrigin: "https://widgets.example.com",
+            publicMcpUrl: "https://widgets.example.com/mcp",
+            env: {},
+        });
+
+        const meta = content._meta as {
+            ui: { domain?: string; csp: { connectDomains: string[] } };
+            "openai/widgetDomain"?: string;
+        };
+
+        expect(meta.ui.domain).toBe("https://widgets.example.com");
+        expect(meta["openai/widgetDomain"]).toBe("https://widgets.example.com");
+    });
+
+    it("omits the domain key entirely when the resolver omits ui.domain", async () => {
+        const content = await buildWidgetResourceContent({
+            widgetUri: "ui://doit/cloud-intelligence-v9.html",
+            mcpClient: "acme-mcp-client",
+            widgetFetchOrigin: "https://widgets.example.com",
+            publicMcpUrl: "https://widgets.example.com/mcp",
+            env: {},
+        });
+
+        const meta = content._meta as {
+            ui: { domain?: string; csp: { connectDomains: string[] } };
+            "openai/widgetDomain"?: string;
+        };
+
+        expect(meta.ui).not.toHaveProperty("domain");
+        expect(meta).not.toHaveProperty("openai/widgetDomain");
+        expect(content.text).toContain('"https://widgets.example.com/widget"');
+    });
+});


### PR DESCRIPTION
https://doitintl.atlassian.net/browse/CMP-41546

## Summary

This PR fixes `CMP-41546`, where the DoiT Cloud Intelligence widget failed to render inline in Claude Cowork because the MCP resource returned a single generic `ui.domain` shape for all hosts.

`ui.domain` is provider-specific metadata:
- Claude-family hosts expect a hashed hostname in the form `{sha256(public-mcp-url)}.claudemcpcontent.com`
- OpenAI-family hosts expect an origin-style domain
- Unknown / unsupported hosts should not receive a guessed `ui.domain`

Previously, we effectively treated the worker origin as the UI domain and returned one generic value. That worked for some hosts but caused Cowork to reject the widget metadata with:

`Invalid ui.domain format: expected "{hash}.claudemcpcontent.com"`


## Root Cause

There are two separate concepts involved in widget rendering:

- `widgetFetchOrigin`: where the widget HTML is actually fetched from (`/widget`)
- `ui.domain`: host-specific sandbox metadata used by the MCP client for widget/iframe isolation

Those values cannot be treated as the same thing across providers.

During local repro, OAuth and MCP tool calls were working, but widget rendering failed at the metadata layer. We also found a second issue while debugging: `mcpClient` can be available during MCP initialization but later be missing on `resources/read`, which meant the server could no longer reliably resolve the correct provider-specific `ui.domain` unless that provider was remembered per session.


## What Changed

- Extracted widget metadata / `ui.domain` logic into a dedicated helper module.
- Added provider-aware classification for:
  - Claude-family clients
  - OpenAI-family clients
  - Unknown / unsupported clients
- Separated the real widget fetch origin from the public MCP URL used for Claude-family hashing.
- Introduced `PUBLIC_MCP_URL` so Claude-family hashes are computed from the exact host-facing MCP endpoint string.
- Resolved `ui.domain` dynamically by provider instead of returning one generic value.
- Added the OpenAI-specific widget domain alias when applicable.
- Persisted the normalized provider on the `DoitMCPAgent` session so the widget resource can still resolve the correct metadata even when `mcpClient` is missing on `resources/read`.
- Kept `UI_DOMAIN_PROVIDER` as an optional override for debugging / rollout control, not as the normal path.
- Hardened the Claude hash helper so it works in both Cloudflare Workers and Node/Vitest environments.


## Provider Behavior After This Change

- Claude-family hosts receive a hashed Claude-compatible `ui.domain`
- OpenAI-family hosts receive an origin-style domain and the OpenAI widget-domain alias
- Unknown / unsupported hosts omit `ui.domain`

This keeps the widget metadata compatible across hosts instead of optimizing for one provider at the expense of the others.


## Testing

### Automated
- Added focused tests covering:
  - Claude-family aliases seen in logs
  - OpenAI hosts
  - Unknown hosts
  - Missing `mcpClient`
  - Persisted session-provider fallback
  - Explicit unknown-client precedence over persisted provider
  - CSP `connectDomains` behavior
- Full test suite passes
- Worker type-check passes

### Cowork validation
We reproduced and validated the Cowork render path locally by:
- running the Worker with `wrangler dev`
- exposing it through a public tunnel
- connecting Cowork to the public MCP endpoint
- authenticating through the normal OAuth flow
- confirming that the widget resource path was hit (`resources/read`)
- confirming that Cowork requested the widget HTML (`GET /widget`)
- validating successful inline rendering using a smaller widget-friendly flow such as anomalies

One important note: `get_cloud_overview` can exceed the host's inline output limits, which blocks widget rendering for a separate reason (payload size). Cowork validation therefore used a narrower tool path rather than the oversized overview payload.


## Notes / Rollout Considerations

- `PUBLIC_MCP_URL` remains configurable because Claude-family hashing must use the exact public MCP endpoint string seen by the host.
- `UI_DOMAIN_PROVIDER` should only be used as a temporary override for debugging or rollout control.
- This PR fixes the provider-aware metadata path; remaining cross-host validation should still include Cowork, Claude Chat, ChatGPT, and one unknown/plain MCP client.

## What was implemented:

- Added PUBLIC_MCP_URL variable to wrangler configuration for improved resource access.
- Refactored Bindings type in app.ts to utilize DoitWorkerEnv for better environment management.
- Introduced runtimeEnv.ts to define environment variables and types, including UiDomainProvider.
- Implemented widget resource functions in widgetResource.ts to manage widget fetching and domain classification.
- Added tests for widget resource functionality to ensure correct behavior and domain resolution.

These changes improve the overall structure and functionality of the MCP server, enhancing widget management and environment configuration.

## Final manual tests:
- on Cowork and Claude Chat in desktop app
- in Claude Chat on web
- in ChatGPT on web

<img width="1076" height="1101" alt="image" src="https://github.com/user-attachments/assets/58fac35d-d4d0-41f4-82a2-c80035aa2f54" />

<img width="1026" height="1295" alt="image" src="https://github.com/user-attachments/assets/564604c5-eed7-4825-ab88-f710459e8a9e" />

