### PR TITLE
fix(worker): remove hot-path DO storage ops causing timeout resets

### DIFF
--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -413,15 +413,19 @@ export class DoitMCPAgent extends McpAgent {
   // exchange the MCP-scoped token for a separate upstream token before calling
   // DoiT APIs, per the MCP authorization spec.
   private async getToken(): Promise<string> {
-    // Prefer the persisted live token over props.credential, which can be the stale
-    // connect-time token after the DO is evicted and re-woken (see applyOAuthSession).
-    const persisted = await this.ctx.storage.get<string>(
-      LIVE_CREDENTIAL_STORAGE_KEY
-    );
-    const token =
-      typeof persisted === "string" && persisted
-        ? persisted
-        : (this.props.credential as string);
+    // applyOAuthSession is called before every message dispatch and keeps
+    // this.props.credential current in memory, so read from there on the hot path.
+    // Fall back to durable storage only when props were lost (DO evicted before
+    // applyOAuthSession ran — abnormal, but guards against a stale connect-time token).
+    let token = this.props.credential as string;
+    if (!token) {
+      const persisted = await this.ctx.storage.get<string>(
+        LIVE_CREDENTIAL_STORAGE_KEY
+      );
+      if (typeof persisted === "string" && persisted) {
+        token = persisted;
+      }
+    }
     const authMethod = this.props.authMethod as string | undefined;
     console.info("[mcp] resolving upstream DoiT API token", {
       authMethod,
@@ -478,8 +482,9 @@ export class DoitMCPAgent extends McpAgent {
   // Re-deliver the live, Worker-verified OAuth session to the DO. The SDK delivers props
   // only at connect/initialize and never refreshes them on later messages, so the
   // connect-time token goes stale (~15 min) and an evicted DO re-wakes with the stale token.
-  // We rebuild the session from the token's own (already-verified) claims and persist the
-  // token durably so getToken() uses it even on a re-woken instance. customerContext is kept
+  // We rebuild the session from the token's own (already-verified) claims. The token is
+  // persisted to durable storage only when it changes, so getToken() can recover it after
+  // DO eviction without incurring a storage write on every message. customerContext is kept
   // when already set so a mid-session change_customer switch isn't reverted. Called per
   // message via applyOAuthSessionFromRequest.
   async applyOAuthSession(token: string): Promise<void> {
@@ -502,8 +507,9 @@ export class DoitMCPAgent extends McpAgent {
       flowId: claims.flowId,
       isDoitUser: claims.isDoitUser,
     };
-    await this.ctx.storage.put(LIVE_CREDENTIAL_STORAGE_KEY, token);
     if (credentialChanged) {
+      // Persist the new token so getToken() can recover it after DO eviction.
+      await this.ctx.storage.put(LIVE_CREDENTIAL_STORAGE_KEY, token);
       // Drop the cached upstream token so getToken() re-exchanges with the live one.
       this.upstreamTokenCache = undefined;
     }


### PR DESCRIPTION
## Summary

- `getToken()` was doing `storage.get(LIVE_CREDENTIAL_STORAGE_KEY)` on **every tool call**, even though `this.props.credential` is already kept current in memory by `applyOAuthSession` (called before every message dispatch)
- `applyOAuthSession()` was doing `storage.put` on **every message** regardless of whether the credential changed — the `credentialChanged` guard only protected `upstreamTokenCache`, not the write

Under load these sequential SQLite ops exceeded Cloudflare's per-operation timeout and reset the Durable Object, producing: `"Durable Object storage operation exceeded timeout which caused object to be reset."`

## Fix

- `getToken()`: reads `this.props.credential` directly (in-memory). Falls back to durable storage only when `this.props.credential` is empty (DO evicted before `applyOAuthSession` ran — abnormal path)
- `applyOAuthSession()`: moves `storage.put` inside the `credentialChanged` guard, so it only writes when the token actually rotates (~every 15 min per session)

Correctness is preserved: `applyOAuthSessionFromRequest` is called before every message dispatch, so `this.props.credential` is always the live token by the time any tool callback calls `getToken()`.

## Test plan

- [ ] Deploy to dev and verify MCP connections succeed without DO storage timeout errors in logs
- [ ] Make multiple tool calls in a single session and confirm no `storage.get` on each call in logs
- [ ] Wait >15 min to let token rotate and confirm a single `storage.put` fires on credential change

🤖 Generated with [Claude Code](https://claude.com/claude-code)