### PR TITLE
Remove approval token dialog for create ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - chore: disable server-enforced approval flow for `create_ticket`; confirmation UX is now delegated to the MCP client via the tool's `destructiveHint: true` annotation.
+- chore: remove `confirm_action` from the advertised tool surface on both transports (stdio and HTTP/SSE Worker). With no tool minting approval tokens there is nothing to confirm, so the gate-handler tool is no longer listed. Clients enumerating tools will see one fewer entry.
 
 ## v0.13.0 (2026-05-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- chore: disable server-enforced approval flow for `create_ticket`; confirmation UX is now delegated to the MCP client via the tool's `destructiveHint: true` annotation.
+
 ## v0.13.0 (2026-05-07)
 
 ### Features

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -111,10 +111,12 @@ import {
   TriggerCloudFlowArgumentsSchema,
   triggerCloudFlowTool,
 } from "../../src/tools/cloudflow.js";
-import {
-  ConfirmActionArgumentsSchema,
-  confirmActionTool,
-} from "../../src/tools/confirmAction.js";
+// Re-enable alongside the WRITE_GATED_SUMMARIES entry in utils/toolsHandler.ts
+// and the registerTool() call further down.
+// import {
+//   ConfirmActionArgumentsSchema,
+//   confirmActionTool,
+// } from "../../src/tools/confirmAction.js";
 import {
   ListOrganizationsArgumentsSchema,
   listOrganizationsTool,
@@ -799,7 +801,9 @@ export class DoitMCPAgent extends McpAgent {
 
     // Approval flow — exposed so the LLM can finalize destructive actions that
     // were previously staged by other tools. See src/tools/confirmAction.ts.
-    this.registerTool(confirmActionTool, ConfirmActionArgumentsSchema);
+    // Currently disabled along with the WRITE_GATED_SUMMARIES gate; no tool
+    // mints approval tokens, so there's nothing for clients to confirm.
+    // this.registerTool(confirmActionTool, ConfirmActionArgumentsSchema);
 
     // Change Customer tool (requires special handling)
     if (this.props.isDoitUser === "true") {

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -821,7 +821,10 @@ describe("CallToolRequestSchema handler", () => {
 
     // Tools gated by the server-side approval flow (confirm_action two-phase commit).
     // POC scope keeps the gated set minimal; see WRITE_GATED_SUMMARIES in toolsHandler.ts.
-    const WRITE_GATED_TOOL_NAMES = new Set(["create_ticket"]);
+    // Approval gating for create_ticket is currently disabled — we rely on the tool's
+    // `destructiveHint: true` annotation instead. Re-add "create_ticket" here when the
+    // WRITE_GATED_SUMMARIES entry is uncommented.
+    const WRITE_GATED_TOOL_NAMES = new Set<string>([/* "create_ticket" */]);
 
     it.each(toolRoutingCases)("routes %s to the correct handler", async (_label, toolName, args, handler) => {
         const first = await getCallToolHandler()(mockRequest(toolName, args));

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -824,7 +824,9 @@ describe("CallToolRequestSchema handler", () => {
     // Approval gating for create_ticket is currently disabled — we rely on the tool's
     // `destructiveHint: true` annotation instead. Re-add "create_ticket" here when the
     // WRITE_GATED_SUMMARIES entry is uncommented.
-    const WRITE_GATED_TOOL_NAMES = new Set<string>([/* "create_ticket" */]);
+    const WRITE_GATED_TOOL_NAMES = new Set<string>([
+        /* "create_ticket" */
+    ]);
 
     it.each(toolRoutingCases)("routes %s to the correct handler", async (_label, toolName, args, handler) => {
         const first = await getCallToolHandler()(mockRequest(toolName, args));

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -231,7 +231,7 @@ import { findCloudDiagramsTool } from "../tools/cloudDiagrams.js";
 import { triggerCloudFlowTool } from "../tools/cloudflow.js";
 import { cloudIncidentsTool, cloudIncidentTool } from "../tools/cloudIncidents.js";
 import { getCommitmentTool, listCommitmentsTool } from "../tools/commitmentManager.js";
-import { confirmActionTool } from "../tools/confirmAction.js";
+// import { confirmActionTool } from "../tools/confirmAction.js"; // disabled with the approval gate
 import {
     createDatahubDatasetTool,
     getDatahubDatasetTool,
@@ -393,7 +393,7 @@ describe("ListToolsRequestSchema handler", () => {
                 listCommitmentsTool,
                 getCommitmentTool,
                 askAvaSyncTool,
-                confirmActionTool,
+                // confirmActionTool, // disabled with the approval gate
             ],
         });
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,9 @@ import {
     handleListCommitmentsRequest,
     listCommitmentsTool,
 } from "./tools/commitmentManager.js";
-import { confirmActionTool } from "./tools/confirmAction.js";
+// Re-enable alongside the WRITE_GATED_SUMMARIES entry in utils/toolsHandler.ts
+// and the registration on the tool list below.
+// import { confirmActionTool } from "./tools/confirmAction.js";
 import {
     createDatahubDatasetTool,
     getDatahubDatasetTool,
@@ -243,7 +245,10 @@ export function createServer() {
                 listCommitmentsTool,
                 getCommitmentTool,
                 askAvaSyncTool,
-                confirmActionTool,
+                // confirm_action is no longer exposed while the approval gate is
+                // disabled — without any write-gated tool minting tokens there is
+                // nothing for clients to confirm. Re-add when the gate returns.
+                // confirmActionTool,
             ],
         };
     });

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -153,6 +153,9 @@ export const createTicketTool = {
     },
     annotations: {
         readOnlyHint: false,
+        // `destructiveHint` is advisory per the MCP spec — clients are expected (but not
+        // required) to surface a confirmation dialog. For a *server-enforced* confirmation
+        // step, re-enable the WRITE_GATED_SUMMARIES entry in src/utils/toolsHandler.ts.
         destructiveHint: true,
         openWorldHint: true,
     },

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -102,6 +102,27 @@ describe("executeToolHandler approval gate", () => {
         expect(makeDoitRequest).toHaveBeenCalledTimes(1);
     });
 
+    it("confirm_action called by a stale client returns a clean error (no throw)", async () => {
+        // `confirm_action` is no longer advertised in the tool list (see src/server.ts
+        // and doit-mcp-server/src/index.ts), but a misbehaving client with cached
+        // metadata could still send the call. Verify it returns the canonical
+        // "Approval token unknown or expired" error instead of throwing, and never
+        // reaches the DoiT API.
+        const { makeDoitRequest } = await import("../util.js");
+        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+        const approvalStore = new MemoryApprovalStore();
+        const response = await executeToolHandler(
+            "confirm_action",
+            { token: "00000000-0000-0000-0000-000000000000" },
+            apiToken,
+            { userKey, approvalStore }
+        );
+
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(response.content[0].text).toContain("Approval token unknown or expired");
+    });
+
     it("create_ticket runs directly when its WRITE_GATED_SUMMARIES entry is disabled (current default)", async () => {
         // Locks in the disabled-approval behavior: even with both userKey and approvalStore
         // supplied (i.e. the gate would fire if `create_ticket` were registered), we expect

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -34,7 +34,10 @@ describe("executeToolHandler approval gate", () => {
         },
     } as const;
 
-    it("write-gated tools return approval_required without calling the API on the first call", async () => {
+    // Skipped: approval-token gating for create_ticket is currently disabled
+    // (see WRITE_GATED_SUMMARIES in toolsHandler.ts). Re-enable by removing
+    // `.skip` once the registry entry is uncommented.
+    it.skip("write-gated tools return approval_required without calling the API on the first call", async () => {
         const { makeDoitRequest } = await import("../util.js");
         (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
 
@@ -52,7 +55,8 @@ describe("executeToolHandler approval gate", () => {
         expect(parsed.summary).toContain("Create support ticket");
     });
 
-    it("confirm_action with a valid token runs the write-gated tool", async () => {
+    // Skipped: approval-token gating for create_ticket is currently disabled.
+    it.skip("confirm_action with a valid token runs the write-gated tool", async () => {
         const { makeDoitRequest } = await import("../util.js");
         (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
         (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "ticket-new-1" });
@@ -76,7 +80,8 @@ describe("executeToolHandler approval gate", () => {
         expect(opts.method).toBe("POST");
     });
 
-    it("two un-confirmed write-gated calls mint two distinct tokens", async () => {
+    // Skipped: approval-token gating for create_ticket is currently disabled.
+    it.skip("two un-confirmed write-gated calls mint two distinct tokens", async () => {
         const approvalStore = new MemoryApprovalStore();
 
         const r1 = await executeToolHandler("create_ticket", validTicketArgs, apiToken, { userKey, approvalStore });

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -102,6 +102,29 @@ describe("executeToolHandler approval gate", () => {
         expect(makeDoitRequest).toHaveBeenCalledTimes(1);
     });
 
+    it("create_ticket runs directly when its WRITE_GATED_SUMMARIES entry is disabled (current default)", async () => {
+        // Locks in the disabled-approval behavior: even with both userKey and approvalStore
+        // supplied (i.e. the gate would fire if `create_ticket` were registered), we expect
+        // the handler to call the DoiT API directly and return the API response — not an
+        // `approval_required` envelope. Re-enabling the WRITE_GATED_SUMMARIES entry in
+        // `src/utils/toolsHandler.ts` should make this test fail; that's intentional.
+        const { makeDoitRequest } = await import("../util.js");
+        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
+        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "ticket-new-1" });
+
+        const approvalStore = new MemoryApprovalStore();
+        const response = await executeToolHandler("create_ticket", validTicketArgs, apiToken, {
+            userKey,
+            approvalStore,
+        });
+
+        expect(makeDoitRequest).toHaveBeenCalledTimes(1);
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.status).not.toBe("approval_required");
+        expect(parsed.approvalToken).toBeUndefined();
+        expect(approvalStore.size()).toBe(0);
+    });
+
     it("non-gated tools pass through even with the gate enabled", async () => {
         const { makeDoitRequest } = await import("../util.js");
         (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -70,7 +70,7 @@ import {
 } from "../tools/reports.js";
 import { handleListRolesRequest } from "../tools/roles.js";
 import {
-    createTicketTool,
+    // createTicketTool, // Re-enable alongside the WRITE_GATED_SUMMARIES entry below.
     handleCreateTicketCommentRequest,
     handleCreateTicketRequest,
     handleGetTicketRequest,

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -103,7 +103,10 @@ import {
  * No tool handler code needs to change.
  */
 const WRITE_GATED_SUMMARIES: Record<string, (args: any) => string> = {
-    [createTicketTool.name]: createTicketTool.summary,
+    // Approval-token gating for create_ticket is disabled — we rely on the
+    // tool's `destructiveHint: true` annotation to surface a client-side
+    // confirmation dialog instead. Re-enable by uncommenting the line below.
+    // [createTicketTool.name]: createTicketTool.summary,
 };
 
 export interface ToolHandlerOptions {

--- a/test/integration/stdio/approvalFlow.test.ts
+++ b/test/integration/stdio/approvalFlow.test.ts
@@ -4,7 +4,12 @@ import { createTestClient, getTextContent } from "../helpers.js";
 // This suite intentionally uses `rawClient` to bypass the test helper's
 // auto-confirm wrapper, so we can observe the two-phase approval envelope
 // emitted by the server directly.
-describe("Write-gated tool approval flow (stdio)", () => {
+//
+// Skipped: server-enforced approval gating for `create_ticket` is currently
+// disabled (see WRITE_GATED_SUMMARIES in src/utils/toolsHandler.ts). All five
+// tests below assert behavior of that gate. Remove `.skip` once the registry
+// entry is uncommented.
+describe.skip("Write-gated tool approval flow (stdio)", () => {
     let rawClient: { callTool: (p: { name: string; arguments: Record<string, unknown> }) => Promise<any> };
     let cleanup: () => Promise<void>;
 

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -116,8 +116,12 @@ describe("MCP Tools Integration", () => {
     describe("STDIO ↔ SSE tool registration sync", () => {
         // Tools whose source-level references (import + commented-out registration)
         // are intentionally retained for an easy re-enable, but which are NOT actually
-        // exposed to clients. Filter them from the regex-extracted lists so the parity
-        // check matches the live MCP tool surface.
+        // exposed to clients. The regex extractor matches on raw text, so commented-out
+        // identifiers like `// confirmActionTool,` in src/server.ts and
+        // `// this.registerTool(confirmActionTool, ...)` in doit-mcp-server/src/index.ts
+        // would otherwise be counted as live. Filter them here so the parity check
+        // reflects the actual MCP tool surface; re-enabling a tool means uncommenting
+        // its source references AND removing its name from this set.
         const DISABLED_TOOL_VARS = new Set(["confirmActionTool"]);
 
         function extractToolVarNames(source: string, pattern: RegExp): string[] {

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -33,7 +33,7 @@ describe("MCP Tools Integration", () => {
                     "ask_ava_sync",
                     "assign_objects_to_label",
                     "compare_spend",
-                    "confirm_action",
+                    // "confirm_action", // disabled with the approval gate
                     "cost_breakdown",
                     "cost_trend",
                     "create_alert",
@@ -114,10 +114,16 @@ describe("MCP Tools Integration", () => {
     });
 
     describe("STDIO ↔ SSE tool registration sync", () => {
+        // Tools whose source-level references (import + commented-out registration)
+        // are intentionally retained for an easy re-enable, but which are NOT actually
+        // exposed to clients. Filter them from the regex-extracted lists so the parity
+        // check matches the live MCP tool surface.
+        const DISABLED_TOOL_VARS = new Set(["confirmActionTool"]);
+
         function extractToolVarNames(source: string, pattern: RegExp): string[] {
             const names: string[] = [];
             for (const m of source.matchAll(pattern)) {
-                names.push(m[1]);
+                if (!DISABLED_TOOL_VARS.has(m[1])) names.push(m[1]);
             }
             return names;
         }


### PR DESCRIPTION
**Summary**
Disable server-side approval token for create_ticket; rely on destructiveHint annotation

**What changed**
Commented out the create_ticket entry in WRITE_GATED_SUMMARIES (src/utils/toolsHandler.ts) so the two-phase approval flow is bypassed.
Skipped 3 approval-gate tests in src/utils/__tests__/toolsHandler.test.ts via it.skip.
Emptied WRITE_GATED_TOOL_NAMES in src/__tests__/server.test.ts (old value preserved as a comment).

**Why**
The MCP client already surfaces a confirmation dialog via the tool's destructiveHint: true annotation. The custom approval_required / confirm_action round-trip was redundant for the POC and added an extra LLM turn before every ticket creation.

**Behavior**
create_ticket now runs directly — no token minted, no confirm_action round-trip.
Confirmation UX is delegated to the MCP client (Claude Desktop, Claude Code, ChatGPT, Cursor all honor destructiveHint).
Approval infrastructure (ApprovalStore, confirm_action, buildApprovalResponse) is not removed — uncomment one line to restore the hard gate.