### PR TITLE
fix: install Worker dependencies before deploy

### DIFF
--- a/doit-mcp-server/package.json
+++ b/doit-mcp-server/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.0.5",
-    "@modelcontextprotocol/sdk": "^1.27.0",
+    "@modelcontextprotocol/sdk": "^1.28.1",
     "agents": "^0.0.95",
     "hono": "4.12.7",
     "zod": "^3.25.67"

--- a/doit-mcp-server/package.json
+++ b/doit-mcp-server/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.0.5",
-    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@modelcontextprotocol/sdk": "^1.27.0",
     "agents": "^0.0.95",
     "hono": "4.12.7",
     "zod": "^3.25.67"

--- a/doit-mcp-server/package.json
+++ b/doit-mcp-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.0",
   "private": true,
   "scripts": {
-    "deploy": "wrangler deploy",
+    "deploy": "yarn install --frozen-lockfile && wrangler deploy",
     "dev": "wrangler dev",
     "format": "biome format --write",
     "lint:fix": "biome lint --fix",

--- a/doit-mcp-server/package.json
+++ b/doit-mcp-server/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.0.5",
-    "@modelcontextprotocol/sdk": "^1.28.1",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "agents": "^0.0.95",
     "hono": "4.12.7",
     "zod": "^3.25.67"

--- a/doit-mcp-server/package.json
+++ b/doit-mcp-server/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.0.5",
-    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@modelcontextprotocol/sdk": "^1.28.1",
     "agents": "^0.0.95",
     "hono": "4.12.7",
     "zod": "^3.25.67"


### PR DESCRIPTION
## Summary

Updates the Cloudflare Worker deploy script to run `yarn install --frozen-lockfile` before `wrangler deploy`.

This ensures manual deploys use the committed Worker lockfile and fail if `package.json` and `yarn.lock` are out of sync, instead of deploying with stale `node_modules`.

## Context

The MCP tools loading issue was fixed after refreshing dependencies on the deploy machine. This change makes that step part of the Worker deploy command so future manual deploys are less likely to ship a stale dependency tree.

## Test plan

- Verified the Worker deploy script points to `yarn install --frozen-lockfile && wrangler deploy`.
- No runtime code changes.