### PR TITLE
feat: enhance user validation handling with new parsing function

### DIFF
--- a/doit-mcp-server/src/app.ts
+++ b/doit-mcp-server/src/app.ts
@@ -194,14 +194,14 @@ app.post("/customer-context", async (c) => {
         }
       : {};
 
-    const validatePromise = await handleValidateUserRequest(
+    const validateResponse = await handleValidateUserRequest(
       doitEmployeeContext,
       apiKey
     );
 
     let validatedUser: ValidateUserResponse;
     try {
-      validatedUser = parseValidatedUserResponse(validatePromise);
+      validatedUser = parseValidatedUserResponse(validateResponse);
     } catch (error) {
       console.error("OAuth validate response parsing failed", {
         reason: error instanceof Error ? error.message : String(error),

--- a/doit-mcp-server/src/app.ts
+++ b/doit-mcp-server/src/app.ts
@@ -10,7 +10,7 @@ import {
   renderCustomerContextScreen,
 } from "./utils";
 import type { OAuthHelpers } from "@cloudflare/workers-oauth-provider";
-import { handleValidateUserRequest } from "../../src/tools/validateUser";
+import { handleValidateUserRequest, parseValidatedUserResponse, type ValidateUserResponse } from "../../src/tools/validateUser";
 import { decodeJWT } from "../../src/utils/util";
 import { DEMO_TOKEN } from "../../src/utils/demoData";
 import { WIDGET_HTML } from "./widgetHtml";
@@ -198,9 +198,26 @@ app.post("/customer-context", async (c) => {
       doitEmployeeContext,
       apiKey
     );
-    const result = validatePromise.content[0].text;
 
-    if (!result.toLowerCase().includes(payload.sub)) {
+    let validatedUser: ValidateUserResponse;
+    try {
+      validatedUser = parseValidatedUserResponse(validatePromise);
+    } catch (error) {
+      console.error("OAuth validate response parsing failed", {
+        reason: error instanceof Error ? error.message : String(error),
+        isDoitEmployee: Boolean(payload.DoitEmployee),
+      });
+      return await renderAuthorizationRejection(
+        c,
+        oauthReqInfo?.redirectUri || "/"
+      );
+    }
+
+    const payloadSub = typeof payload.sub === "string" ? payload.sub : "";
+    if (validatedUser.email.toLowerCase() !== payloadSub.toLowerCase()) {
+      console.error("OAuth validate email mismatch", {
+        isDoitEmployee: Boolean(payload.DoitEmployee),
+      });
       return await renderAuthorizationRejection(
         c,
         oauthReqInfo?.redirectUri || "/"
@@ -208,10 +225,8 @@ app.post("/customer-context", async (c) => {
     }
 
     if (!payload.DoitEmployee) {
-      // For non-DoiT employees, extract the domain from the validate response
-      // and use it as customerContext (the DoiT API identifies their account by domain).
-      const domainMatch = result.match(/Domain:\s*(\S+)/);
-      const customerContext = domainMatch ? domainMatch[1] : undefined;
+      // For non-DoiT employees, the DoiT API identifies their account by domain.
+      const customerContext = validatedUser.domain;
 
       if (!oauthReqInfo) {
         return c.html("INVALID LOGIN", 401);

--- a/src/tools/__tests__/changeCustomer.test.ts
+++ b/src/tools/__tests__/changeCustomer.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createErrorResponse, createSuccessResponse, formatZodError, handleGeneralError } from "../../utils/util.js";
 import { ChangeCustomerArgumentsSchema, handleChangeCustomerRequest } from "../changeCustomer.js";
+import { handleValidateUserRequest } from "../validateUser.js";
 
 // Mock the utility functions
 vi.mock("../../utils/util.js", () => ({
@@ -14,23 +15,32 @@ vi.mock("../../utils/util.js", () => ({
     handleGeneralError: vi.fn((error, context) => ({
         content: [{ type: "text", text: `Error in ${context}: ${error.message}` }],
     })),
+    DOIT_API_BASE: "https://api.doit.com",
 }));
 
 // Mock the validateUser function
-vi.mock("../validateUser.js", () => ({
-    handleValidateUserRequest: vi.fn(() => ({
-        content: [
-            {
-                type: "text",
-                text: "User validation successful:\nDomain: example.com (the domain of the user, make it bold)\nEmail: user@example.com",
-            },
-        ],
-    })),
-}));
+vi.mock("../validateUser.js", async () => {
+    const actual = await vi.importActual<typeof import("../validateUser.js")>("../validateUser.js");
+    return {
+        ...actual,
+        handleValidateUserRequest: vi.fn(),
+    };
+});
 
 describe("changeCustomer", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(handleValidateUserRequest).mockResolvedValue({
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify({
+                        domain: "example.com",
+                        email: "user@example.com",
+                    }),
+                },
+            ],
+        });
     });
 
     describe("ChangeCustomerArgumentsSchema", () => {
@@ -77,7 +87,7 @@ describe("changeCustomer", () => {
 
             expect(updateCallback).toHaveBeenCalledWith(newContext);
             expect(createSuccessResponse).toHaveBeenCalledWith(
-                "Customer context successfully changed to 'example.com (the domain of the user, make it bold)\nEmail: user@example.com'"
+                "Customer context successfully changed to 'example.com'"
             );
         });
 
@@ -95,7 +105,7 @@ describe("changeCustomer", () => {
 
             expect(updateCallback).toHaveBeenCalledWith(newContext);
             expect(createSuccessResponse).toHaveBeenCalledWith(
-                "Customer context successfully changed to 'example.com (the domain of the user, make it bold)\nEmail: user@example.com'"
+                "Customer context successfully changed to 'example.com'"
             );
         });
 
@@ -109,7 +119,24 @@ describe("changeCustomer", () => {
             const _result = await handleChangeCustomerRequest({ ...args, customerContext: newContext }, token);
 
             expect(createSuccessResponse).toHaveBeenCalledWith(
-                "Customer context successfully changed to 'example.com (the domain of the user, make it bold)\nEmail: user@example.com'"
+                "Customer context successfully changed to 'example.com'"
+            );
+        });
+
+        it("should reject an invalid customer context when validation returns an error", async () => {
+            vi.mocked(handleValidateUserRequest).mockResolvedValue({
+                content: [{ type: "text", text: "The customer context is not authorized" }],
+                isError: true,
+            } as any);
+            const newContext = "new-customer-123";
+            const token = "mock-token";
+            const updateCallback = vi.fn();
+
+            await handleChangeCustomerRequest({ customerContext: newContext }, token, updateCallback);
+
+            expect(updateCallback).not.toHaveBeenCalled();
+            expect(createErrorResponse).toHaveBeenCalledWith(
+                "Customer context is invalid. Please try again with a valid customer id."
             );
         });
 

--- a/src/tools/__tests__/validateUser.test.ts
+++ b/src/tools/__tests__/validateUser.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createErrorResponse, createSuccessResponse, handleGeneralError, makeDoitRequest } from "../../utils/util.js";
-import { handleValidateUserRequest } from "../validateUser.js";
+import { handleValidateUserRequest, parseValidatedUserResponse } from "../validateUser.js";
 
 // Mock the utility functions
 vi.mock("../../utils/util.js", () => ({
@@ -32,7 +32,7 @@ describe("validateUser", () => {
                 domain: "example.com",
                 email: "user@example.com",
             };
-            (makeDoitRequest as vi.Mock).mockResolvedValue(mockApiResponse);
+            vi.mocked(makeDoitRequest).mockResolvedValue(mockApiResponse);
 
             const response = await handleValidateUserRequest(mockArgs, mockToken);
 
@@ -40,12 +40,20 @@ describe("validateUser", () => {
                 appendParams: true,
                 method: "GET",
             });
-            expect(createSuccessResponse).toHaveBeenCalledWith(expect.stringContaining("example.com"));
+            expect(createSuccessResponse).toHaveBeenCalledWith(
+                JSON.stringify({
+                    domain: "example.com",
+                    email: "user@example.com",
+                })
+            );
             expect(response).toEqual({
                 content: [
                     {
                         type: "text",
-                        text: expect.stringContaining("example.com"),
+                        text: JSON.stringify({
+                            domain: "example.com",
+                            email: "user@example.com",
+                        }),
                     },
                 ],
             });
@@ -53,7 +61,7 @@ describe("validateUser", () => {
 
         it("should handle API request failure", async () => {
             const mockArgs = {};
-            (makeDoitRequest as vi.Mock).mockResolvedValue(null);
+            vi.mocked(makeDoitRequest).mockResolvedValue(null);
 
             const response = await handleValidateUserRequest(mockArgs, mockToken);
 
@@ -69,7 +77,7 @@ describe("validateUser", () => {
 
         it("should handle general errors", async () => {
             const mockArgs = {};
-            (makeDoitRequest as vi.Mock).mockRejectedValue(new Error("Network error"));
+            vi.mocked(makeDoitRequest).mockRejectedValue(new Error("Network error"));
 
             const response = await handleValidateUserRequest(mockArgs, mockToken);
 
@@ -77,6 +85,79 @@ describe("validateUser", () => {
             expect(response).toEqual({
                 content: [{ type: "text", text: "General Error: making DoiT API request" }],
             });
+        });
+    });
+
+    describe("parseValidatedUserResponse", () => {
+        it("should parse a successful JSON validate response", () => {
+            const response = {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({
+                            domain: "example.com",
+                            email: "user@example.com",
+                        }),
+                    },
+                ],
+            };
+
+            expect(parseValidatedUserResponse(response)).toEqual({
+                domain: "example.com",
+                email: "user@example.com",
+            });
+        });
+
+        it("should reject validate errors", () => {
+            const response = {
+                content: [{ type: "text", text: "The customer context is not authorized" }],
+                isError: true,
+            };
+
+            expect(() => parseValidatedUserResponse(response)).toThrow("Failed to validate user");
+        });
+
+        it("should reject malformed JSON", () => {
+            const response = {
+                content: [{ type: "text", text: "Domain: example.com\nEmail: user@example.com" }],
+            };
+
+            expect(() => parseValidatedUserResponse(response)).toThrow();
+        });
+
+        it("should reject JSON missing required fields", () => {
+            const response = {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({
+                            email: "user@example.com",
+                        }),
+                    },
+                ],
+            };
+
+            expect(() => parseValidatedUserResponse(response)).toThrow(
+                "Validate user response missing domain or email"
+            );
+        });
+
+        it("should reject JSON with non-string required fields", () => {
+            const response = {
+                content: [
+                    {
+                        type: "text",
+                        text: JSON.stringify({
+                            domain: 123,
+                            email: "user@example.com",
+                        }),
+                    },
+                ],
+            };
+
+            expect(() => parseValidatedUserResponse(response)).toThrow(
+                "Validate user response missing domain or email"
+            );
         });
     });
 });

--- a/src/tools/__tests__/validateUser.test.ts
+++ b/src/tools/__tests__/validateUser.test.ts
@@ -36,10 +36,14 @@ describe("validateUser", () => {
 
             const response = await handleValidateUserRequest(mockArgs, mockToken);
 
-            expect(makeDoitRequest).toHaveBeenCalledWith("https://api.doit.com/auth/v1/validate", mockToken, {
-                appendParams: true,
-                method: "GET",
-            });
+            expect(makeDoitRequest).toHaveBeenCalledWith(
+                "https://api.doit.com/auth/v1/validate",
+                mockToken,
+                expect.objectContaining({
+                    appendParams: true,
+                    method: "GET",
+                })
+            );
             expect(createSuccessResponse).toHaveBeenCalledWith(
                 JSON.stringify({
                     domain: "example.com",
@@ -65,10 +69,14 @@ describe("validateUser", () => {
 
             const response = await handleValidateUserRequest(mockArgs, mockToken);
 
-            expect(makeDoitRequest).toHaveBeenCalledWith("https://api.doit.com/auth/v1/validate", mockToken, {
-                appendParams: true,
-                method: "GET",
-            });
+            expect(makeDoitRequest).toHaveBeenCalledWith(
+                "https://api.doit.com/auth/v1/validate",
+                mockToken,
+                expect.objectContaining({
+                    appendParams: true,
+                    method: "GET",
+                })
+            );
             expect(createErrorResponse).toHaveBeenCalledWith("Failed to validate user");
             expect(response).toEqual({
                 content: [{ type: "text", text: "Failed to validate user" }],

--- a/src/tools/changeCustomer.ts
+++ b/src/tools/changeCustomer.ts
@@ -58,10 +58,7 @@ export async function handleChangeCustomerRequest(
         const _previousContext = args.customerContext;
 
         // Verify that the new context is valid
-        const validateResponse = await handleValidateUserRequest(
-            { customerContext: newContext },
-            token
-        );
+        const validateResponse = await handleValidateUserRequest({ customerContext: newContext }, token);
 
         let validatedUser: ValidateUserResponse;
         try {

--- a/src/tools/changeCustomer.ts
+++ b/src/tools/changeCustomer.ts
@@ -58,14 +58,14 @@ export async function handleChangeCustomerRequest(
         const _previousContext = args.customerContext;
 
         // Verify that the new context is valid
-        const newCustomerDomain = await handleValidateUserRequest(
+        const validateResponse = await handleValidateUserRequest(
             { customerContext: newContext },
             token
         );
 
         let validatedUser: ValidateUserResponse;
         try {
-            validatedUser = parseValidatedUserResponse(newCustomerDomain);
+            validatedUser = parseValidatedUserResponse(validateResponse);
         } catch {
             return createErrorResponse("Customer context is invalid. Please try again with a valid customer id.");
         }

--- a/src/tools/changeCustomer.ts
+++ b/src/tools/changeCustomer.ts
@@ -59,7 +59,7 @@ export async function handleChangeCustomerRequest(
 
         // Verify that the new context is valid
         const newCustomerDomain = await handleValidateUserRequest(
-            { customerContext: newContext }, // Validate doers
+            { customerContext: newContext },
             token
         );
 

--- a/src/tools/changeCustomer.ts
+++ b/src/tools/changeCustomer.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createErrorResponse, createSuccessResponse, formatZodError, handleGeneralError } from "../utils/util.js";
-import { handleValidateUserRequest } from "./validateUser.js";
+import { handleValidateUserRequest, parseValidatedUserResponse, type ValidateUserResponse } from "./validateUser.js";
 
 // Schema definition
 export const ChangeCustomerArgumentsSchema = z.object({
@@ -63,7 +63,10 @@ export async function handleChangeCustomerRequest(
             token
         );
 
-        if (newCustomerDomain.content[0].text.toLowerCase().includes("failed")) {
+        let validatedUser: ValidateUserResponse;
+        try {
+            validatedUser = parseValidatedUserResponse(newCustomerDomain);
+        } catch {
             return createErrorResponse("Customer context is invalid. Please try again with a valid customer id.");
         }
 
@@ -72,12 +75,10 @@ export async function handleChangeCustomerRequest(
             await updateCustomerContext(newContext);
         }
 
-        const domain = newCustomerDomain.content[0].text.split("Domain: ")[1];
-
         // Create response
         const response: ChangeCustomerResponse = {
             success: true,
-            message: `Customer context successfully changed to '${domain}'`,
+            message: `Customer context successfully changed to '${validatedUser.domain}'`,
         };
 
         return createSuccessResponse(response.message);

--- a/src/tools/validateUser.ts
+++ b/src/tools/validateUser.ts
@@ -19,6 +19,40 @@ export interface ValidateUserResponse {
     email: string;
 }
 
+export interface ValidateUserToolResponse {
+    content: Array<{
+        type: string;
+        text: string;
+    }>;
+    isError?: boolean;
+}
+
+/**
+ * Parse the result of `handleValidateUserRequest` into typed user data.
+ * Throws on `isError`, empty content, malformed JSON, or missing/invalid fields.
+ * Use this anywhere internal control flow depends on validate-user data.
+ */
+export function parseValidatedUserResponse(response: ValidateUserToolResponse): ValidateUserResponse {
+    if (response.isError) {
+        throw new Error("Failed to validate user");
+    }
+
+    const text = response.content[0]?.text;
+    if (!text) {
+        throw new Error("Validate user response is empty");
+    }
+
+    const parsed = JSON.parse(text) as { domain?: unknown; email?: unknown };
+    if (typeof parsed.domain !== "string" || !parsed.domain || typeof parsed.email !== "string" || !parsed.email) {
+        throw new Error("Validate user response missing domain or email");
+    }
+
+    return {
+        domain: parsed.domain,
+        email: parsed.email,
+    };
+}
+
 // Tool metadata
 export const validateUserTool = {
     name: "validate_user",


### PR DESCRIPTION
Jira Issue: https://doitintl.atlassian.net/browse/CMP-42135

## Summary

Fix CMP-42135 by restoring customer context detection in the remote MCP OAuth flow.

`validate_user` now returns JSON (`{"domain":"...","email":"..."}`), but the remote OAuth `/customer-context` flow still parsed the old text format (`Domain: ...`). For non-DoiT customer users, this caused OAuth to complete with `customerContext: undefined`, so customer-scoped MCP tools could fail after connection.

This PR adds a shared parser for validate-user responses and uses it in both affected internal callers.

## Changes

- Parse `validate_user` responses as JSON through a shared `parseValidatedUserResponse()` helper.
- Set OAuth `props.customerContext` from the validated customer domain for non-DoiT users.
- Reject malformed validate responses, validate errors, missing/invalid fields, and email mismatches.
- Reuse the same parser in `change_customer` so it no longer depends on the old `Domain: ...` text format.
- Add focused unit coverage for the validate response contract and `change_customer` regression path.
- Add conservative OAuth rejection logs without logging API keys or raw validate responses.

## Manual Verification

Reproduced locally through Wrangler + ngrok using remote MCP connectors.

Before the fix, OAuth completed but the Worker initialized the MCP agent with no customer context:

```text
Initializing Doit MCP Agent undefined
Loaded customer context: undefined
After loading persisted props: undefined
```

After the fix, both Claude Desktop and ChatGPT connector flows populated the customer context correctly:

```text
POST /customer-context 302 Found
tokenExchangeCallback authorization_code {
  customerContext: 'budgetao.com',
  isDoitUser: 'false'
}
POST /token 200 OK
Initializing Doit MCP Agent budgetao.com
Loaded customer context: budgetao.com
After loading persisted props: budgetao.com
Saving customer context: budgetao.com
POST /mcp 200 OK
```

Notes
The customer-facing Customer Context screen is not expected for non-DoiT users. Their tenant context should be auto-detected from the validated API key. This PR restores that behavior.

## What was committed

- Introduced `parseValidatedUserResponse` to streamline the parsing of user validation responses, improving error handling and data extraction.
- Updated `handleChangeCustomerRequest` and `/customer-context` endpoint to utilize the new parsing function, ensuring consistent validation logic.
- Enhanced tests for both user validation and customer change functionalities to cover new parsing scenarios and error cases.

This change improves the robustness of user validation processes and enhances overall code maintainability.