### PR TITLE
chore: ignore local .doit-api-coverage loop config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ _local
 widget-gallery.html
 .yarn/
 package-lock.json
+
+# Local API-coverage loop config (not part of the published server)
+.doit-api-coverage/


### PR DESCRIPTION
## What

Adds `.doit-api-coverage/` to the root `.gitignore`.

This directory holds the local config/prompt for the DoiT MCP API-coverage self-heal loop. It is a developer-local artifact, not part of the published server, so it should not be tracked.

## Why

It was showing up as an untracked directory in `git status` for anyone running the coverage loop locally. Ignoring it keeps the working tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)