### PR TITLE
fix(worker): patch hono and transitive audit advisories (CMP-43005)

### DIFF
--- a/doit-mcp-server/package.json
+++ b/doit-mcp-server/package.json
@@ -16,9 +16,14 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
     "agents": "^0.0.95",
-    "hono": "4.12.7",
+    "hono": "4.12.25",
     "jose": "^6.1.3",
     "zod": "^3.25.67"
+  },
+  "resolutions": {
+    "hono": "4.12.25",
+    "@hono/node-server": "1.19.14",
+    "express-rate-limit": "8.5.2"
   },
   "devDependencies": {
     "@types/node": "^24.0.4",

--- a/doit-mcp-server/yarn.lock
+++ b/doit-mcp-server/yarn.lock
@@ -383,10 +383,10 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
   integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
 
-"@hono/node-server@^1.19.9":
-  version "1.19.11"
-  resolved "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz"
-  integrity sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==
+"@hono/node-server@1.19.14", "@hono/node-server@^1.19.9":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
 "@img/colour@^1.0.0":
   version "1.1.0"
@@ -1032,12 +1032,12 @@ eventsource@^3.0.2:
   dependencies:
     eventsource-parser "^3.0.1"
 
-express-rate-limit@^8.2.1:
-  version "8.3.1"
-  resolved "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz"
-  integrity sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==
+express-rate-limit@8.5.2, express-rate-limit@^8.2.1:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz#5922dbf76df2124611cea955d93432b37514b2f3"
+  integrity sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==
   dependencies:
-    ip-address "10.1.0"
+    ip-address "^10.2.0"
 
 express@^5.2.1:
   version "5.2.1"
@@ -1217,10 +1217,10 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-hono@4.12.7, hono@^4.11.4:
-  version "4.12.7"
-  resolved "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz"
-  integrity sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==
+hono@4.12.25, hono@^4.11.4:
+  version "4.12.25"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.25.tgz#f2d9996a54e8c9c0c5f5de1c8f3a962e43a98c4e"
+  integrity sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==
 
 http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
   version "2.0.1"
@@ -1245,10 +1245,10 @@ inherits@~2.0.4:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ip-address@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz"
-  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
+ip-address@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
## Summary
Patches the four worker-side security advisories from the CMP-43005 audit report.

- `hono` `4.12.7` → `4.12.25` (cookie validation, toSSG path traversal, JSX injection,
  ipRestriction, bodyLimit — plus the newer CORS-credentials advisory)
- `@hono/node-server` → `1.19.14` (serveStatic middleware bypass)
- `express-rate-limit` → `8.5.2`; `ip-address` follows to `10.2.0` (Address6 XSS)

## Changes
- `doit-mcp-server/package.json`: pin `hono` to `4.12.25`; add `resolutions` for `hono`,
  `@hono/node-server`, `express-rate-limit`
- `doit-mcp-server/yarn.lock`: regenerated with the patched versions

`resolutions` are used because `yarn install` kept the satisfying-but-vulnerable transitive
versions and Yarn classic won't bump nested deps via `yarn upgrade`. All forced versions stay
within the existing semver ranges (`@modelcontextprotocol/sdk`), so nothing is over-constrained.
`yarn why hono` confirms a single deduped version.

## Testing
- All four in-scope advisories cleared in `yarn audit`
- `yarn type-check` clean; `yarn test` 30/30; root `yarn test` 764 passing
- `wrangler dev` smoke: home/widget/metadata 200, CORS preflight 204, unauth `/sse` 401
