### PR TITLE
hide approval token from user

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,50 @@ This MCP server provides many tools including the following:
 - [`assign_objects_to_label`](https://developer.doit.com/reference/assignobjectstolabel): Assigns or unassigns objects to a label
 
 
+## Confirmation prompts for write-gated tools
+
+A small set of state-changing tools (currently `create_ticket`) goes through a two-phase
+approval flow: the first call stages the request and returns a human-readable summary
+("Are you sure you want to create the support ticket with the above details?") which the
+assistant displays in chat. The actual write only happens after you confirm and the
+assistant calls `confirm_action`.
+
+On top of that in-chat confirmation, your MCP client may show its own permission dialog
+before each tool call. This is **purely client-side gating**.
+If you want the in-chat summary to be the only confirmation step, allowlist the two
+tools below in your client:
+
+### Claude Code
+
+Add to `~/.claude/settings.json` (or your project's `.claude/settings.json`):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__doit_mcp_server__create_ticket",
+      "mcp__doit_mcp_server__confirm_action"
+    ]
+  }
+}
+```
+
+Both entries are needed — without `confirm_action`, Claude Code will still prompt at the
+commit step.
+
+### Cursor
+
+When Cursor shows the "Run *create_ticket*" prompt, open the **Ask Every Time** dropdown
+and switch it to **Auto-run**. Cursor remembers the choice per tool. Do the same for
+`confirm_action` the first time it's invoked.
+
+### Claude Desktop App
+
+When the in-app permission dialog appears, tick **Always allow** for `create_ticket` and
+`confirm_action`. There is no JSON file to edit — Claude Desktop stores the choice
+internally.
+
+
 ## Usage Examples
 
 Here are some common queries you can ask using the DoiT MCP server:

--- a/doit-mcp-server/src/durableObjectApprovalStore.ts
+++ b/doit-mcp-server/src/durableObjectApprovalStore.ts
@@ -7,32 +7,34 @@ import type { ApprovalStore, PendingAction } from "../../src/utils/approval.js";
  * `DurableObjectStorage`, which is only available inside Worker runtime. The stdio
  * build uses `MemoryApprovalStore` from `src/utils/approval.ts`.
  *
- * Pending actions are persisted under keys of the form `pending:${token}` so the DO
- * isolate can be evicted between the destructive tool call and the matching
- * `confirm_action` without losing the staged action. TTL is enforced at `consume`
- * time — we do not schedule alarms.
+ * Pending actions are persisted under keys of the form `pending:${userKey}` (one per
+ * user) so the DO isolate can be evicted between the destructive tool call and the
+ * matching `confirm_action` without losing the staged action. TTL is enforced at
+ * `consume` time — we do not schedule alarms.
  */
 export class DurableObjectApprovalStore implements ApprovalStore {
     private static readonly KEY_PREFIX = "pending:";
 
     constructor(private readonly storage: DurableObjectStorage) {}
 
-    async stash(token: string, pending: PendingAction): Promise<void> {
-        await this.storage.put(this.key(token), pending);
+    async stash(pending: PendingAction): Promise<void> {
+        // One pending action per userKey: `put` naturally overwrites any prior staged
+        // action for the same user, matching MemoryApprovalStore semantics.
+        await this.storage.put(this.key(pending.userKey), pending);
     }
 
-    async consume(token: string, userKey: string): Promise<PendingAction | null> {
-        const k = this.key(token);
+    async consume(userKey: string): Promise<PendingAction | null> {
+        const k = this.key(userKey);
         const p = await this.storage.get<PendingAction>(k);
         if (!p) return null;
-        // Single-use: evict on every successful lookup regardless of match/expiry so a
-        // leaked token cannot be retried and an expired token does not linger.
+        // Single-use: evict on every lookup regardless of expiry so an expired
+        // entry does not linger across isolate restarts.
         await this.storage.delete(k);
-        if (p.userKey !== userKey || p.expiresAt < Date.now()) return null;
+        if (p.expiresAt < Date.now()) return null;
         return p;
     }
 
-    private key(token: string): string {
-        return `${DurableObjectApprovalStore.KEY_PREFIX}${token}`;
+    private key(userKey: string): string {
+        return `${DurableObjectApprovalStore.KEY_PREFIX}${userKey}`;
     }
 }

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -828,7 +828,9 @@ describe("CallToolRequestSchema handler", () => {
         if (WRITE_GATED_TOOL_NAMES.has(toolName)) {
             const envelope = JSON.parse(first.content[0].text);
             expect(envelope.status).toBe("approval_required");
-            await getCallToolHandler()(mockRequest("confirm_action", { token: envelope.approvalToken }));
+            // confirm_action takes no arguments — the server resolves the pending
+            // action from the caller's userKey. See src/utils/approval.ts.
+            await getCallToolHandler()(mockRequest("confirm_action", {}));
         }
         expect(handler).toHaveBeenCalledWith(args, "fake-token");
     });

--- a/src/tools/__tests__/confirmAction.test.ts
+++ b/src/tools/__tests__/confirmAction.test.ts
@@ -16,8 +16,8 @@ describe("handleConfirmActionRequest", () => {
     const userKey = "stdio-local";
     const apiToken = "fake-api-token";
 
-    async function stash(store: MemoryApprovalStore, token: string) {
-        await store.stash(token, {
+    async function stash(store: MemoryApprovalStore) {
+        await store.stash({
             toolName: "create_ticket",
             args: { ticket: { subject: "demo", severity: "high" } },
             userKey,
@@ -27,10 +27,10 @@ describe("handleConfirmActionRequest", () => {
 
     it("happy path: calls runOriginal with the stashed tool + args, returns its result", async () => {
         const store = new MemoryApprovalStore();
-        await stash(store, "tok-happy");
+        await stash(store);
         const runOriginal = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
 
-        const result = await handleConfirmActionRequest({ token: "tok-happy" }, apiToken, userKey, store, runOriginal);
+        const result = await handleConfirmActionRequest({}, apiToken, userKey, store, runOriginal);
 
         expect(runOriginal).toHaveBeenCalledWith(
             "create_ticket",
@@ -40,74 +40,71 @@ describe("handleConfirmActionRequest", () => {
         expect(result).toEqual({ content: [{ type: "text", text: "ok" }] });
     });
 
-    it("returns an error without running the tool when the token is unknown", async () => {
+    it("returns an error without running the tool when there is no pending action for the user", async () => {
         const store = new MemoryApprovalStore();
         const runOriginal = vi.fn();
 
+        const result = await handleConfirmActionRequest({}, apiToken, userKey, store, runOriginal);
+
+        expect(runOriginal).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("No pending action to confirm");
+    });
+
+    it("returns an error without running the tool when the pending action has expired", async () => {
+        const store = new MemoryApprovalStore();
+        await stash(store);
+        const runOriginal = vi.fn();
+
+        vi.advanceTimersByTime(APPROVAL_TTL_MS + 1);
+
+        const result = await handleConfirmActionRequest({}, apiToken, userKey, store, runOriginal);
+
+        expect(runOriginal).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+    });
+
+    it("returns nothing-pending error when a DIFFERENT user calls confirm_action", async () => {
+        const store = new MemoryApprovalStore();
+        await stash(store); // staged for `stdio-local`
+        const runOriginal = vi.fn();
+
+        const result = await handleConfirmActionRequest({}, apiToken, "different-user", store, runOriginal);
+
+        expect(runOriginal).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+    });
+
+    it("is single-use: a second confirm_action for the same user is rejected", async () => {
+        const store = new MemoryApprovalStore();
+        await stash(store);
+        const runOriginal = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+
+        await handleConfirmActionRequest({}, apiToken, userKey, store, runOriginal);
+        const retry = await handleConfirmActionRequest({}, apiToken, userKey, store, runOriginal);
+
+        expect(runOriginal).toHaveBeenCalledTimes(1);
+        expect(retry.isError).toBe(true);
+    });
+
+    it("rejects args that include unexpected fields (the schema is strict) and never touches the store", async () => {
+        const store = new MemoryApprovalStore();
+        await stash(store);
+        const consumeSpy = vi.spyOn(store, "consume");
+        const runOriginal = vi.fn();
+
+        // Defends against LLMs that pass a leftover `token` field from the prior contract.
         const result = await handleConfirmActionRequest(
-            { token: "does-not-exist" },
+            { token: "00000000-0000-0000-0000-000000000000" },
             apiToken,
             userKey,
             store,
             runOriginal
         );
 
+        expect(consumeSpy).not.toHaveBeenCalled();
         expect(runOriginal).not.toHaveBeenCalled();
         expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain("unknown or expired");
-    });
-
-    it("returns an error without running the tool when the token has expired", async () => {
-        const store = new MemoryApprovalStore();
-        await stash(store, "tok-stale");
-        const runOriginal = vi.fn();
-
-        vi.advanceTimersByTime(APPROVAL_TTL_MS + 1);
-
-        const result = await handleConfirmActionRequest({ token: "tok-stale" }, apiToken, userKey, store, runOriginal);
-
-        expect(runOriginal).not.toHaveBeenCalled();
-        expect(result.isError).toBe(true);
-    });
-
-    it("returns an error without running the tool when the userKey does not match", async () => {
-        const store = new MemoryApprovalStore();
-        await stash(store, "tok-mismatch");
-        const runOriginal = vi.fn();
-
-        const result = await handleConfirmActionRequest(
-            { token: "tok-mismatch" },
-            apiToken,
-            "different-user",
-            store,
-            runOriginal
-        );
-
-        expect(runOriginal).not.toHaveBeenCalled();
-        expect(result.isError).toBe(true);
-    });
-
-    it("is single-use: a second confirm_action with the same token is rejected", async () => {
-        const store = new MemoryApprovalStore();
-        await stash(store, "tok-reused");
-        const runOriginal = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
-
-        await handleConfirmActionRequest({ token: "tok-reused" }, apiToken, userKey, store, runOriginal);
-        const retry = await handleConfirmActionRequest({ token: "tok-reused" }, apiToken, userKey, store, runOriginal);
-
-        expect(runOriginal).toHaveBeenCalledTimes(1);
-        expect(retry.isError).toBe(true);
-    });
-
-    it("rejects args without a token and never touches the store", async () => {
-        const store = new MemoryApprovalStore();
-        const stashSpy = vi.spyOn(store, "consume");
-        const runOriginal = vi.fn();
-
-        const result = await handleConfirmActionRequest({}, apiToken, userKey, store, runOriginal);
-
-        expect(stashSpy).not.toHaveBeenCalled();
-        expect(runOriginal).not.toHaveBeenCalled();
-        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("no arguments");
     });
 });

--- a/src/tools/confirmAction.ts
+++ b/src/tools/confirmAction.ts
@@ -71,9 +71,7 @@ export async function handleConfirmActionRequest(
         return await runOriginal(pending.toolName, pending.args, apiToken);
     } catch (error) {
         if (error instanceof z.ZodError) {
-            return createErrorResponse(
-                "confirm_action takes no arguments. Call it with an empty arguments object."
-            );
+            return createErrorResponse("confirm_action takes no arguments. Call it with an empty arguments object.");
         }
         return handleGeneralError(error, "handling confirm_action request");
     }

--- a/src/tools/confirmAction.ts
+++ b/src/tools/confirmAction.ts
@@ -1,16 +1,14 @@
 import { z } from "zod";
 import type { ApprovalStore } from "../utils/approval.js";
 import { zodToMcpInputSchema } from "../utils/schemaHelpers.js";
-import { createErrorResponse, formatZodError, handleGeneralError } from "../utils/util.js";
+import { createErrorResponse, handleGeneralError } from "../utils/util.js";
 
-export const ConfirmActionArgumentsSchema = z.object({
-    token: z
-        .string()
-        .min(1, "token is required and cannot be empty.")
-        .describe(
-            "The approval token returned by a previous write/mutating tool call. Exactly as received, no quoting changes."
-        ),
-});
+/**
+ * `confirm_action` takes no arguments — the server resolves the pending action from
+ * the caller's `userKey`. We still parse with Zod so additional/unexpected fields
+ * are surfaced loudly rather than silently ignored (`.strict()`).
+ */
+export const ConfirmActionArgumentsSchema = z.object({}).strict();
 
 /**
  * The "gate" tool. This itself is annotated `destructiveHint: false` because, per the MCP
@@ -22,16 +20,19 @@ export const ConfirmActionArgumentsSchema = z.object({
  * annotation-honoring clients to prompt a second time on top of that summary, which is a
  * confusing UX.
  *
- * This tool should never be called without a prior write-action staging call.
+ * This tool should never be called without a prior write-action staging call. It takes
+ * no arguments: the server looks up the pending action by the caller's identity so the
+ * client never has to surface an internal approval id to the end user (the previous
+ * design exposed a UUID in MCP client permission dialogs).
  */
 export const confirmActionTool = {
     name: "confirm_action",
     description:
-        "Finalizes a pending write action (e.g. creating, updating, or deleting a resource) " +
-        "that was previously staged by another tool. Only call this after the user has " +
-        "explicitly confirmed the action summary returned by the previous tool call. If the " +
-        "user declined, do not call this tool — the token will expire automatically. Pass the " +
-        "token exactly as it was returned.",
+        "Finalizes the pending write action (e.g. creating, updating, or deleting a resource) " +
+        "previously staged for the current user by another tool. Only call this AFTER the user " +
+        "has explicitly confirmed the action summary returned by the previous tool call. If the " +
+        "user declined, do not call this tool — the pending action will expire automatically. " +
+        "Takes no arguments: the server resolves the pending action from the caller's session.",
     inputSchema: zodToMcpInputSchema(ConfirmActionArgumentsSchema),
     annotations: {
         readOnlyHint: false,
@@ -46,7 +47,7 @@ export const confirmActionTool = {
 };
 
 /**
- * Runs a previously-staged write-gated tool, identified by `token`. The caller supplies
+ * Runs the previously-staged write-gated tool for `userKey`. The caller supplies
  * `runOriginal` so this module does not have to depend on the full dispatch switch in
  * `toolsHandler.ts` — this keeps the wiring direction one-way and avoids a cycle.
  */
@@ -58,16 +59,22 @@ export async function handleConfirmActionRequest(
     runOriginal: (toolName: string, args: any, apiToken: string) => Promise<any>
 ): Promise<any> {
     try {
-        const { token } = ConfirmActionArgumentsSchema.parse(args);
-        const pending = await store.consume(token, userKey);
+        // Validate args even though we don't use them — surfaces a clear error if the
+        // LLM passes a stray field instead of silently ignoring it.
+        ConfirmActionArgumentsSchema.parse(args ?? {});
+        const pending = await store.consume(userKey);
         if (!pending) {
             return createErrorResponse(
-                "Approval token unknown or expired. Re-issue the original tool call to get a fresh token."
+                "No pending action to confirm (or it expired). Re-issue the original tool call to stage a new one."
             );
         }
         return await runOriginal(pending.toolName, pending.args, apiToken);
     } catch (error) {
-        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(
+                "confirm_action takes no arguments. Call it with an empty arguments object."
+            );
+        }
         return handleGeneralError(error, "handling confirm_action request");
     }
 }

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -156,11 +156,51 @@ export const createTicketTool = {
         destructiveHint: true,
         openWorldHint: true,
     },
-    summary: (args: any) => {
+    /**
+     * Approval payload for the `create_ticket` write gate. Returns both:
+     *   - `summary`: a multi-line block (one-sentence header + "More details below:"
+     *     transition + an indented Platform/Product/Severity/Subject/Body table). The
+     *     LLM is instructed to render this verbatim so the user can verify every field.
+     *   - `userPrompt`: the short yes/no question the LLM asks AFTER showing summary.
+     *     Tool-specific so we can phrase it naturally ("with the above details") rather
+     *     than restating the entire header.
+     *
+     * Values in the header are double-quoted so they're visually distinct from the
+     * surrounding prose (`with severity "high" on platform "aws"`).
+     */
+    summary: (args: any): { summary: string; userPrompt: string } => {
         const ticket = args?.ticket ?? {};
-        const severity = ticket.severity ? ` [${ticket.severity}]` : "";
-        const platform = ticket.platform ? ` on ${ticket.platform}` : "";
-        return `Create support ticket${severity}${platform}: "${ticket.subject ?? "<no subject>"}".`;
+        const parts: string[] = ["Create support ticket"];
+        if (ticket.severity) parts.push(`with severity "${ticket.severity}"`);
+        if (ticket.platform) parts.push(`on platform "${ticket.platform}"`);
+        if (ticket.subject) parts.push(`with subject "${ticket.subject}"`);
+        const header = `${parts.join(" ")}.`;
+
+        const rows: Array<[string, string | undefined]> = [
+            ["Platform", ticket.platform],
+            ["Product", ticket.product],
+            ["Severity", ticket.severity],
+            ["Subject", ticket.subject],
+            ["Body", ticket.body],
+        ];
+        const details = rows
+            .filter(([, v]) => typeof v === "string" && v.length > 0)
+            .map(([k, v]) => `  ${k.padEnd(8)}: ${v}`)
+            .join("\n");
+
+        if (!details) {
+            // No fields to enumerate (defensive): fall back to a derived yes/no off the
+            // header alone, so the LLM still has a sensible question to ask.
+            const body = header.replace(/[.!?]+\s*$/, "");
+            return {
+                summary: header,
+                userPrompt: `Are you sure you want to ${body.charAt(0).toLowerCase()}${body.slice(1)}?`,
+            };
+        }
+        return {
+            summary: `${header} More details below:\n${details}`,
+            userPrompt: "Are you sure you want to create the support ticket with the above details?",
+        };
     },
     _meta: {
         "openai/toolInvocation/invoking": "Creating support ticket...",
@@ -187,7 +227,7 @@ export async function handleCreateTicketRequest(args: any, token: string) {
         const parsed = CreateTicketArgumentsSchema.parse(args);
         const { customerContext } = args;
         const url = TICKETS_BASE_URL;
-        const response = await makeDoitRequest(url, token, {
+        const response = await makeDoitRequest<Partial<Ticket>>(url, token, {
             method: "POST",
             body: { ticket: parsed.ticket },
             customerContext,
@@ -195,10 +235,29 @@ export async function handleCreateTicketRequest(args: any, token: string) {
         if (!response) {
             return createErrorResponse("Failed to create ticket: No data returned");
         }
-        return createSuccessResponse(JSON.stringify(response));
+        return createSuccessResponse(formatCreatedTicket(response));
     } catch (error) {
         return handleGeneralError(error, "creating ticket");
     }
+}
+
+/**
+ * Renders the create-ticket API response as a markdown block that surfaces the ticket
+ * URL prominently, alongside the full JSON payload. We include both because:
+ *   - The markdown header is what shows in chat clients (Claude Desktop / ChatGPT) —
+ *     a clickable link is the action the user actually wants right now.
+ *   - The JSON tail keeps the structured fields available so the LLM can still answer
+ *     follow-up questions ("what's the ticket id?", "what severity did it get?")
+ *     without another API round-trip.
+ */
+function formatCreatedTicket(response: Partial<Ticket>): string {
+    const url = response.urlUI;
+    const id = response.id;
+    const subject = response.subject ?? "(no subject)";
+    const headerLine =
+        id !== undefined ? `Ticket #${id} created: ${subject}` : `Ticket created: ${subject}`;
+    const linkLine = url ? `\nView ticket: ${url}` : "";
+    return `${headerLine}${linkLine}\n\n${JSON.stringify(response)}`;
 }
 
 // Arguments schema for getting a single ticket

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -112,7 +112,24 @@ export async function handleListTicketsRequest(args: any, token: string) {
 export const createTicketTool = {
     name: "create_ticket",
     description:
-        "Use this when the user wants to create a new support ticket. Ask the user to confirm the ticket details before executing. Do NOT use this for viewing existing tickets (use list_tickets) or cloud incidents (use get_cloud_incidents).",
+        // Two-phase approval: calling this tool only STAGES the request — it does NOT " +
+        // actually create the ticket. The real creation happens on a follow-up
+        // confirm_action call (the user must confirm in chat first). Because the gate is
+        // enforced server-side, the agent must NOT add its own pre-flight "are you sure?"
+        // step in chat — that produces a redundant double prompt that PR reviewers and
+        // users have repeatedly flagged. The previous version of this description ended
+        // with "Ask the user to confirm the ticket details before executing" and is the
+        // exact behaviour we are now countermanding.
+        "Create a new support ticket. " +
+        "CALL THIS TOOL IMMEDIATELY with whatever ticket fields the user has provided — " +
+        "do NOT ask the user to confirm the ticket details in chat before calling. " +
+        "This is safe: nothing is created on this call. The server stages the request and " +
+        "returns an `approval_required` envelope containing the exact question to ask the user. " +
+        "The ticket is only created after the user confirms and you make a follow-up `confirm_action` call. " +
+        "Adding your own chat-level confirmation before calling this tool produces a duplicate prompt " +
+        "and is incorrect. " +
+        "Use this ONLY for creating a new ticket. To view existing tickets use `list_tickets`; " +
+        "for cloud incidents use `get_cloud_incidents`.",
     inputSchema: {
         type: "object",
         properties: {
@@ -162,7 +179,7 @@ export const createTicketTool = {
      *     transition + an indented Platform/Product/Severity/Subject/Body table). The
      *     LLM is instructed to render this verbatim so the user can verify every field.
      *   - `userPrompt`: the short yes/no question the LLM asks AFTER showing summary.
-     *     Tool-specific so we can phrase it naturally ("with the above details") rather
+     *     Tool-specific so we can phrase it naturally ("with these details") rather
      *     than restating the entire header.
      *
      * Values in the header are double-quoted so they're visually distinct from the
@@ -170,10 +187,16 @@ export const createTicketTool = {
      */
     summary: (args: any): { summary: string; userPrompt: string } => {
         const ticket = args?.ticket ?? {};
-        const parts: string[] = ["Create support ticket"];
+        const parts: string[] = ["Create a support ticket"];
         if (ticket.severity) parts.push(`with severity "${ticket.severity}"`);
         if (ticket.platform) parts.push(`on platform "${ticket.platform}"`);
-        if (ticket.subject) parts.push(`with subject "${ticket.subject}"`);
+        // Strip trailing sentence punctuation from the subject before quoting it inside
+        // the header — otherwise a user-supplied subject like "Question about discounts."
+        // produces `...with subject "Question about discounts.".` (double period). The
+        // raw subject (with its original punctuation) still appears in the bullet list
+        // below, so nothing is hidden from the user.
+        const headerSubject = typeof ticket.subject === "string" ? ticket.subject.replace(/[.!?]+\s*$/, "") : "";
+        if (headerSubject) parts.push(`with subject "${headerSubject}"`);
         const header = `${parts.join(" ")}.`;
 
         const rows: Array<[string, string | undefined]> = [
@@ -183,9 +206,14 @@ export const createTicketTool = {
             ["Subject", ticket.subject],
             ["Body", ticket.body],
         ];
+        // Markdown bullet list with bold labels. Single-newline-separated indented text
+        // (the previous format) was being flattened to a single line by some chat
+        // clients (notably Cursor) because plain whitespace newlines are interpreted as
+        // soft wraps. Markdown bullets force each field to its own rendered line and
+        // bold labels make the structure scannable at a glance.
         const details = rows
             .filter(([, v]) => typeof v === "string" && v.length > 0)
-            .map(([k, v]) => `  ${k.padEnd(8)}: ${v}`)
+            .map(([k, v]) => `- **${k}:** ${v}`)
             .join("\n");
 
         if (!details) {
@@ -197,9 +225,12 @@ export const createTicketTool = {
                 userPrompt: `Are you sure you want to ${body.charAt(0).toLowerCase()}${body.slice(1)}?`,
             };
         }
+        // Blank line between header and the bullet list — markdown parsers require it
+        // before a list block starts after a regular paragraph, otherwise some
+        // renderers fold the first bullet into the paragraph above.
         return {
-            summary: `${header} More details below:\n${details}`,
-            userPrompt: "Are you sure you want to create the support ticket with the above details?",
+            summary: `${header} More details below:\n\n${details}`,
+            userPrompt: "Are you sure you want to create the support ticket with these details?",
         };
     },
     _meta: {

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -254,8 +254,7 @@ function formatCreatedTicket(response: Partial<Ticket>): string {
     const url = response.urlUI;
     const id = response.id;
     const subject = response.subject ?? "(no subject)";
-    const headerLine =
-        id !== undefined ? `Ticket #${id} created: ${subject}` : `Ticket created: ${subject}`;
+    const headerLine = id !== undefined ? `Ticket #${id} created: ${subject}` : `Ticket created: ${subject}`;
     const linkLine = url ? `\nView ticket: ${url}` : "";
     return `${headerLine}${linkLine}\n\n${JSON.stringify(response)}`;
 }

--- a/src/utils/__tests__/approval.test.ts
+++ b/src/utils/__tests__/approval.test.ts
@@ -119,11 +119,11 @@ describe("buildApprovalResponse", () => {
     it("uses the caller-supplied userPrompt verbatim when one is provided", () => {
         // This is the preferred path for new gated tools: the tool's `summary` function
         // returns `{ summary, userPrompt }` so the question can be phrased naturally
-        // (e.g. "…with the above details?") instead of restating the multi-line header.
+        // (e.g. "…with these details?") instead of restating the multi-line header.
         const summary =
             'Create support ticket with severity "high" on platform "aws" with subject "demo". More details below:\n' +
             "  Platform: aws\n  Body: please help";
-        const explicit = "Are you sure you want to create the support ticket with the above details?";
+        const explicit = "Are you sure you want to create the support ticket with these details?";
         const res = buildApprovalResponse(summary, explicit);
         const parsed = JSON.parse(res.content[0].text);
         expect(parsed.userPrompt).toBe(explicit);
@@ -150,7 +150,9 @@ describe("buildApprovalResponse", () => {
         // the user needs to see), and the LLM is told to render it before asking.
         expect(parsed.summary).toBe(summary);
         expect(parsed.next).toMatch(/verbatim/i);
-        expect(parsed.next).toMatch(/preserv\w* line breaks/i);
+        // Summary is markdown — instruction must tell the LLM not to flatten the bullets.
+        expect(parsed.next).toMatch(/markdown/i);
+        expect(parsed.next).toMatch(/keep each bullet on its own line/i);
     });
 
     it("instructs the LLM to surface a 'declined' message on chat-no AND on permission-deny", () => {

--- a/src/utils/__tests__/approval.test.ts
+++ b/src/utils/__tests__/approval.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-    APPROVAL_TTL_MS,
-    buildApprovalResponse,
-    MemoryApprovalStore,
-    mintApprovalToken,
-    type PendingAction,
-} from "../approval.js";
+import { APPROVAL_TTL_MS, buildApprovalResponse, MemoryApprovalStore, type PendingAction } from "../approval.js";
 
 beforeEach(() => {
     vi.useFakeTimers();
@@ -30,75 +24,152 @@ describe("MemoryApprovalStore", () => {
     it("stash + consume returns the pending action exactly once", async () => {
         const store = new MemoryApprovalStore();
         const pending = makePending();
-        await store.stash("tok-1", pending);
+        await store.stash(pending);
 
-        const first = await store.consume("tok-1", "stdio-local");
+        const first = await store.consume("stdio-local");
         expect(first).toEqual(pending);
 
-        const second = await store.consume("tok-1", "stdio-local");
+        const second = await store.consume("stdio-local");
         expect(second).toBeNull();
     });
 
-    it("returns null when the userKey does not match (and evicts the row)", async () => {
+    it("isolates pending actions per userKey — one user cannot consume another's", async () => {
         const store = new MemoryApprovalStore();
-        await store.stash("tok-2", makePending({ userKey: "alice" }));
+        await store.stash(makePending({ userKey: "alice" }));
 
-        const result = await store.consume("tok-2", "mallory");
-        expect(result).toBeNull();
+        const wrongUser = await store.consume("mallory");
+        expect(wrongUser).toBeNull();
 
-        // Even the legitimate owner cannot now consume — a token seen by a wrong
-        // user is considered burned to prevent retry-after-probe attacks.
-        const retry = await store.consume("tok-2", "alice");
-        expect(retry).toBeNull();
+        // Alice can still consume her own — unlike the previous token-keyed design,
+        // a probe by another user does not burn the row.
+        const alice = await store.consume("alice");
+        expect(alice).not.toBeNull();
+        expect(alice?.userKey).toBe("alice");
     });
 
     it("returns null after TTL expiry", async () => {
         const store = new MemoryApprovalStore();
-        await store.stash("tok-3", makePending());
+        await store.stash(makePending());
 
         vi.advanceTimersByTime(APPROVAL_TTL_MS + 1);
 
-        const result = await store.consume("tok-3", "stdio-local");
+        const result = await store.consume("stdio-local");
         expect(result).toBeNull();
     });
 
-    it("returns null for an unknown token", async () => {
+    it("returns null for a user with no pending action", async () => {
         const store = new MemoryApprovalStore();
-        const result = await store.consume("does-not-exist", "stdio-local");
+        const result = await store.consume("nobody-staged-anything");
         expect(result).toBeNull();
+    });
+
+    it("staging a second action for the same user evicts the first", async () => {
+        const store = new MemoryApprovalStore();
+        await store.stash(
+            makePending({
+                args: { ticket: { subject: "first" } },
+            })
+        );
+        await store.stash(
+            makePending({
+                args: { ticket: { subject: "second" } },
+            })
+        );
+
+        const consumed = await store.consume("stdio-local");
+        // The first staged action is dropped; the second is what `confirm_action` sees.
+        expect(consumed?.args).toEqual({ ticket: { subject: "second" } });
+        expect(store.size()).toBe(0);
     });
 
     it("sweeps expired entries opportunistically on subsequent operations", async () => {
         const store = new MemoryApprovalStore();
-        await store.stash("tok-a", makePending());
-        await store.stash("tok-b", makePending());
+        await store.stash(makePending({ userKey: "u-a" }));
+        await store.stash(makePending({ userKey: "u-b" }));
         expect(store.size()).toBe(2);
 
         vi.advanceTimersByTime(APPROVAL_TTL_MS + 1);
 
-        await store.stash("tok-c", makePending());
+        await store.stash(makePending({ userKey: "u-c" }));
         expect(store.size()).toBe(1);
     });
 });
 
-describe("mintApprovalToken", () => {
-    it("returns RFC 4122 UUIDs that are unique across calls", () => {
-        const t1 = mintApprovalToken();
-        const t2 = mintApprovalToken();
-        expect(t1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-        expect(t2).not.toBe(t1);
-    });
-});
-
 describe("buildApprovalResponse", () => {
-    it("serializes an approval_required envelope carrying the token and summary", () => {
-        const res = buildApprovalResponse("tok-xyz", 'Create support ticket: "demo".');
+    it("serializes an approval_required envelope WITHOUT exposing any token to the LLM", () => {
+        const res = buildApprovalResponse('Create support ticket: "demo".');
         expect(res.isError).toBeFalsy();
-        const text = res.content[0].text;
-        const parsed = JSON.parse(text);
+        const parsed = JSON.parse(res.content[0].text);
         expect(parsed.status).toBe("approval_required");
-        expect(parsed.approvalToken).toBe("tok-xyz");
         expect(parsed.summary).toBe('Create support ticket: "demo".');
-        expect(parsed.next).toContain("tok-xyz");
+        // No approvalToken field anywhere — the prior design surfaced this in MCP
+        // client permission dialogs as a raw UUID.
+        expect(parsed.approvalToken).toBeUndefined();
+        expect(JSON.stringify(parsed)).not.toMatch(/token/i);
+    });
+
+    it("derives a yes/no userPrompt from the summary and tells the LLM to call confirm_action with no args", () => {
+        const res = buildApprovalResponse('Create support ticket: "demo".');
+        const parsed = JSON.parse(res.content[0].text);
+        expect(parsed.userPrompt).toBe('Are you sure you want to create support ticket: "demo"?');
+        expect(parsed.next).toMatch(/userPrompt/);
+        expect(parsed.next).toMatch(/no arguments/);
+    });
+
+    it("uses the caller-supplied userPrompt verbatim when one is provided", () => {
+        // This is the preferred path for new gated tools: the tool's `summary` function
+        // returns `{ summary, userPrompt }` so the question can be phrased naturally
+        // (e.g. "…with the above details?") instead of restating the multi-line header.
+        const summary =
+            'Create support ticket with severity "high" on platform "aws" with subject "demo". More details below:\n' +
+            "  Platform: aws\n  Body: please help";
+        const explicit = "Are you sure you want to create the support ticket with the above details?";
+        const res = buildApprovalResponse(summary, explicit);
+        const parsed = JSON.parse(res.content[0].text);
+        expect(parsed.userPrompt).toBe(explicit);
+        expect(parsed.summary).toBe(summary);
+    });
+
+    it("derives userPrompt from JUST the first line when summary is a multi-line details block", () => {
+        // Tools like create_ticket return a header + indented key/value details so the
+        // user can verify every populated field before confirming.
+        const summary =
+            'Create support ticket with severity high on platform aws with subject "demo".\n' +
+            "  Platform: aws\n" +
+            "  Product:  Compute Engine\n" +
+            "  Severity: high\n" +
+            "  Subject:  demo\n" +
+            "  Body:     please help";
+        const res = buildApprovalResponse(summary);
+        const parsed = JSON.parse(res.content[0].text);
+
+        // Question is short — only the first line is folded into it.
+        expect(parsed.userPrompt).toBe(
+            'Are you sure you want to create support ticket with severity high on platform aws with subject "demo"?'
+        );
+        // Full summary survives in the envelope verbatim (including the indented details
+        // the user needs to see), and the LLM is told to render it before asking.
+        expect(parsed.summary).toBe(summary);
+        expect(parsed.next).toMatch(/verbatim/i);
+        expect(parsed.next).toMatch(/preserv\w* line breaks/i);
+    });
+
+    it("instructs the LLM to surface a 'declined' message on chat-no AND on permission-deny", () => {
+        const res = buildApprovalResponse('Create support ticket: "demo".');
+        const parsed = JSON.parse(res.content[0].text);
+        // Without this, a `Deny` click in Claude Code's confirm_action permission prompt
+        // leaves the LLM silently stopped, which feels like a hang.
+        expect(parsed.next).toMatch(/rejected by the MCP client|permission prompt|Deny/i);
+        // Must forbid retrying confirm_action so the LLM doesn't loop.
+        expect(parsed.next).toMatch(/do NOT call confirm_action/i);
+        // Must forbid silence — the original "hang" bug was the LLM doing nothing
+        // after the user typed "no" or pressed Deny.
+        expect(parsed.next).toMatch(/do NOT stay silent/i);
+        // Must require an immediate, explicit "declined" acknowledgement so the user
+        // sees that their decline registered.
+        expect(parsed.next).toMatch(/immediately reply|acknowledge.*decline/i);
+        // Must list common chat-decline phrasings so the LLM recognizes them
+        // (the previous wording said only "declines in chat" without examples).
+        expect(parsed.next).toMatch(/no|cancel|stop/i);
     });
 });

--- a/src/utils/__tests__/approval.test.ts
+++ b/src/utils/__tests__/approval.test.ts
@@ -143,7 +143,6 @@ describe("buildApprovalResponse", () => {
         const res = buildApprovalResponse(summary);
         const parsed = JSON.parse(res.content[0].text);
 
-        // Question is short — only the first line is folded into it.
         expect(parsed.userPrompt).toBe(
             'Are you sure you want to create support ticket with severity high on platform aws with subject "demo"?'
         );

--- a/src/utils/__tests__/durableObjectApprovalStore.test.ts
+++ b/src/utils/__tests__/durableObjectApprovalStore.test.ts
@@ -51,52 +51,67 @@ describe("DurableObjectApprovalStore", () => {
         const storage = new FakeDurableObjectStorage();
         const store = new DurableObjectApprovalStore(storage as any);
         const pending = makePending();
-        await store.stash("tok-1", pending);
+        await store.stash(pending);
 
-        const first = await store.consume("tok-1", "api-key-alice");
+        const first = await store.consume("api-key-alice");
         expect(first).toEqual(pending);
 
-        const second = await store.consume("tok-1", "api-key-alice");
+        const second = await store.consume("api-key-alice");
         expect(second).toBeNull();
     });
 
-    it("namespaces keys under 'pending:' so it cannot collide with other DO storage", async () => {
+    it("namespaces keys under 'pending:<userKey>' so it cannot collide with other DO storage", async () => {
         const storage = new FakeDurableObjectStorage();
         const store = new DurableObjectApprovalStore(storage as any);
-        await store.stash("tok-ns", makePending());
+        await store.stash(makePending({ userKey: "api-key-alice" }));
 
-        expect(storage.map.has("pending:tok-ns")).toBe(true);
-        expect(storage.map.has("tok-ns")).toBe(false);
+        expect(storage.map.has("pending:api-key-alice")).toBe(true);
+        expect(storage.map.has("api-key-alice")).toBe(false);
     });
 
-    it("returns null and burns the row when userKey mismatches", async () => {
+    it("isolates pending actions per userKey — alice's confirm does not see mallory's", async () => {
         const storage = new FakeDurableObjectStorage();
         const store = new DurableObjectApprovalStore(storage as any);
-        await store.stash("tok-mismatch", makePending({ userKey: "api-key-alice" }));
+        await store.stash(makePending({ userKey: "api-key-alice" }));
 
-        const r1 = await store.consume("tok-mismatch", "api-key-mallory");
+        const r1 = await store.consume("api-key-mallory");
         expect(r1).toBeNull();
 
-        const r2 = await store.consume("tok-mismatch", "api-key-alice");
-        expect(r2).toBeNull();
+        // Alice can still consume — unlike the old token-keyed model, a probe by
+        // another user does not burn alice's row.
+        const r2 = await store.consume("api-key-alice");
+        expect(r2).not.toBeNull();
     });
 
     it("returns null after TTL expiry and evicts the row", async () => {
         const storage = new FakeDurableObjectStorage();
         const store = new DurableObjectApprovalStore(storage as any);
-        await store.stash("tok-stale", makePending());
+        await store.stash(makePending());
 
         vi.advanceTimersByTime(APPROVAL_TTL_MS + 1);
 
-        const r = await store.consume("tok-stale", "api-key-alice");
+        const r = await store.consume("api-key-alice");
         expect(r).toBeNull();
         expect(storage.map.size).toBe(0);
     });
 
-    it("returns null for an unknown token without touching anything", async () => {
+    it("returns null for a user with no pending action without touching anything", async () => {
         const storage = new FakeDurableObjectStorage();
         const store = new DurableObjectApprovalStore(storage as any);
-        const r = await store.consume("missing", "api-key-alice");
+        const r = await store.consume("api-key-nobody");
         expect(r).toBeNull();
+        expect(storage.map.size).toBe(0);
+    });
+
+    it("staging twice for the same user overwrites — confirm_action only sees the latest", async () => {
+        const storage = new FakeDurableObjectStorage();
+        const store = new DurableObjectApprovalStore(storage as any);
+
+        await store.stash(makePending({ args: { ticket: { subject: "first" } } }));
+        await store.stash(makePending({ args: { ticket: { subject: "second" } } }));
+
+        const consumed = await store.consume("api-key-alice");
+        expect(consumed?.args).toEqual({ ticket: { subject: "second" } });
+        expect(storage.map.size).toBe(0);
     });
 });

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -48,23 +48,29 @@ describe("executeToolHandler approval gate", () => {
         expect(response.isError).toBeFalsy();
         const parsed = JSON.parse(response.content[0].text);
         expect(parsed.status).toBe("approval_required");
-        expect(parsed.approvalToken).toMatch(/^[0-9a-f-]{36}$/);
         expect(parsed.summary).toContain("Create support ticket");
+        // New per-tool userPrompt contract: the question references "the above details"
+        // rather than restating the multi-line summary. See createTicketTool.summary.
+        expect(parsed.userPrompt).toBe(
+            "Are you sure you want to create the support ticket with the above details?"
+        );
+        // The envelope must not leak any token to the LLM — that's the whole point of
+        // routing confirm_action via `userKey` lookups instead of a token argument.
+        expect(parsed.approvalToken).toBeUndefined();
     });
 
-    it("confirm_action with a valid token runs the write-gated tool", async () => {
+    it("confirm_action (no args) runs the write-gated tool staged for this user", async () => {
         const { makeDoitRequest } = await import("../util.js");
         (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
         (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "ticket-new-1" });
 
         const approvalStore = new MemoryApprovalStore();
-        const first = await executeToolHandler("create_ticket", validTicketArgs, apiToken, {
+        await executeToolHandler("create_ticket", validTicketArgs, apiToken, {
             userKey,
             approvalStore,
         });
-        const { approvalToken } = JSON.parse(first.content[0].text);
 
-        await executeToolHandler("confirm_action", { token: approvalToken }, apiToken, {
+        await executeToolHandler("confirm_action", {}, apiToken, {
             userKey,
             approvalStore,
         });
@@ -76,15 +82,36 @@ describe("executeToolHandler approval gate", () => {
         expect(opts.method).toBe("POST");
     });
 
-    it("two un-confirmed write-gated calls mint two distinct tokens", async () => {
+    it("a second un-confirmed write-gated call for the same user evicts the first", async () => {
         const approvalStore = new MemoryApprovalStore();
 
-        const r1 = await executeToolHandler("create_ticket", validTicketArgs, apiToken, { userKey, approvalStore });
-        const r2 = await executeToolHandler("create_ticket", validTicketArgs, apiToken, { userKey, approvalStore });
+        // First staging — different subject so we can tell which one wins.
+        await executeToolHandler(
+            "create_ticket",
+            { ticket: { ...validTicketArgs.ticket, subject: "first" } },
+            apiToken,
+            { userKey, approvalStore }
+        );
+        // Second staging overwrites.
+        await executeToolHandler(
+            "create_ticket",
+            { ticket: { ...validTicketArgs.ticket, subject: "second" } },
+            apiToken,
+            { userKey, approvalStore }
+        );
 
-        const t1 = JSON.parse(r1.content[0].text).approvalToken;
-        const t2 = JSON.parse(r2.content[0].text).approvalToken;
-        expect(t1).not.toBe(t2);
+        const { makeDoitRequest } = await import("../util.js");
+        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
+        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "ticket-new-1" });
+
+        await executeToolHandler("confirm_action", {}, apiToken, { userKey, approvalStore });
+
+        expect(makeDoitRequest).toHaveBeenCalledTimes(1);
+        const [, , opts] = (makeDoitRequest as any).mock.calls[0];
+        // The handler passes `body` to makeDoitRequest as an object — the JSON
+        // stringification happens inside makeDoitRequest (which is mocked here),
+        // so the captured value is still the structured payload.
+        expect(opts.body.ticket.subject).toBe("second");
     });
 
     it("without userKey/approvalStore the gate is bypassed (opt-in enforcement)", async () => {

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -51,9 +51,7 @@ describe("executeToolHandler approval gate", () => {
         expect(parsed.summary).toContain("Create support ticket");
         // New per-tool userPrompt contract: the question references "the above details"
         // rather than restating the multi-line summary. See createTicketTool.summary.
-        expect(parsed.userPrompt).toBe(
-            "Are you sure you want to create the support ticket with the above details?"
-        );
+        expect(parsed.userPrompt).toBe("Are you sure you want to create the support ticket with the above details?");
         // The envelope must not leak any token to the LLM — that's the whole point of
         // routing confirm_action via `userKey` lookups instead of a token argument.
         expect(parsed.approvalToken).toBeUndefined();
@@ -92,7 +90,6 @@ describe("executeToolHandler approval gate", () => {
             apiToken,
             { userKey, approvalStore }
         );
-        // Second staging overwrites.
         await executeToolHandler(
             "create_ticket",
             { ticket: { ...validTicketArgs.ticket, subject: "second" } },

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -48,13 +48,40 @@ describe("executeToolHandler approval gate", () => {
         expect(response.isError).toBeFalsy();
         const parsed = JSON.parse(response.content[0].text);
         expect(parsed.status).toBe("approval_required");
-        expect(parsed.summary).toContain("Create support ticket");
-        // New per-tool userPrompt contract: the question references "the above details"
+        expect(parsed.summary).toContain("Create a support ticket");
+        // New per-tool userPrompt contract: the question references "these details"
         // rather than restating the multi-line summary. See createTicketTool.summary.
-        expect(parsed.userPrompt).toBe("Are you sure you want to create the support ticket with the above details?");
+        expect(parsed.userPrompt).toBe("Are you sure you want to create the support ticket with these details?");
         // The envelope must not leak any token to the LLM — that's the whole point of
         // routing confirm_action via `userKey` lookups instead of a token argument.
         expect(parsed.approvalToken).toBeUndefined();
+    });
+
+    it("create_ticket summary header does not double-punctuate when the subject ends in a period", async () => {
+        // Real-world regression: users naturally type "Question about GCP discounts."
+        // (full sentence with period) as a subject. The previous header wrapped that as
+        // `with subject "Question about GCP discounts."` and then appended its own
+        // sentence-ending `.`, producing the visible artifact `discounts.".`. Strip
+        // trailing sentence punctuation from the embedded subject so the header reads
+        // cleanly. The raw value (with its original period) still appears in the bullet
+        // list so the user can verify exactly what gets POSTed.
+        const approvalStore = new MemoryApprovalStore();
+        const response = await executeToolHandler(
+            "create_ticket",
+            {
+                ticket: {
+                    ...validTicketArgs.ticket,
+                    subject: "Question about GCP commitment discounts.",
+                },
+            },
+            apiToken,
+            { userKey, approvalStore }
+        );
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.summary).not.toMatch(/\."\./); // no `."` immediately followed by `.`
+        expect(parsed.summary).toContain('with subject "Question about GCP commitment discounts".');
+        // Bullet still carries the original punctuation so what-you-confirm == what-you-send.
+        expect(parsed.summary).toContain("**Subject:** Question about GCP commitment discounts.");
     });
 
     it("confirm_action (no args) runs the write-gated tool staged for this user", async () => {

--- a/src/utils/approval.ts
+++ b/src/utils/approval.ts
@@ -114,8 +114,8 @@ function deriveUserPromptFromSummary(summary: string): string {
 
 export function buildApprovalResponse(summary: string, userPrompt?: string) {
     // Each tool can supply its own `userPrompt` so the yes/no question reads naturally
-    // (e.g. "Are you sure you want to create the support ticket with the above
-    // details?" rather than restating the multi-line header). If the tool only returns
+    // (e.g. "Are you sure you want to create the support ticket with these details?"
+    // rather than restating the multi-line header). If the tool only returns
     // a string summary (back-compat), we fall back to deriving the question from the
     // first non-empty line — single-line summaries produce a sensible question this way.
     const resolvedUserPrompt = userPrompt ?? deriveUserPromptFromSummary(summary);
@@ -125,7 +125,7 @@ export function buildApprovalResponse(summary: string, userPrompt?: string) {
                 status: "approval_required",
                 summary,
                 userPrompt: resolvedUserPrompt,
-                next: "FIRST: display 'summary' to the user verbatim, preserving line breaks. The indented lines under the header are the structured details (e.g. body, product) the user MUST see before confirming — do not paraphrase or omit them. THEN: ask the user the exact question in 'userPrompt' and wait for an explicit yes/no answer. If the user confirms (yes/confirm/go ahead/etc.), call confirm_action with no arguments (the server resolves the pending action from the user's session). If the user declines in chat (any negative response — 'no', 'nope', 'cancel', 'don't', 'stop', 'nevermind', etc.), OR if confirm_action returns an error / is rejected by the MCP client (e.g. the user pressed Deny on a permission prompt), you MUST immediately reply to the user with a short explicit acknowledgement that the action was declined and will not be performed (e.g. 'Got it — no ticket was created. The pending request will expire on its own.'). Do NOT call confirm_action. Do NOT call any other tool. Do NOT investigate or ask follow-up questions. Do NOT stay silent. Just acknowledge the decline and stop.",
+                next: "FIRST: display 'summary' to the user verbatim. It is already formatted as markdown — a headline paragraph followed by a bullet list of structured details. Preserve the markdown EXACTLY: keep each bullet on its own line, do not collapse the list onto one line, do not rewrite the bullets as prose, and do not omit any bullet. Every bullet is a field the user MUST see before confirming, even ones that look obvious or repetitive. THEN: ask the user the exact question in 'userPrompt' and wait for an explicit yes/no answer. If the user confirms (yes/confirm/go ahead/etc.), call confirm_action with no arguments (the server resolves the pending action from the user's session). If the user declines in chat (any negative response — 'no', 'nope', 'cancel', 'don't', 'stop', 'nevermind', etc.), OR if confirm_action returns an error / is rejected by the MCP client (e.g. the user pressed Deny on a permission prompt), you MUST immediately reply to the user with a short explicit acknowledgement that the action was declined and will not be performed (e.g. 'Got it — no ticket was created. The pending request will expire on its own.'). Do NOT call confirm_action. Do NOT call any other tool. Do NOT investigate or ask follow-up questions. Do NOT stay silent. Just acknowledge the decline and stop.",
             },
             null,
             2

--- a/src/utils/approval.ts
+++ b/src/utils/approval.ts
@@ -1,18 +1,24 @@
-import { randomUUID } from "node:crypto";
 import { createSuccessResponse } from "./util.js";
 
 /**
  * Represents a write-gated tool call that has been staged but not yet executed.
- * The original tool handler is re-invoked only after the matching approval token
- * is consumed via the `confirm_action` tool.
+ * The original tool handler is re-invoked only after the matching `confirm_action`
+ * call resolves it via the user's `userKey`.
  */
 export interface PendingAction {
     toolName: string;
     args: any;
     /**
-     * Identity the approval is bound to. On stdio this is a constant (single-user process);
-     * on the HTTP/SSE Worker it is the OAuth-derived `props.apiKey`. Never a session id
-     * and never client-supplied — see the security notes in approval plan §3.
+     * Identity the approval is bound to AND the lookup key. On stdio this is a
+     * constant (single-user process); on the HTTP/SSE Worker it is the OAuth-derived
+     * `props.apiKey`. Never a session id, never client-supplied — see the security
+     * notes in approval plan §3.
+     *
+     * Because the store is keyed by `userKey`, there is at most one pending action
+     * per user at any time. Staging a second action for the same user before the
+     * first is confirmed silently evicts the first — this is intentional so the
+     * tokenless `confirm_action` call is never ambiguous about which action it is
+     * confirming.
      */
     userKey: string;
     /** Unix millis when this pending action stops being valid. */
@@ -22,19 +28,28 @@ export interface PendingAction {
 /**
  * Storage interface for pending write-gated actions. Two impls: an in-memory store for
  * the stdio transport, and a Durable-Object-backed store for the Cloudflare Worker (so
- * tokens survive isolate eviction between the stage and confirm round-trips).
+ * pending actions survive isolate eviction between the stage and confirm round-trips).
+ *
+ * The contract is "one pending action per `userKey`" — this is what lets
+ * `confirm_action` take zero arguments while still resolving deterministically.
  */
 export interface ApprovalStore {
-    stash(token: string, pending: PendingAction): Promise<void>;
     /**
-     * Looks up and removes the pending action iff the token exists, is unexpired, and the
-     * supplied `userKey` matches. Returns null otherwise. Always single-use: the row is
-     * deleted whether we return it, it was expired, or the user key mismatched.
+     * Stash a pending action for `pending.userKey`. If a prior pending action exists
+     * for the same user, it is overwritten. The previous action is silently dropped;
+     * the LLM is responsible for not staging two actions back-to-back without an
+     * intervening `confirm_action`.
      */
-    consume(token: string, userKey: string): Promise<PendingAction | null>;
+    stash(pending: PendingAction): Promise<void>;
+    /**
+     * Looks up and removes the pending action for `userKey` iff it exists and is
+     * unexpired. Returns null otherwise. Always single-use: the row is deleted
+     * whether we return it or it was expired.
+     */
+    consume(userKey: string): Promise<PendingAction | null>;
 }
 
-/** Default TTL for pending approval tokens: 5 minutes. */
+/** Default TTL for pending approval actions: 5 minutes. */
 export const APPROVAL_TTL_MS = 5 * 60 * 1000;
 
 /**
@@ -44,19 +59,20 @@ export const APPROVAL_TTL_MS = 5 * 60 * 1000;
 export class MemoryApprovalStore implements ApprovalStore {
     private readonly map = new Map<string, PendingAction>();
 
-    async stash(token: string, pending: PendingAction): Promise<void> {
+    async stash(pending: PendingAction): Promise<void> {
         this.sweep();
-        this.map.set(token, pending);
+        // One pending action per userKey: overwrite any prior staged action so the
+        // tokenless confirm_action call cannot be ambiguous.
+        this.map.set(pending.userKey, pending);
     }
 
-    async consume(token: string, userKey: string): Promise<PendingAction | null> {
+    async consume(userKey: string): Promise<PendingAction | null> {
         this.sweep();
-        const p = this.map.get(token);
+        const p = this.map.get(userKey);
         if (!p) return null;
-        // Always evict on lookup, even on mismatch, to avoid leaking a valid token
-        // across identities on subsequent attempts.
-        this.map.delete(token);
-        if (p.userKey !== userKey || p.expiresAt < Date.now()) return null;
+        // Always evict on lookup, even on expiry, to keep the store tidy.
+        this.map.delete(userKey);
+        if (p.expiresAt < Date.now()) return null;
         return p;
     }
 
@@ -74,29 +90,42 @@ export class MemoryApprovalStore implements ApprovalStore {
 }
 
 /**
- * Generates an unguessable one-time approval token.
+ * Builds the structured response returned to the LLM when a write-gated tool has been
+ * staged but not yet executed. The LLM is expected to surface `userPrompt` to the user,
+ * obtain explicit yes/no confirmation, and then call `confirm_action` with no arguments.
  *
- * Imported from `node:crypto` so it works on Node 18 (where the Web Crypto global
- * is not yet exposed by default) and on the Cloudflare Worker, which already enables
- * `nodejs_compat` in `wrangler.jsonc`.
+ * No approval token is included — the server resolves the pending action from the
+ * caller's `userKey` server-side. This keeps tokens out of MCP client permission
+ * dialogs (which display raw tool arguments) so the user never sees an opaque UUID.
  */
-export function mintApprovalToken(): string {
-    return randomUUID();
+/**
+ * Fallback used when a tool's summary function returned only a string (no explicit
+ * userPrompt). Takes the first non-empty line of `summary`, strips the trailing
+ * sentence punctuation, lowercases the first letter, and frames it as "Are you sure
+ * you want to <...>?". Single-line summaries (e.g. "Delete dashboard \"foo\".") yield
+ * a clean question; multi-line summaries get a less-readable one, which is why we
+ * encourage tools to provide their own `userPrompt`.
+ */
+function deriveUserPromptFromSummary(summary: string): string {
+    const firstLine = summary.split("\n").find((l) => l.trim().length > 0) ?? summary;
+    const body = firstLine.replace(/[.!?]+\s*$/, "");
+    return `Are you sure you want to ${body.charAt(0).toLowerCase()}${body.slice(1)}?`;
 }
 
-/**
- * Builds the structured response returned to the LLM when a write-gated tool has been
- * staged but not yet executed. The LLM is expected to surface `summary` to the user,
- * obtain explicit confirmation, and then call `confirm_action` with `token`.
- */
-export function buildApprovalResponse(token: string, summary: string) {
+export function buildApprovalResponse(summary: string, userPrompt?: string) {
+    // Each tool can supply its own `userPrompt` so the yes/no question reads naturally
+    // (e.g. "Are you sure you want to create the support ticket with the above
+    // details?" rather than restating the multi-line header). If the tool only returns
+    // a string summary (back-compat), we fall back to deriving the question from the
+    // first non-empty line — single-line summaries produce a sensible question this way.
+    const resolvedUserPrompt = userPrompt ?? deriveUserPromptFromSummary(summary);
     return createSuccessResponse(
         JSON.stringify(
             {
                 status: "approval_required",
-                approvalToken: token,
                 summary,
-                next: `Call confirm_action with { token: "${token}" } once the user has explicitly confirmed this action. Do not call confirm_action if the user declined — the token will expire on its own.`,
+                userPrompt: resolvedUserPrompt,
+                next: "FIRST: display 'summary' to the user verbatim, preserving line breaks. The indented lines under the header are the structured details (e.g. body, product) the user MUST see before confirming — do not paraphrase or omit them. THEN: ask the user the exact question in 'userPrompt' and wait for an explicit yes/no answer. If the user confirms (yes/confirm/go ahead/etc.), call confirm_action with no arguments (the server resolves the pending action from the user's session). If the user declines in chat (any negative response — 'no', 'nope', 'cancel', 'don't', 'stop', 'nevermind', etc.), OR if confirm_action returns an error / is rejected by the MCP client (e.g. the user pressed Deny on a permission prompt), you MUST immediately reply to the user with a short explicit acknowledgement that the action was declined and will not be performed (e.g. 'Got it — no ticket was created. The pending request will expire on its own.'). Do NOT call confirm_action. Do NOT call any other tool. Do NOT investigate or ask follow-up questions. Do NOT stay silent. Just acknowledge the decline and stop.",
             },
             null,
             2

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -79,7 +79,7 @@ import {
 } from "../tools/tickets.js";
 import { handleInviteUserRequest, handleListUsersRequest, handleUpdateUserRequest } from "../tools/users.js";
 import { handleValidateUserRequest } from "../tools/validateUser.js";
-import { APPROVAL_TTL_MS, type ApprovalStore, buildApprovalResponse, mintApprovalToken } from "./approval.js";
+import { APPROVAL_TTL_MS, type ApprovalStore, buildApprovalResponse } from "./approval.js";
 import {
     createErrorResponse,
     formatZodError,
@@ -102,7 +102,19 @@ import {
  * definition and (b) adding an entry below. Removing approval enforcement is the inverse.
  * No tool handler code needs to change.
  */
-const WRITE_GATED_SUMMARIES: Record<string, (args: any) => string> = {
+/**
+ * A gated tool's `summary` function may return either:
+ *   - a plain string (the legacy contract — `buildApprovalResponse` derives a yes/no
+ *     question from the first line), or
+ *   - `{ summary, userPrompt }` so the tool can phrase its own natural-sounding question
+ *     ("…with the above details?") instead of restating a multi-line header.
+ *
+ * New gated tools should prefer the object form. The string form is supported only so
+ * we don't have to change every existing entry the day a new tool joins the gate set.
+ */
+type GatedSummaryFn = (args: any) => string | { summary: string; userPrompt: string };
+
+const WRITE_GATED_SUMMARIES: Record<string, GatedSummaryFn> = {
     [createTicketTool.name]: createTicketTool.summary,
 };
 
@@ -173,8 +185,11 @@ export async function executeToolHandler(
 
                 const summaryFn = WRITE_GATED_SUMMARIES[toolName];
                 if (summaryFn) {
-                    const approvalToken = mintApprovalToken();
-                    await approvalStore.stash(approvalToken, {
+                    // Stash a single pending action per `userKey`. No client-visible
+                    // token is minted — `confirm_action` resolves the pending action
+                    // by `userKey` server-side. See the rationale on
+                    // `buildApprovalResponse` in `src/utils/approval.ts`.
+                    await approvalStore.stash({
                         toolName,
                         args,
                         userKey,
@@ -190,7 +205,11 @@ export async function executeToolHandler(
                     //       approval JSON as if it were tool results.
                     // The real tool output (after `confirm_action` → `runOriginal`) still
                     // flows through `convertResponse` normally.
-                    return buildApprovalResponse(approvalToken, summaryFn(args));
+                    const summaryResult = summaryFn(args);
+                    if (typeof summaryResult === "string") {
+                        return buildApprovalResponse(summaryResult);
+                    }
+                    return buildApprovalResponse(summaryResult.summary, summaryResult.userPrompt);
                 }
             }
 

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -107,7 +107,7 @@ import {
  *   - a plain string (the legacy contract — `buildApprovalResponse` derives a yes/no
  *     question from the first line), or
  *   - `{ summary, userPrompt }` so the tool can phrase its own natural-sounding question
- *     ("…with the above details?") instead of restating a multi-line header.
+ *     ("…with these details?") instead of restating a multi-line header.
  *
  * New gated tools should prefer the object form. The string form is supported only so
  * we don't have to change every existing entry the day a new tool joins the gate set.

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -10,9 +10,10 @@ type ToolResult = { content: Array<{ type: string; text?: string }>; isError?: b
  * The returned `client.callTool` is wrapped so that write-gated tools which go
  * through the server's approval flow (confirm_action two-phase commit) appear
  * to behave as before from the test's perspective: the wrapper detects an
- * `approval_required` envelope, issues the follow-up `confirm_action` with the
- * minted token, and returns the final response. This keeps existing assertions
- * that inspect handler output (ids, names, validator errors) working unchanged.
+ * `approval_required` envelope and issues the follow-up `confirm_action` (no
+ * args — the server resolves the pending action by the caller's `userKey`).
+ * This keeps existing assertions that inspect handler output (ids, names,
+ * validator errors) working unchanged.
  *
  * The two-phase shape itself is asserted explicitly in
  * test/integration/stdio/approvalFlow.test.ts using `rawClient`.
@@ -34,18 +35,18 @@ export async function createTestClient() {
 
         const text = getTextContent(first);
         if (!text) return first;
-        let parsed: { status?: string; approvalToken?: string } | undefined;
+        let parsed: { status?: string } | undefined;
         try {
             parsed = JSON.parse(text);
         } catch {
             return first;
         }
-        if (parsed?.status !== "approval_required" || !parsed?.approvalToken) {
+        if (parsed?.status !== "approval_required") {
             return first;
         }
         return (await originalCallTool({
             name: "confirm_action",
-            arguments: { token: parsed.approvalToken },
+            arguments: {},
         })) as ToolResult;
     };
 

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -130,7 +130,14 @@ export const mockedDoitApiHandlers = [
         return HttpResponse.json(fixtures.tickets);
     }),
     http.post(`${API_BASE}/support/v1/tickets`, () => {
-        return HttpResponse.json({ id: 99999, status: "created" });
+        // Match the real API shape: include `urlUI` and `subject` so the create-ticket
+        // handler's markdown rendering (header line + clickable link) is exercised.
+        return HttpResponse.json({
+            id: 99999,
+            status: "created",
+            subject: "Gated Ticket",
+            urlUI: "https://console.doit.com/customers/fake/support/tickets/99999",
+        });
     }),
 
     // Invoices (hardcoded URL in source)

--- a/test/integration/stdio/approvalFlow.test.ts
+++ b/test/integration/stdio/approvalFlow.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestClient, getTextContent } from "../helpers.js";
 
+/**
+ * `handleCreateTicketRequest` returns a markdown header (with the clickable ticket
+ * URL) followed by the JSON payload. Pull just the trailing JSON object so existing
+ * structured assertions keep working.
+ */
+function parseTicketResponse(text: string): { id?: number; status?: string; urlUI?: string } {
+    const match = text.match(/\{[\s\S]*\}\s*$/);
+    if (!match) throw new Error(`Expected trailing JSON object in: ${text}`);
+    return JSON.parse(match[0]);
+}
+
 // This suite intentionally uses `rawClient` to bypass the test helper's
 // auto-confirm wrapper, so we can observe the two-phase approval envelope
 // emitted by the server directly.
@@ -29,56 +40,93 @@ describe("Write-gated tool approval flow (stdio)", () => {
         vi.restoreAllMocks();
     });
 
-    it("emits an approval_required envelope on the first call to a write-gated tool", async () => {
+    it("emits an approval_required envelope on the first call — and never leaks a token to the LLM", async () => {
         const result = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
         const body = JSON.parse(getTextContent(result));
 
         expect(body.status).toBe("approval_required");
-        expect(body.approvalToken).toMatch(/^[0-9a-f-]{36}$/i);
-        expect(body.summary).toContain("Create support ticket");
+        // Header line uses natural prepositional phrases with double-quoted values
+        // (severity "high", platform "amazon_web_services", subject "Gated Ticket")
+        // followed by "More details below:" and the indented field table — see
+        // createTicketTool.summary in src/tools/tickets.ts.
+        expect(body.summary).toContain('with severity "high"');
+        expect(body.summary).toContain('on platform "amazon_web_services"');
+        expect(body.summary).toContain("More details below:");
+        expect(body.summary).toContain("Body    : Need help with billing.");
+        // Question references "the above details" rather than restating the header.
+        expect(body.userPrompt).toBe(
+            "Are you sure you want to create the support ticket with the above details?"
+        );
         expect(body.next).toContain("confirm_action");
+        // The whole point of the userKey-keyed design: no UUID surfaces to the LLM
+        // (and therefore to MCP client permission dialogs that render raw args).
+        expect(body.approvalToken).toBeUndefined();
+        expect(JSON.stringify(body)).not.toMatch(/token/i);
     });
 
-    it("confirm_action with the minted token executes the original write-gated call", async () => {
-        const first = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
-        const { approvalToken } = JSON.parse(getTextContent(first));
+    it("confirm_action (no args) executes the staged write-gated call and surfaces the ticket link", async () => {
+        await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
 
         const second = await rawClient.callTool({
             name: "confirm_action",
-            arguments: { token: approvalToken },
+            arguments: {},
         });
-        const parsed = JSON.parse(getTextContent(second));
+        const text = getTextContent(second);
+        // The markdown header is what makes the URL clickable in chat clients —
+        // assert it is present so we don't accidentally regress to raw JSON output.
+        expect(text).toMatch(/^Ticket #99999 created/);
+        expect(text).toContain("View ticket:");
+        const parsed = parseTicketResponse(text);
         expect(parsed.id).toBe(99999);
         expect(parsed.status).toBe("created");
     });
 
-    it("approval tokens are single-use — replaying a consumed token errors out", async () => {
-        const first = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
-        const { approvalToken } = JSON.parse(getTextContent(first));
+    it("pending actions are single-use — a second confirm_action after a successful one errors out", async () => {
+        await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
 
-        await rawClient.callTool({ name: "confirm_action", arguments: { token: approvalToken } });
+        await rawClient.callTool({ name: "confirm_action", arguments: {} });
         const replay = await rawClient.callTool({
             name: "confirm_action",
-            arguments: { token: approvalToken },
+            arguments: {},
         });
 
-        expect(getTextContent(replay)).toContain("Approval token unknown or expired");
+        expect(getTextContent(replay)).toContain("No pending action to confirm");
     });
 
-    it("confirm_action with an unknown token returns the canonical error", async () => {
+    it("confirm_action with no prior staging returns the canonical error", async () => {
         const result = await rawClient.callTool({
+            name: "confirm_action",
+            arguments: {},
+        });
+        expect(getTextContent(result)).toContain("No pending action to confirm");
+    });
+
+    it("staging twice in a row overwrites — the user is only ever confirming the most recent action", async () => {
+        await rawClient.callTool({
+            name: "create_ticket",
+            arguments: { ticket: { ...ticketArgs.ticket, subject: "first" } },
+        });
+        await rawClient.callTool({
+            name: "create_ticket",
+            arguments: { ticket: { ...ticketArgs.ticket, subject: "second" } },
+        });
+
+        const confirmed = await rawClient.callTool({ name: "confirm_action", arguments: {} });
+        // The stdio integration uses the canned fixture handler, which echoes a fixed
+        // id regardless of input. We just verify it succeeded — the unit-level test
+        // in toolsHandler.test.ts asserts the second-wins payload directly against
+        // the mocked makeDoitRequest.
+        const parsed = parseTicketResponse(getTextContent(confirmed));
+        expect(parsed.status).toBe("created");
+    });
+
+    it("confirm_action rejects unexpected arguments (defends against stale `token` field from old contract)", async () => {
+        await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
+
+        const rejected = await rawClient.callTool({
             name: "confirm_action",
             arguments: { token: "00000000-0000-0000-0000-000000000000" },
         });
-        expect(getTextContent(result)).toContain("Approval token unknown or expired");
-    });
-
-    it("calling a write-gated tool twice mints two distinct tokens (idempotent on LLM misbehavior)", async () => {
-        const r1 = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
-        const r2 = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
-
-        const t1 = JSON.parse(getTextContent(r1)).approvalToken;
-        const t2 = JSON.parse(getTextContent(r2)).approvalToken;
-        expect(t1).not.toBe(t2);
+        expect(getTextContent(rejected)).toContain("no arguments");
     });
 });

--- a/test/integration/stdio/approvalFlow.test.ts
+++ b/test/integration/stdio/approvalFlow.test.ts
@@ -52,9 +52,12 @@ describe("Write-gated tool approval flow (stdio)", () => {
         expect(body.summary).toContain('with severity "high"');
         expect(body.summary).toContain('on platform "amazon_web_services"');
         expect(body.summary).toContain("More details below:");
-        expect(body.summary).toContain("Body    : Need help with billing.");
-        // Question references "the above details" rather than restating the header.
-        expect(body.userPrompt).toBe("Are you sure you want to create the support ticket with the above details?");
+        // Detail rows are markdown bullets with bold labels — see the rationale in
+        // createTicketTool.summary about chat clients flattening plain whitespace.
+        expect(body.summary).toContain("- **Body:** Need help with billing.");
+        expect(body.summary).toContain("- **Platform:** amazon_web_services");
+        // Question references "these details" rather than restating the header.
+        expect(body.userPrompt).toBe("Are you sure you want to create the support ticket with these details?");
         expect(body.next).toContain("confirm_action");
         // The whole point of the userKey-keyed design: no UUID surfaces to the LLM
         // (and therefore to MCP client permission dialogs that render raw args).

--- a/test/integration/stdio/approvalFlow.test.ts
+++ b/test/integration/stdio/approvalFlow.test.ts
@@ -54,9 +54,7 @@ describe("Write-gated tool approval flow (stdio)", () => {
         expect(body.summary).toContain("More details below:");
         expect(body.summary).toContain("Body    : Need help with billing.");
         // Question references "the above details" rather than restating the header.
-        expect(body.userPrompt).toBe(
-            "Are you sure you want to create the support ticket with the above details?"
-        );
+        expect(body.userPrompt).toBe("Are you sure you want to create the support ticket with the above details?");
         expect(body.next).toContain("confirm_action");
         // The whole point of the userKey-keyed design: no UUID surfaces to the LLM
         // (and therefore to MCP client permission dialogs that render raw args).


### PR DESCRIPTION
## Summary

Approval tokens are no longer exposed to the LLM/user; the server resolves the pending action from the caller's session when confirm_action is invoked.
create_ticket (and related write tools) now stage a pending action and return a human-readable summary + confirmation prompt instead of a raw token.
Updated approval.ts, confirmAction.ts, toolsHandler.ts, durableObjectApprovalStore.ts, and the ticket tool wiring; tests and integration approval-flow tests updated accordingly.