### PR TITLE
feat: enhance widget resource error handling and fallback content

### DIFF
--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -390,9 +390,13 @@ export class DoitMCPAgent extends McpAgent {
         return provider;
       }
     } catch (error) {
-      console.error("[widget] failed to load persisted UI domain provider", {
-        reason: getErrorMessage(error),
-      });
+      console.error(
+        "[widget] failed to load persisted UI domain provider",
+        {
+          reason: getErrorMessage(error),
+        },
+        error
+      );
     }
 
     return undefined;

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -318,7 +318,6 @@ export class DoitMCPAgent extends McpAgent {
   // so there is no cross-session bleed between DO instances sharing the same isolate.
   private _mcpClientInfo: TrackingContext = {};
   private _sessionUiDomainProvider?: UiDomainProvider;
-  private _didAttemptLoadSessionUiDomainProvider = false;
 
   // Per-instance approval store for the two-phase destructive-tool commit flow.
   // Backed by `this.ctx.storage` (DurableObject storage) so that a staged action
@@ -385,7 +384,6 @@ export class DoitMCPAgent extends McpAgent {
       const provider = await this.ctx.storage.get<UiDomainProvider>(
         SESSION_UI_DOMAIN_PROVIDER_KEY
       );
-      this._didAttemptLoadSessionUiDomainProvider = true;
 
       if (provider === "claude" || provider === "openai") {
         this._sessionUiDomainProvider = provider;
@@ -505,8 +503,7 @@ export class DoitMCPAgent extends McpAgent {
         async () => {
           if (
             !this._mcpClientInfo.mcpClient &&
-            !this._sessionUiDomainProvider &&
-            !this._didAttemptLoadSessionUiDomainProvider
+            !this._sessionUiDomainProvider
           ) {
             await this.loadPersistedSessionUiDomainProvider();
           }

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -583,7 +583,7 @@ export class DoitMCPAgent extends McpAgent {
       });
     };
 
-    // Swallow transient DO storage errors so init never aborts; tools fall back to in-memory props.
+    // Swallow transient DO storage errors here so init never aborts.
     // Customer context predates widget support and is needed by tool callbacks.
     try {
       await this.loadPersistedProps();

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -241,10 +241,14 @@ function logMcpInitStorageError(
   error: unknown,
   props: Record<string, unknown>
 ) {
-  console.error(message, {
-    reason: getErrorMessage(error),
-    hasApiKey: Boolean(props.apiKey),
-  });
+  console.error(
+    message,
+    {
+      reason: getErrorMessage(error),
+      hasApiKey: Boolean(props.apiKey),
+    },
+    error
+  );
 }
 
 function logWidgetResourceError(

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -408,7 +408,19 @@ export class DoitMCPAgent extends McpAgent {
   private createToolCallback(toolName: string) {
     return async (args: any) => {
       const token = this.getToken();
-      const persistedCustomerContext = await this.loadPersistedProps();
+      let persistedCustomerContext: string | null = null;
+      try {
+        persistedCustomerContext = await this.loadPersistedProps();
+      } catch (error) {
+        console.error(
+          "[mcp] loadPersistedProps failed during tool call",
+          {
+            reason: getErrorMessage(error),
+            toolName,
+          },
+          error
+        );
+      }
       const customerContext =
         persistedCustomerContext || (this.props.customerContext as string);
 

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -475,13 +475,15 @@ export class DoitMCPAgent extends McpAgent {
 
   private registerWidgetResource() {
     try {
-      void this.loadPersistedSessionUiDomainProvider();
       const env = this.env as DoitWorkerEnv;
       this.server.resource(
         "cloud-intelligence-widget",
         WIDGET_URI,
         { mimeType: WIDGET_RESOURCE_MIME_TYPE },
         async () => {
+          if (!this._mcpClientInfo.mcpClient && !this._sessionUiDomainProvider) {
+            await this.loadPersistedSessionUiDomainProvider();
+          }
           const logContext = {
             mcpClient: this._mcpClientInfo.mcpClient,
             mcpClientVersion: this._mcpClientInfo.mcpClientVersion,

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -494,83 +494,73 @@ export class DoitMCPAgent extends McpAgent {
   }
 
   private registerWidgetResource() {
-    try {
-      const env = this.env as DoitWorkerEnv;
-      this.server.resource(
-        "cloud-intelligence-widget",
-        WIDGET_URI,
-        { mimeType: WIDGET_RESOURCE_MIME_TYPE },
-        async () => {
-          if (
-            !this._mcpClientInfo.mcpClient &&
-            !this._sessionUiDomainProvider
-          ) {
-            await this.loadPersistedSessionUiDomainProvider();
-          }
-          const logContext = {
-            mcpClient: this._mcpClientInfo.mcpClient,
-            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
-            sessionProvider: this._sessionUiDomainProvider,
-            hasWorkerUrl: Boolean(env.WORKER_URL),
-            hasPublicMcpUrl: Boolean(env.PUBLIC_MCP_URL),
-            hasClaudeUiDomain: Boolean(env.CLAUDE_UI_DOMAIN),
-            hasOpenAiUiDomain: Boolean(env.OPENAI_UI_DOMAIN),
+    const env = this.env as DoitWorkerEnv;
+    this.server.resource(
+      "cloud-intelligence-widget",
+      WIDGET_URI,
+      { mimeType: WIDGET_RESOURCE_MIME_TYPE },
+      async () => {
+        if (
+          !this._mcpClientInfo.mcpClient &&
+          !this._sessionUiDomainProvider
+        ) {
+          await this.loadPersistedSessionUiDomainProvider();
+        }
+        const logContext = {
+          mcpClient: this._mcpClientInfo.mcpClient,
+          mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+          sessionProvider: this._sessionUiDomainProvider,
+          hasWorkerUrl: Boolean(env.WORKER_URL),
+          hasPublicMcpUrl: Boolean(env.PUBLIC_MCP_URL),
+          hasClaudeUiDomain: Boolean(env.CLAUDE_UI_DOMAIN),
+          hasOpenAiUiDomain: Boolean(env.OPENAI_UI_DOMAIN),
+        };
+        let widgetFetchOrigin: string;
+        let publicMcpUrl: string;
+        try {
+          widgetFetchOrigin = resolveWidgetFetchOrigin(env);
+          publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
+        } catch (error) {
+          logWidgetResourceError(
+            "[widget] config resolution failed",
+            error,
+            logContext
+          );
+          return {
+            contents: [buildFallbackWidgetResourceContent(WIDGET_URI)],
           };
-          let widgetFetchOrigin: string;
-          let publicMcpUrl: string;
-          try {
-            widgetFetchOrigin = resolveWidgetFetchOrigin(env);
-            publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
-          } catch (error) {
-            logWidgetResourceError(
-              "[widget] config resolution failed",
-              error,
-              logContext
-            );
-            return {
-              contents: [buildFallbackWidgetResourceContent(WIDGET_URI)],
-            };
-          }
+        }
 
-          console.log("[widget] resources/read called for", WIDGET_URI, {
+        console.log("[widget] resources/read called for", WIDGET_URI, {
+          mcpClient: this._mcpClientInfo.mcpClient,
+          mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+          sessionProvider: this._sessionUiDomainProvider,
+          widgetFetchOrigin,
+          publicMcpUrl,
+        });
+        let resourceContent: WidgetResourceContent;
+        try {
+          resourceContent = await buildWidgetResourceContent({
+            widgetUri: WIDGET_URI,
             mcpClient: this._mcpClientInfo.mcpClient,
-            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
             sessionProvider: this._sessionUiDomainProvider,
             widgetFetchOrigin,
             publicMcpUrl,
+            env,
           });
-          let resourceContent: WidgetResourceContent;
-          try {
-            resourceContent = await buildWidgetResourceContent({
-              widgetUri: WIDGET_URI,
-              mcpClient: this._mcpClientInfo.mcpClient,
-              sessionProvider: this._sessionUiDomainProvider,
-              widgetFetchOrigin,
-              publicMcpUrl,
-              env,
-            });
-          } catch (error) {
-            logWidgetResourceError(
-              "[widget] resource content build failed",
-              error,
-              logContext
-            );
-            resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
-          }
-          return {
-            contents: [resourceContent],
-          };
+        } catch (error) {
+          logWidgetResourceError(
+            "[widget] resource content build failed",
+            error,
+            logContext
+          );
+          resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
         }
-      );
-    } catch (error) {
-      console.error(
-        "[widget] failed to register widget resource",
-        {
-          reason: getErrorMessage(error),
-        },
-        error
-      );
-    }
+        return {
+          contents: [resourceContent],
+        };
+      }
+    );
   }
 
   async init() {
@@ -794,7 +784,17 @@ export class DoitMCPAgent extends McpAgent {
       );
     }
 
-    this.registerWidgetResource();
+    try {
+      this.registerWidgetResource();
+    } catch (error) {
+      console.error(
+        "[widget] failed to register widget resource",
+        {
+          reason: getErrorMessage(error),
+        },
+        error
+      );
+    }
   }
 }
 

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -208,10 +208,12 @@ import { WIDGET_URI } from "./responseAdapter.js";
 import { promptsIncludingLegacyNames, resolvePromptMessages } from "../../src/prompts/index.js";
 import type { DoitWorkerEnv, UiDomainProvider } from "./runtimeEnv.js";
 import {
+  buildFallbackWidgetResourceContent,
   buildWidgetResourceContent,
   classifyUiDomainProvider,
   resolvePublicMcpUrl,
   resolveWidgetFetchOrigin,
+  type WidgetResourceContent,
   WIDGET_RESOURCE_MIME_TYPE,
 } from "./widgetResource.js";
 
@@ -229,6 +231,29 @@ const SSE_KEEP_ALIVE_MESSAGE = new TextEncoder().encode(
   `event: message\ndata: ${JSON.stringify(MCP_NOTIFICATIONS_PING)}\n\n`
 );
 const SESSION_UI_DOMAIN_PROVIDER_KEY = "sessionUiDomainProvider";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function logWidgetResourceError(
+  message: string,
+  error: unknown,
+  context: {
+    mcpClient?: string;
+    mcpClientVersion?: string;
+    sessionProvider?: UiDomainProvider;
+    hasWorkerUrl: boolean;
+    hasPublicMcpUrl: boolean;
+    hasClaudeUiDomain: boolean;
+    hasOpenAiUiDomain: boolean;
+  }
+) {
+  console.error(message, {
+    reason: getErrorMessage(error),
+    ...context,
+  });
+}
 
 // Context Storage Durable Object
 export class ContextStorage extends DurableObject {
@@ -346,6 +371,16 @@ export class DoitMCPAgent extends McpAgent {
     }
 
     return undefined;
+  }
+
+  private async loadPersistedSessionUiDomainProviderSafely(): Promise<void> {
+    try {
+      await this.loadPersistedSessionUiDomainProvider();
+    } catch (error) {
+      console.error("[widget] failed to load persisted UI domain provider", {
+        reason: getErrorMessage(error),
+      });
+    }
   }
 
   // Generic callback factory for tools
@@ -466,12 +501,10 @@ export class DoitMCPAgent extends McpAgent {
       });
     };
 
-    // Load persisted session state first so widget resource reads can still resolve a
-    // provider after DO hibernation, even before oninitialized runs again.
-    await Promise.all([
-      this.loadPersistedProps(),
-      this.loadPersistedSessionUiDomainProvider(),
-    ]);
+    // Customer context predates widget support and is needed by tool callbacks.
+    await this.loadPersistedProps();
+    // Widget-only state should never block MCP initialization or tool discovery.
+    void this.loadPersistedSessionUiDomainProviderSafely();
 
     console.log("After loading persisted props:", {
       hasCustomerContext: Boolean(this.props.customerContext),
@@ -495,38 +528,6 @@ export class DoitMCPAgent extends McpAgent {
         })),
       }));
     });
-
-    // Register the widget as an MCP resource so ChatGPT can load it in the iframe.
-    // The resource returns a tiny loader stub (~600 B) that fetches the real widget
-    // HTML from GET /widget on every render. This means widget updates never require
-    // ChatGPT app re-registration — only the served HTML at /widget changes.
-    const env = this.env as DoitWorkerEnv;
-    const widgetFetchOrigin = resolveWidgetFetchOrigin(env);
-    const publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
-    this.server.resource(
-      "cloud-intelligence-widget",
-      WIDGET_URI,
-      { mimeType: WIDGET_RESOURCE_MIME_TYPE },
-      async () => {
-        console.log("[widget] resources/read called for", WIDGET_URI, {
-          mcpClient: this._mcpClientInfo.mcpClient,
-          mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
-          sessionProvider: this._sessionUiDomainProvider,
-          publicMcpUrl,
-        });
-        const resourceContent = await buildWidgetResourceContent({
-          widgetUri: WIDGET_URI,
-          mcpClient: this._mcpClientInfo.mcpClient,
-          sessionProvider: this._sessionUiDomainProvider,
-          widgetFetchOrigin,
-          publicMcpUrl,
-          env,
-        });
-        return {
-          contents: [resourceContent as any],
-        };
-      }
-    );
 
     // Cloud Overview tool
     this.registerTool(cloudOverviewTool, CloudOverviewArgumentsSchema);
@@ -665,6 +666,76 @@ export class DoitMCPAgent extends McpAgent {
         },
         this.createChangeCustomerCallback()
       );
+    }
+
+    // Register the widget as an MCP resource after tools so widget failures
+    // cannot prevent tool discovery.
+    const env = this.env as DoitWorkerEnv;
+    try {
+      this.server.resource(
+        "cloud-intelligence-widget",
+        WIDGET_URI,
+        { mimeType: WIDGET_RESOURCE_MIME_TYPE },
+        async () => {
+          const logContext = {
+            mcpClient: this._mcpClientInfo.mcpClient,
+            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+            sessionProvider: this._sessionUiDomainProvider,
+            hasWorkerUrl: Boolean(env.WORKER_URL),
+            hasPublicMcpUrl: Boolean(env.PUBLIC_MCP_URL),
+            hasClaudeUiDomain: Boolean(env.CLAUDE_UI_DOMAIN),
+            hasOpenAiUiDomain: Boolean(env.OPENAI_UI_DOMAIN),
+          };
+          let widgetFetchOrigin: string;
+          let publicMcpUrl: string;
+          try {
+            widgetFetchOrigin = resolveWidgetFetchOrigin(env);
+            publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
+          } catch (error) {
+            logWidgetResourceError(
+              "[widget] config resolution failed",
+              error,
+              logContext
+            );
+            return {
+              contents: [buildFallbackWidgetResourceContent(WIDGET_URI) as any],
+            };
+          }
+
+          console.log("[widget] resources/read called for", WIDGET_URI, {
+            mcpClient: this._mcpClientInfo.mcpClient,
+            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+            sessionProvider: this._sessionUiDomainProvider,
+            widgetFetchOrigin,
+            publicMcpUrl,
+          });
+          let resourceContent: WidgetResourceContent;
+          try {
+            resourceContent = await buildWidgetResourceContent({
+              widgetUri: WIDGET_URI,
+              mcpClient: this._mcpClientInfo.mcpClient,
+              sessionProvider: this._sessionUiDomainProvider,
+              widgetFetchOrigin,
+              publicMcpUrl,
+              env,
+            });
+          } catch (error) {
+            logWidgetResourceError(
+              "[widget] resource content build failed",
+              error,
+              logContext
+            );
+            resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
+          }
+          return {
+            contents: [resourceContent as any],
+          };
+        }
+      );
+    } catch (error) {
+      console.error("[widget] failed to register widget resource", {
+        reason: getErrorMessage(error),
+      });
     }
   }
 }

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -381,11 +381,11 @@ export class DoitMCPAgent extends McpAgent {
   private async loadPersistedSessionUiDomainProvider(): Promise<
     UiDomainProvider | undefined
   > {
-    this._didAttemptLoadSessionUiDomainProvider = true;
     try {
       const provider = await this.ctx.storage.get<UiDomainProvider>(
         SESSION_UI_DOMAIN_PROVIDER_KEY
       );
+      this._didAttemptLoadSessionUiDomainProvider = true;
 
       if (provider === "claude" || provider === "openai") {
         this._sessionUiDomainProvider = provider;

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -533,7 +533,7 @@ export class DoitMCPAgent extends McpAgent {
             resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
           }
           return {
-            contents: [resourceContent as any],
+            contents: [resourceContent],
           };
         }
       );

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -236,6 +236,17 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function logMcpInitStorageError(
+  message: string,
+  error: unknown,
+  props: Record<string, unknown>
+) {
+  console.error(message, {
+    reason: getErrorMessage(error),
+    hasApiKey: Boolean(props.apiKey),
+  });
+}
+
 function logWidgetResourceError(
   message: string,
   error: unknown,
@@ -361,26 +372,22 @@ export class DoitMCPAgent extends McpAgent {
   private async loadPersistedSessionUiDomainProvider(): Promise<
     UiDomainProvider | undefined
   > {
-    const provider = await this.ctx.storage.get<UiDomainProvider>(
-      SESSION_UI_DOMAIN_PROVIDER_KEY
-    );
-
-    if (provider === "claude" || provider === "openai") {
-      this._sessionUiDomainProvider = provider;
-      return provider;
-    }
-
-    return undefined;
-  }
-
-  private async loadPersistedSessionUiDomainProviderSafely(): Promise<void> {
     try {
-      await this.loadPersistedSessionUiDomainProvider();
+      const provider = await this.ctx.storage.get<UiDomainProvider>(
+        SESSION_UI_DOMAIN_PROVIDER_KEY
+      );
+
+      if (provider === "claude" || provider === "openai") {
+        this._sessionUiDomainProvider = provider;
+        return provider;
+      }
     } catch (error) {
       console.error("[widget] failed to load persisted UI domain provider", {
         reason: getErrorMessage(error),
       });
     }
+
+    return undefined;
   }
 
   // Generic callback factory for tools
@@ -462,6 +469,77 @@ export class DoitMCPAgent extends McpAgent {
     );
   }
 
+  private registerWidgetResource() {
+    try {
+      void this.loadPersistedSessionUiDomainProvider();
+      const env = this.env as DoitWorkerEnv;
+      this.server.resource(
+        "cloud-intelligence-widget",
+        WIDGET_URI,
+        { mimeType: WIDGET_RESOURCE_MIME_TYPE },
+        async () => {
+          const logContext = {
+            mcpClient: this._mcpClientInfo.mcpClient,
+            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+            sessionProvider: this._sessionUiDomainProvider,
+            hasWorkerUrl: Boolean(env.WORKER_URL),
+            hasPublicMcpUrl: Boolean(env.PUBLIC_MCP_URL),
+            hasClaudeUiDomain: Boolean(env.CLAUDE_UI_DOMAIN),
+            hasOpenAiUiDomain: Boolean(env.OPENAI_UI_DOMAIN),
+          };
+          let widgetFetchOrigin: string;
+          let publicMcpUrl: string;
+          try {
+            widgetFetchOrigin = resolveWidgetFetchOrigin(env);
+            publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
+          } catch (error) {
+            logWidgetResourceError(
+              "[widget] config resolution failed",
+              error,
+              logContext
+            );
+            return {
+              contents: [buildFallbackWidgetResourceContent(WIDGET_URI) as any],
+            };
+          }
+
+          console.log("[widget] resources/read called for", WIDGET_URI, {
+            mcpClient: this._mcpClientInfo.mcpClient,
+            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
+            sessionProvider: this._sessionUiDomainProvider,
+            widgetFetchOrigin,
+            publicMcpUrl,
+          });
+          let resourceContent: WidgetResourceContent;
+          try {
+            resourceContent = await buildWidgetResourceContent({
+              widgetUri: WIDGET_URI,
+              mcpClient: this._mcpClientInfo.mcpClient,
+              sessionProvider: this._sessionUiDomainProvider,
+              widgetFetchOrigin,
+              publicMcpUrl,
+              env,
+            });
+          } catch (error) {
+            logWidgetResourceError(
+              "[widget] resource content build failed",
+              error,
+              logContext
+            );
+            resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
+          }
+          return {
+            contents: [resourceContent as any],
+          };
+        }
+      );
+    } catch (error) {
+      console.error("[widget] failed to register widget resource", {
+        reason: getErrorMessage(error),
+      });
+    }
+  }
+
   async init() {
     // Guard: this.props may be undefined on the very first connection because
     // McpAgent.onStart() calls _init(stored_props) → init() BEFORE the Worker-side
@@ -501,10 +579,17 @@ export class DoitMCPAgent extends McpAgent {
       });
     };
 
+    // Swallow transient DO storage errors so init never aborts; tools fall back to in-memory props.
     // Customer context predates widget support and is needed by tool callbacks.
-    await this.loadPersistedProps();
-    // Widget-only state should never block MCP initialization or tool discovery.
-    void this.loadPersistedSessionUiDomainProviderSafely();
+    try {
+      await this.loadPersistedProps();
+    } catch (error) {
+      logMcpInitStorageError(
+        "[mcp] failed to load persisted customer context",
+        error,
+        this.props
+      );
+    }
 
     console.log("After loading persisted props:", {
       hasCustomerContext: Boolean(this.props.customerContext),
@@ -513,7 +598,15 @@ export class DoitMCPAgent extends McpAgent {
 
     // Save current props if they exist (for initial OAuth setup)
     if (this.props.apiKey && this.props.customerContext) {
-      await this.saveProps();
+      try {
+        await this.saveProps();
+      } catch (error) {
+        logMcpInitStorageError(
+          "[mcp] failed to save persisted customer context",
+          error,
+          this.props
+        );
+      }
     }
 
     // Register prompts
@@ -668,75 +761,7 @@ export class DoitMCPAgent extends McpAgent {
       );
     }
 
-    // Register the widget as an MCP resource after tools so widget failures
-    // cannot prevent tool discovery.
-    const env = this.env as DoitWorkerEnv;
-    try {
-      this.server.resource(
-        "cloud-intelligence-widget",
-        WIDGET_URI,
-        { mimeType: WIDGET_RESOURCE_MIME_TYPE },
-        async () => {
-          const logContext = {
-            mcpClient: this._mcpClientInfo.mcpClient,
-            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
-            sessionProvider: this._sessionUiDomainProvider,
-            hasWorkerUrl: Boolean(env.WORKER_URL),
-            hasPublicMcpUrl: Boolean(env.PUBLIC_MCP_URL),
-            hasClaudeUiDomain: Boolean(env.CLAUDE_UI_DOMAIN),
-            hasOpenAiUiDomain: Boolean(env.OPENAI_UI_DOMAIN),
-          };
-          let widgetFetchOrigin: string;
-          let publicMcpUrl: string;
-          try {
-            widgetFetchOrigin = resolveWidgetFetchOrigin(env);
-            publicMcpUrl = resolvePublicMcpUrl(env, widgetFetchOrigin);
-          } catch (error) {
-            logWidgetResourceError(
-              "[widget] config resolution failed",
-              error,
-              logContext
-            );
-            return {
-              contents: [buildFallbackWidgetResourceContent(WIDGET_URI) as any],
-            };
-          }
-
-          console.log("[widget] resources/read called for", WIDGET_URI, {
-            mcpClient: this._mcpClientInfo.mcpClient,
-            mcpClientVersion: this._mcpClientInfo.mcpClientVersion,
-            sessionProvider: this._sessionUiDomainProvider,
-            widgetFetchOrigin,
-            publicMcpUrl,
-          });
-          let resourceContent: WidgetResourceContent;
-          try {
-            resourceContent = await buildWidgetResourceContent({
-              widgetUri: WIDGET_URI,
-              mcpClient: this._mcpClientInfo.mcpClient,
-              sessionProvider: this._sessionUiDomainProvider,
-              widgetFetchOrigin,
-              publicMcpUrl,
-              env,
-            });
-          } catch (error) {
-            logWidgetResourceError(
-              "[widget] resource content build failed",
-              error,
-              logContext
-            );
-            resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
-          }
-          return {
-            contents: [resourceContent as any],
-          };
-        }
-      );
-    } catch (error) {
-      console.error("[widget] failed to register widget resource", {
-        reason: getErrorMessage(error),
-      });
-    }
+    this.registerWidgetResource();
   }
 }
 

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -260,10 +260,14 @@ function logWidgetResourceError(
     hasOpenAiUiDomain: boolean;
   }
 ) {
-  console.error(message, {
-    reason: getErrorMessage(error),
-    ...context,
-  });
+  console.error(
+    message,
+    {
+      reason: getErrorMessage(error),
+      ...context,
+    },
+    error
+  );
 }
 
 // Context Storage Durable Object

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -318,6 +318,7 @@ export class DoitMCPAgent extends McpAgent {
   // so there is no cross-session bleed between DO instances sharing the same isolate.
   private _mcpClientInfo: TrackingContext = {};
   private _sessionUiDomainProvider?: UiDomainProvider;
+  private _didAttemptLoadSessionUiDomainProvider = false;
 
   // Per-instance approval store for the two-phase destructive-tool commit flow.
   // Backed by `this.ctx.storage` (DurableObject storage) so that a staged action
@@ -380,6 +381,7 @@ export class DoitMCPAgent extends McpAgent {
   private async loadPersistedSessionUiDomainProvider(): Promise<
     UiDomainProvider | undefined
   > {
+    this._didAttemptLoadSessionUiDomainProvider = true;
     try {
       const provider = await this.ctx.storage.get<UiDomainProvider>(
         SESSION_UI_DOMAIN_PROVIDER_KEY
@@ -489,7 +491,11 @@ export class DoitMCPAgent extends McpAgent {
         WIDGET_URI,
         { mimeType: WIDGET_RESOURCE_MIME_TYPE },
         async () => {
-          if (!this._mcpClientInfo.mcpClient && !this._sessionUiDomainProvider) {
+          if (
+            !this._mcpClientInfo.mcpClient &&
+            !this._sessionUiDomainProvider &&
+            !this._didAttemptLoadSessionUiDomainProvider
+          ) {
             await this.loadPersistedSessionUiDomainProvider();
           }
           const logContext = {

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -503,7 +503,7 @@ export class DoitMCPAgent extends McpAgent {
               logContext
             );
             return {
-              contents: [buildFallbackWidgetResourceContent(WIDGET_URI) as any],
+              contents: [buildFallbackWidgetResourceContent(WIDGET_URI)],
             };
           }
 

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -554,9 +554,13 @@ export class DoitMCPAgent extends McpAgent {
         }
       );
     } catch (error) {
-      console.error("[widget] failed to register widget resource", {
-        reason: getErrorMessage(error),
-      });
+      console.error(
+        "[widget] failed to register widget resource",
+        {
+          reason: getErrorMessage(error),
+        },
+        error
+      );
     }
   }
 

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -33,6 +33,13 @@ export interface BuildWidgetResourceContentArgs extends ResolveUiDomainArgs {
   widgetUri: string;
 }
 
+export interface WidgetResourceContent {
+  uri: string;
+  mimeType: string;
+  text: string;
+  _meta: Record<string, unknown>;
+}
+
 export function resolveWidgetFetchOrigin(
   env: Pick<RuntimeEnvVars, "WORKER_URL">
 ): string {
@@ -222,14 +229,35 @@ export function buildWidgetConnectDomains(
   );
 }
 
+export function buildFallbackWidgetResourceContent(
+  widgetUri: string
+): WidgetResourceContent {
+  return {
+    uri: widgetUri,
+    mimeType: WIDGET_RESOURCE_MIME_TYPE,
+    text: `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+<p style="padding:16px;color:#888;font-size:0.8125rem;font-family:system-ui,sans-serif">
+Widget unavailable — MCP tools are still available.
+</p>
+</body>
+</html>`,
+    _meta: {
+      ui: {
+        // Intentionally omit ui.domain so strict clients cannot reject the fallback.
+        csp: {
+          connectDomains: ["https://api.doit.com", "https://mcp.doit.com"],
+        },
+      },
+    },
+  };
+}
+
 export async function buildWidgetResourceContent(
   args: BuildWidgetResourceContentArgs
-): Promise<{
-  uri: string;
-  mimeType: string;
-  text: string;
-  _meta: Record<string, unknown>;
-}> {
+): Promise<WidgetResourceContent> {
   const { provider, uiDomain } = await resolveUiDomain(args);
 
   const uiMeta: {

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -251,7 +251,7 @@ Widget unavailable — MCP tools are still available.
       ui: {
         // Intentionally omit ui.domain so strict clients cannot reject the fallback.
         csp: {
-          connectDomains: DEFAULT_WIDGET_CONNECT_DOMAINS,
+          connectDomains: [...DEFAULT_WIDGET_CONNECT_DOMAINS],
         },
       },
     },

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -2,6 +2,10 @@ import type { RuntimeEnvVars, UiDomainProvider } from "./runtimeEnv.js";
 
 export const DEFAULT_WIDGET_FETCH_ORIGIN = "https://mcp.doit.com";
 export const WIDGET_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+const DEFAULT_WIDGET_CONNECT_DOMAINS = [
+  "https://api.doit.com",
+  "https://mcp.doit.com",
+];
 type WebCryptoApi = (typeof import("node:crypto"))["webcrypto"];
 
 function requireAbsoluteUrl(
@@ -221,8 +225,7 @@ export function buildWidgetConnectDomains(
 ): string[] {
   return Array.from(
     new Set([
-      "https://api.doit.com",
-      "https://mcp.doit.com",
+      ...DEFAULT_WIDGET_CONNECT_DOMAINS,
       toOrigin(widgetFetchOrigin),
       ...(publicMcpUrl ? [toOrigin(publicMcpUrl)] : []),
     ])
@@ -248,7 +251,7 @@ Widget unavailable — MCP tools are still available.
       ui: {
         // Intentionally omit ui.domain so strict clients cannot reject the fallback.
         csp: {
-          connectDomains: ["https://api.doit.com", "https://mcp.doit.com"],
+          connectDomains: DEFAULT_WIDGET_CONNECT_DOMAINS,
         },
       },
     },

--- a/doit-mcp-server/src/widgetResource.ts
+++ b/doit-mcp-server/src/widgetResource.ts
@@ -4,7 +4,7 @@ export const DEFAULT_WIDGET_FETCH_ORIGIN = "https://mcp.doit.com";
 export const WIDGET_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 const DEFAULT_WIDGET_CONNECT_DOMAINS = [
   "https://api.doit.com",
-  "https://mcp.doit.com",
+  DEFAULT_WIDGET_FETCH_ORIGIN,
 ];
 type WebCryptoApi = (typeof import("node:crypto"))["webcrypto"];
 

--- a/src/utils/__tests__/widgetResource.test.ts
+++ b/src/utils/__tests__/widgetResource.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { WIDGET_URI } from "../../../doit-mcp-server/src/responseAdapter.js";
 import {
+    buildFallbackWidgetResourceContent,
     buildWidgetResourceContent,
     buildWidgetStub,
     classifyUiDomainProvider,
@@ -146,6 +147,23 @@ describe("resolveUiDomain", () => {
 });
 
 describe("widget resource contract", () => {
+    it("builds a safe fallback resource without ui.domain", () => {
+        const content = buildFallbackWidgetResourceContent(WIDGET_URI);
+        const meta = content._meta as {
+            ui: { domain?: string; csp: { connectDomains: string[] } };
+            "openai/widgetDomain"?: string;
+        };
+
+        expect(content.uri).toBe(WIDGET_URI);
+        expect(content.mimeType).toBe("text/html;profile=mcp-app");
+        expect(content.text).toContain("MCP tools are still available");
+        expect(meta.ui).not.toHaveProperty("domain");
+        expect(meta).not.toHaveProperty("openai/widgetDomain");
+        expect(meta.ui.csp.connectDomains).toEqual(
+            expect.arrayContaining(["https://api.doit.com", "https://mcp.doit.com"])
+        );
+    });
+
     it("keeps the widget stub pointed at the real widget fetch origin", () => {
         expect(buildWidgetStub("https://widgets.example.com")).toContain('"https://widgets.example.com/widget"');
     });


### PR DESCRIPTION
# Fix MCP tool loading resilience around widget resource setup

## Summary
- Register all MCP tools before optional widget resource setup so widget failures cannot block `tools/list`.
- Make widget resource generation defensive by falling back to a minimal safe response when widget config or `ui.domain` resolution fails.
- Move widget-only UI-domain provider reads off the awaited init path and guard widget resource setup with richer error logging.
- Guard init-time persisted customer-context load/save failures so transient Durable Object storage issues do not prevent tool registration.

## Test plan
- Ran `yarn type-check` in `doit-mcp-server/doit-mcp-server`.
- Ran focused widget resource tests: `yarn vitest run src/utils/__tests__/widgetResource.test.ts`.
- Checked edited file lints and whitespace with `git diff --check`.

## Commits
- Introduced error logging for widget resource loading and registration, improving visibility into failures.
- Added a fallback widget resource content function to provide a safe response when the primary resource cannot be built.
- Updated DoitMCPAgent to handle widget resource registration more robustly, ensuring tool discovery is not blocked by widget errors.
- Enhanced tests to verify the behavior of the new fallback content and error handling mechanisms.

These changes improve the reliability and user experience of the widget resource management in the MCP server.