### PR TITLE
fix(widget): bump vite to ^6.4.3 to clear vite + postcss advisories (CMP-43005)

### DIFF
--- a/widget/package.json
+++ b/widget/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^5.7.0",
-    "vite": "^6.0.0",
+    "vite": "^6.4.3",
     "vite-plugin-singlefile": "^2.0.0",
     "@preact/preset-vite": "^2.9.0"
   }


### PR DESCRIPTION
## Summary
Patches the two widget-side security advisories from the CMP-43005 audit report by
bumping Vite. Closes the build-tooling portion of CMP-43005.

- `vite` `^6.0.0` → `^6.4.3` — clears the **high** (path traversal in optimized deps
  `.map`; arbitrary file read via dev-server WebSocket)
- `postcss` follows transitively to `8.5.10` — clears the **moderate** (XSS via
  unescaped `</style>`)

The `vite` floor bump in `widget/package.json` is the durable fix because
`widget/package-lock.json` is gitignored; raising the manifest floor guarantees CI
pulls the patched version.

## Changes
- `widget/package.json`: `vite` `^6.0.0` → `^6.4.3` (stays within Vite 6 — no major migration)

## Testing
- `vite` resolves to 6.4.3, `postcss` to 8.5.10; `npm audit` in `widget/` down to 1 low
  (`@babel/core`, out of scope for this ticket)
- `npm run build` succeeds on Vite 6.4.3
- Root `yarn build` succeeds end-to-end and re-inlines the widget
- Vite asset hash unchanged — no behavioral change to the widget

## Notes
- Build-time only: Vite is not shipped to the Worker runtime, and the build runs on Linux CI.
- The regenerated `src/widgetHtml.ts` (minifier-name churn only) was intentionally left out
  to keep the diff to the security fix; it's rebuilt at release time.