### PR TITLE
feat(api): add get_active_theme and get_insight tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,12 @@ This MCP server provides many tools including the following:
 - [`get_folder`](https://developer.doit.com/reference/getfolder): Returns details of a specific Cloud Analytics folder by ID or name
 - [`list_themes`](https://developer.doit.com/reference/listcustomthemes): Returns the custom color themes defined for your account
 - [`get_theme`](https://developer.doit.com/reference/getcustomtheme): Returns details of a specific custom color theme by ID or name
+- [`get_active_theme`](https://developer.doit.com/reference/getactivetheme): Returns the color theme currently active for the authenticated user (the sentinel `"default"` means the built-in default is in use)
 - [`list_account_team`](https://developer.doit.com/reference/listaccountteam): Returns the DoiT account managers assigned to the customer, including name, email, role, and Calendly link
 - [`get_resource_permissions`](https://developer.doit.com/reference/getresourcepermission-2): Returns the sharing settings (per-user roles and public visibility) for a specific alert, budget, report, or allocation
 - [`get_aws_account`](https://developer.doit.com/reference/getawsaccount): Returns the CloudConnect details of a connected AWS account (role ARN, billing S3 bucket, enabled and supported features) by AWS account ID
 - [`get_cloud_connect_supported_features`](https://developer.doit.com/reference/getcloudconnectsupportedfeatures): Returns the DoiT CloudConnect features supported for a connected cloud account (AWS account ID or Azure tenant ID) and whether the required permissions are present
+- [`get_insight`](https://developer.doit.com/reference/getinsightresult): Returns the metadata and aggregate summary (savings, risk counts, status) of a single optimization insight identified by its source and key
 
 
 ## Usage Examples

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -48,8 +48,10 @@ import {
 import {
   ListInsightsArgumentsSchema,
   GetInsightResourcesArgumentsSchema,
+  GetInsightArgumentsSchema,
   listOptimizationRecommendationsTool,
   getInsightResourcesTool,
+  getInsightTool,
 } from "../../src/tools/insights.js";
 import {
   ValidateUserArgumentsSchema,
@@ -178,6 +180,8 @@ import {
 import {
   GetThemeArgumentsSchema,
   getThemeTool,
+  GetActiveThemeArgumentsSchema,
+  getActiveThemeTool,
   ListThemesArgumentsSchema,
   listThemesTool,
 } from "../../src/tools/themes.js";
@@ -877,6 +881,7 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(compareSpendTool, CompareSpendArgumentsSchema);
     this.registerTool(listOptimizationRecommendationsTool, ListInsightsArgumentsSchema);
     this.registerTool(getInsightResourcesTool, GetInsightResourcesArgumentsSchema);
+    this.registerTool(getInsightTool, GetInsightArgumentsSchema);
     this.registerTool(getReportResultsTool, GetReportResultsArgumentsSchema);
     this.registerTool(getReportConfigTool, GetReportConfigArgumentsSchema);
     this.registerTool(createReportTool, CreateReportArgumentsSchema);
@@ -958,6 +963,7 @@ export class DoitMCPAgent extends McpAgent {
     // Themes tools
     this.registerTool(listThemesTool, ListThemesArgumentsSchema);
     this.registerTool(getThemeTool, GetThemeArgumentsSchema);
+    this.registerTool(getActiveThemeTool, GetActiveThemeArgumentsSchema);
 
     // AWS Account Management tools
     this.registerTool(getAwsAccountTool, GetAwsAccountArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -243,7 +243,7 @@ import { sendDatahubEventsTool } from "../tools/datahubEvents.js";
 import { dimensionTool } from "../tools/dimension.js";
 import { dimensionsTool } from "../tools/dimensions.js";
 import { getFolderTool, listFoldersTool } from "../tools/folders.js";
-import { getInsightResourcesTool, listOptimizationRecommendationsTool } from "../tools/insights.js";
+import { getInsightResourcesTool, getInsightTool, listOptimizationRecommendationsTool } from "../tools/insights.js";
 import { getInvoiceTool, listInvoicesTool } from "../tools/invoices.js";
 import {
     assignObjectsToLabelTool,
@@ -268,7 +268,7 @@ import {
     updateReportTool,
 } from "../tools/reports.js";
 import { listRolesTool } from "../tools/roles.js";
-import { getThemeTool, listThemesTool } from "../tools/themes.js";
+import { getActiveThemeTool, getThemeTool, listThemesTool } from "../tools/themes.js";
 import {
     createTicketCommentTool,
     createTicketTool,
@@ -341,6 +341,7 @@ describe("ListToolsRequestSchema handler", () => {
                 compareSpendTool,
                 listOptimizationRecommendationsTool,
                 getInsightResourcesTool,
+                getInsightTool,
                 getReportResultsTool,
                 getReportConfigTool,
                 createReportTool,
@@ -384,6 +385,7 @@ describe("ListToolsRequestSchema handler", () => {
                 getFolderTool,
                 listThemesTool,
                 getThemeTool,
+                getActiveThemeTool,
                 getAwsAccountTool,
                 getCloudConnectSupportedFeaturesTool,
                 listDatahubDatasetsTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,7 +91,7 @@ import { handleSendDatahubEventsRequest, sendDatahubEventsTool } from "./tools/d
 import { dimensionTool, handleDimensionRequest } from "./tools/dimension.js";
 import { dimensionsTool, handleDimensionsRequest } from "./tools/dimensions.js";
 import { getFolderTool, handleGetFolderRequest, handleListFoldersRequest, listFoldersTool } from "./tools/folders.js";
-import { getInsightResourcesTool, listOptimizationRecommendationsTool } from "./tools/insights.js";
+import { getInsightResourcesTool, getInsightTool, listOptimizationRecommendationsTool } from "./tools/insights.js";
 import {
     getInvoiceTool,
     handleGetInvoiceRequest,
@@ -133,7 +133,14 @@ import {
     updateReportTool,
 } from "./tools/reports.js";
 import { handleListRolesRequest, listRolesTool } from "./tools/roles.js";
-import { getThemeTool, handleGetThemeRequest, handleListThemesRequest, listThemesTool } from "./tools/themes.js";
+import {
+    getActiveThemeTool,
+    getThemeTool,
+    handleGetActiveThemeRequest,
+    handleGetThemeRequest,
+    handleListThemesRequest,
+    listThemesTool,
+} from "./tools/themes.js";
 import {
     createTicketCommentTool,
     createTicketTool,
@@ -199,6 +206,7 @@ export function createServer() {
                 compareSpendTool,
                 listOptimizationRecommendationsTool,
                 getInsightResourcesTool,
+                getInsightTool,
                 getReportResultsTool,
                 getReportConfigTool,
                 createReportTool,
@@ -242,6 +250,7 @@ export function createServer() {
                 getFolderTool,
                 listThemesTool,
                 getThemeTool,
+                getActiveThemeTool,
                 getAwsAccountTool,
                 getCloudConnectSupportedFeaturesTool,
                 listDatahubDatasetsTool,
@@ -377,6 +386,7 @@ export {
     handleDimensionsRequest,
     handleFindCloudDiagramsRequest,
     handleGeneralError,
+    handleGetActiveThemeRequest,
     handleGetAlertRequest,
     handleGetAllocationRequest,
     handleGetAnnotationRequest,

--- a/src/tools/__tests__/insights.test.ts
+++ b/src/tools/__tests__/insights.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeDoitRequest } from "../../utils/util.js";
+import { getInsightTool, handleGetInsightRequest, INSIGHTS_BASE_URL } from "../insights.js";
+
+vi.mock("../../utils/util.js", async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, makeDoitRequest: vi.fn() };
+});
+
+beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+const mockInsight = {
+    key: "delete-ebs-volumes",
+    source: "aws-cost-optimization-hub",
+    title: "Delete unattached EBS volumes",
+    shortDescription: "Remove idle EBS volumes to reduce cost.",
+    displayStatus: "actionable",
+    categories: ["FinOps"],
+    summary: {
+        potentialDailySavings: 12.5,
+        securityRisks: 0,
+    },
+    lastUpdated: "2026-06-01T00:00:00.000Z",
+};
+
+describe("getInsightTool metadata", () => {
+    it("should be read-only and named get_insight", () => {
+        expect(getInsightTool.annotations.readOnlyHint).toBe(true);
+        expect(getInsightTool.name).toBe("get_insight");
+    });
+});
+
+describe("get_insight", () => {
+    const mockToken = "fake-token";
+
+    it("should call makeDoitRequest with the source/key URL and return the insight", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockInsight);
+
+        const response = await handleGetInsightRequest(
+            { source: "aws-cost-optimization-hub", key: "delete-ebs-volumes" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${INSIGHTS_BASE_URL}/results/source/aws-cost-optimization-hub/insight/delete-ebs-volumes`,
+            mockToken,
+            { method: "GET", customerContext: undefined }
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.key).toBe("delete-ebs-volumes");
+        expect(parsed.source).toBe("aws-cost-optimization-hub");
+        expect(parsed.summary.potentialDailySavings).toBe(12.5);
+    });
+
+    it("should url-encode source and key path segments", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockInsight);
+
+        await handleGetInsightRequest({ source: "custom source", key: "a/b" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${INSIGHTS_BASE_URL}/results/source/custom%20source/insight/a%2Fb`,
+            mockToken,
+            { method: "GET", customerContext: undefined }
+        );
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockInsight);
+
+        await handleGetInsightRequest(
+            { source: "aws-cost-optimization-hub", key: "delete-ebs-volumes", customerContext: "customer-123" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${INSIGHTS_BASE_URL}/results/source/aws-cost-optimization-hub/insight/delete-ebs-volumes`,
+            mockToken,
+            { method: "GET", customerContext: "customer-123" }
+        );
+    });
+
+    it("should return a validation error when source or key is missing", async () => {
+        const response = await handleGetInsightRequest({ source: "aws-cost-optimization-hub" }, mockToken);
+
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleGetInsightRequest(
+            { source: "aws-cost-optimization-hub", key: "delete-ebs-volumes" },
+            mockToken
+        );
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("delete-ebs-volumes");
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleGetInsightRequest(
+            { source: "aws-cost-optimization-hub", key: "delete-ebs-volumes" },
+            mockToken
+        );
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
+    });
+});

--- a/src/tools/__tests__/themes.test.ts
+++ b/src/tools/__tests__/themes.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
 import {
+    ACTIVE_THEME_URL,
+    getActiveThemeTool,
     getThemeTool,
+    handleGetActiveThemeRequest,
     handleGetThemeRequest,
     handleListThemesRequest,
     listThemesTool,
@@ -194,5 +197,72 @@ describe("get_theme", () => {
     it("should have correct tool name and be read-only", () => {
         expect(getThemeTool.name).toBe("get_theme");
         expect(getThemeTool.annotations.readOnlyHint).toBe(true);
+    });
+});
+
+describe("getActiveThemeTool metadata", () => {
+    it("should be read-only and named get_active_theme", () => {
+        expect(getActiveThemeTool.annotations.readOnlyHint).toBe(true);
+        expect(getActiveThemeTool.name).toBe("get_active_theme");
+    });
+});
+
+describe("get_active_theme", () => {
+    const mockToken = "fake-token";
+
+    it("should call makeDoitRequest with the active-theme URL and return the active theme", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "theme-1" });
+
+        const response = await handleGetActiveThemeRequest({}, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(ACTIVE_THEME_URL, mockToken, {
+            method: "GET",
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.themeId).toBe("theme-1");
+    });
+
+    it("should return the default sentinel when no custom theme is active", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "default" });
+
+        const response = await handleGetActiveThemeRequest({}, mockToken);
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.themeId).toBe("default");
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "theme-1" });
+
+        await handleGetActiveThemeRequest({ customerContext: "customer-123" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(ACTIVE_THEME_URL, mockToken, {
+            method: "GET",
+            customerContext: "customer-123",
+        });
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleGetActiveThemeRequest({}, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("active theme") }],
+            isError: true,
+        });
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleGetActiveThemeRequest({}, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
     });
 });

--- a/src/tools/insights.ts
+++ b/src/tools/insights.ts
@@ -116,6 +116,19 @@ export const GetInsightResourcesArgumentsSchema = z.object({
         ),
 });
 
+export const GetInsightArgumentsSchema = z.object({
+    source: z
+        .string()
+        .describe(
+            "The source of the insight (e.g. 'aws-cost-optimization-hub', 'aws-trusted-advisor'). Use the 'source' field from list_optimization_recommendations."
+        ),
+    key: z
+        .string()
+        .describe(
+            "The key of the insight (e.g. 'delete-ebs-volumes'). Use the 'key' field from list_optimization_recommendations."
+        ),
+});
+
 // ── Tool metadata ───────────────────────────────────────────────────────────
 
 export const listOptimizationRecommendationsTool = {
@@ -155,6 +168,27 @@ export const getInsightResourcesTool = {
     _meta: {
         "openai/toolInvocation/invoking": "Loading insight resources...",
         "openai/toolInvocation/invoked": "Insight resources ready",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export const getInsightTool = {
+    name: "get_insight",
+    description:
+        "Use this when the user wants the details and aggregate summary (savings, risk counts, status, " +
+        "description) of a single optimization insight identified by its source and key. Returns the " +
+        "insight metadata only — it does NOT include the individual affected resources (use " +
+        "get_insight_resources for those) and is not for listing all insights (use " +
+        "list_optimization_recommendations).",
+    inputSchema: zodToMcpInputSchema(GetInsightArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Loading insight...",
+        "openai/toolInvocation/invoked": "Insight ready",
     },
     securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
 };
@@ -276,5 +310,34 @@ export async function handleGetInsightResourcesRequest(args: any, token: string)
             return createErrorResponse(formatZodError(error));
         }
         return handleGeneralError(error, "handling get_insight_resources request");
+    }
+}
+
+export async function handleGetInsightRequest(args: any, token: string) {
+    try {
+        const { source, key } = GetInsightArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const insightUrl = `${INSIGHTS_BASE_URL}/results/source/${encodeURIComponent(source)}/insight/${encodeURIComponent(key)}`;
+
+        try {
+            const data = await makeDoitRequest<InsightResult>(insightUrl, token, {
+                method: "GET",
+                customerContext,
+            });
+
+            if (!data) {
+                return createErrorResponse(`Failed to retrieve insight ${key} (source: ${source})`);
+            }
+
+            return createSuccessResponse(JSON.stringify(data, null, 2));
+        } catch (error) {
+            return handleGeneralError(error, "making DoiT Insights API request");
+        }
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(formatZodError(error));
+        }
+        return handleGeneralError(error, "handling get_insight request");
     }
 }

--- a/src/tools/themes.ts
+++ b/src/tools/themes.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CustomTheme, ThemesResponse } from "../types/themes.js";
+import type { ActiveTheme, CustomTheme, ThemesResponse } from "../types/themes.js";
 import { zodToMcpInputSchema } from "../utils/schemaHelpers.js";
 import {
     createErrorResponse,
@@ -12,6 +12,7 @@ import {
 } from "../utils/util.js";
 
 export const THEMES_BASE_URL = `${DOIT_API_BASE}/analytics/v1/settings/themes`;
+export const ACTIVE_THEME_URL = `${DOIT_API_BASE}/analytics/v1/settings/active-theme`;
 
 // Schema and metadata for list themes
 export const ListThemesArgumentsSchema = z.object({});
@@ -122,5 +123,46 @@ export async function handleGetThemeRequest(args: any, token: string) {
     } catch (error) {
         if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
         return handleGeneralError(error, "handling get theme request");
+    }
+}
+
+// Schema and metadata for get active theme
+export const GetActiveThemeArgumentsSchema = z.object({});
+
+export const getActiveThemeTool = {
+    name: "get_active_theme",
+    description:
+        'Use this when the user wants to know which color theme is currently active for their account (the theme applied to Cloud Analytics reports). Returns the active theme id; the reserved sentinel "default" means no custom or preset theme is selected and the built-in default is in use. Do NOT use this to list all themes (use list_themes) or to fetch a specific theme by id (use get_theme).',
+    inputSchema: zodToMcpInputSchema(GetActiveThemeArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Loading active theme...",
+        "openai/toolInvocation/invoked": "Active theme loaded",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export async function handleGetActiveThemeRequest(args: any, token: string) {
+    try {
+        GetActiveThemeArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const data = await makeDoitRequest<ActiveTheme>(ACTIVE_THEME_URL, token, {
+            method: "GET",
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to retrieve active theme");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling get active theme request");
     }
 }

--- a/src/types/themes.ts
+++ b/src/types/themes.ts
@@ -16,3 +16,11 @@ export type ThemesResponse = {
     rowCount?: number;
     themes: CustomTheme[];
 };
+
+export type ActiveTheme = {
+    /**
+     * Identifier of the active theme. The reserved sentinel "default" is returned
+     * when the user is using the built-in default (no custom or preset theme stored).
+     */
+    themeId: string;
+};

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -43,7 +43,11 @@ import { handleSendDatahubEventsRequest } from "../tools/datahubEvents.js";
 import { handleDimensionRequest } from "../tools/dimension.js";
 import { handleDimensionsRequest } from "../tools/dimensions.js";
 import { handleGetFolderRequest, handleListFoldersRequest } from "../tools/folders.js";
-import { handleGetInsightResourcesRequest, handleListInsightsRequest } from "../tools/insights.js";
+import {
+    handleGetInsightRequest,
+    handleGetInsightResourcesRequest,
+    handleListInsightsRequest,
+} from "../tools/insights.js";
 import { handleGetInvoiceRequest, handleListInvoicesRequest } from "../tools/invoices.js";
 import {
     handleAssignObjectsToLabelRequest,
@@ -72,7 +76,7 @@ import {
     handleUpdateReportRequest,
 } from "../tools/reports.js";
 import { handleListRolesRequest } from "../tools/roles.js";
-import { handleGetThemeRequest, handleListThemesRequest } from "../tools/themes.js";
+import { handleGetActiveThemeRequest, handleGetThemeRequest, handleListThemesRequest } from "../tools/themes.js";
 import {
     // createTicketTool, // Re-enable alongside the WRITE_GATED_SUMMARIES entry below.
     handleCreateTicketCommentRequest,
@@ -254,6 +258,9 @@ async function runOriginalDispatch(toolName: string, args: any, token: string): 
         case "get_insight_resources":
             result = await handleGetInsightResourcesRequest(args, token);
             break;
+        case "get_insight":
+            result = await handleGetInsightRequest(args, token);
+            break;
         case "get_report_results":
             result = await handleGetReportResultsRequest(args, token);
             break;
@@ -389,6 +396,9 @@ async function runOriginalDispatch(toolName: string, args: any, token: string): 
             break;
         case "get_theme":
             result = await handleGetThemeRequest(args, token);
+            break;
+        case "get_active_theme":
+            result = await handleGetActiveThemeRequest(args, token);
             break;
         case "list_datahub_datasets":
             result = await handleListDatahubDatasetsRequest(args, token);

--- a/test/integration/fixtures/analytics.ts
+++ b/test/integration/fixtures/analytics.ts
@@ -499,3 +499,28 @@ export const commitmentFixture = {
     createTime: 1735689600000,
     updateTime: 1750032000000,
 };
+
+export const activeThemeFixture = {
+    themeId: "theme-1",
+};
+
+export const insightFixture = {
+    key: "delete-ebs-volumes",
+    source: "aws-cost-optimization-hub",
+    title: "Delete unattached EBS volumes",
+    shortDescription: "Remove idle EBS volumes to reduce cost.",
+    detailedDescriptionMdx: "Unattached EBS volumes continue to incur storage charges.",
+    displayStatus: "actionable",
+    cloudProvider: "aws",
+    categories: ["FinOps"],
+    summary: {
+        operationalRisks: 0,
+        performanceRisks: 0,
+        potentialDailySavings: 12.5,
+        reliabilityRisks: 0,
+        securityRisks: 0,
+        sustainabilityRisks: 0,
+    },
+    lastUpdated: "2026-06-01T00:00:00.000Z",
+    tags: [],
+};

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -1,4 +1,5 @@
 import {
+    activeThemeFixture,
     alertFixture,
     alertsFixture,
     allocationFixture,
@@ -17,6 +18,7 @@ import {
     createReportFixture,
     dimensionFixture,
     dimensionsFixture,
+    insightFixture,
     labelAssignmentsFixture,
     labelFixture,
     labelsFixture,
@@ -138,6 +140,9 @@ export const fixtures = {
 
     commitment: commitmentFixture,
     commitments: commitmentsFixture,
+
+    activeTheme: activeThemeFixture,
+    insight: insightFixture,
 
     avaAskSync: avaAskSyncFixture,
     avaAskSyncWithConversation: avaAskSyncWithConversationFixture,

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -316,6 +316,19 @@ export const mockedDoitApiHandlers = [
         return HttpResponse.json(fixtures.commitments);
     }),
 
+    // Themes (active)
+    http.get(`${API_BASE}/analytics/v1/settings/active-theme`, () => {
+        return HttpResponse.json(fixtures.activeTheme);
+    }),
+
+    // Insights (retrieve a single insight by source + key)
+    http.get(`${API_BASE}/insights/v1/results/source/:source/insight/:key`, ({ params }) => {
+        if (params.source === "aws-cost-optimization-hub" && params.key === "delete-ebs-volumes") {
+            return HttpResponse.json(fixtures.insight);
+        }
+        return new HttpResponse(null, { status: 404 });
+    }),
+
     // AVA
     http.post(`${API_BASE}/ava/v1/askSync`, async ({ request }) => {
         const body = (await request.json()) as Record<string, unknown>;

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -59,9 +59,11 @@ describe("MCP Tools Integration", () => {
                     "get_cloud_incidents",
                     "get_cloud_overview",
                     "get_commitment",
+                    "get_active_theme",
                     "get_datahub_dataset",
                     "get_dimension",
                     "get_folder",
+                    "get_insight",
                     "get_insight_resources",
                     "get_invoice",
                     "get_label",
@@ -234,6 +236,38 @@ describe("MCP Tools Integration", () => {
             const result = await client.callTool({
                 name: "get_resource_permissions",
                 arguments: { resourceType: "widgets", resourceId: "budget-1" },
+            });
+            expect(result.isError).toBe(true);
+        });
+    });
+
+    describe("get_active_theme", () => {
+        it("returns the active theme id from the mock API", async () => {
+            const result = await client.callTool({ name: "get_active_theme", arguments: {} });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.themeId).toBe("theme-1");
+        });
+    });
+
+    describe("get_insight", () => {
+        it("returns a single insight by source and key", async () => {
+            const result = await client.callTool({
+                name: "get_insight",
+                arguments: { source: "aws-cost-optimization-hub", key: "delete-ebs-volumes" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.key).toBe("delete-ebs-volumes");
+            expect(parsed.source).toBe("aws-cost-optimization-hub");
+            expect(parsed.title).toBe("Delete unattached EBS volumes");
+            expect(parsed.summary.potentialDailySavings).toBe(12.5);
+        });
+
+        it("returns a validation error when key is missing", async () => {
+            const result = await client.callTool({
+                name: "get_insight",
+                arguments: { source: "aws-cost-optimization-hub" },
             });
             expect(result.isError).toBe(true);
         });


### PR DESCRIPTION
## Summary

Adds **2** read-only DoiT API endpoints to the MCP server, registered in **both** the local stdio MCP (`src/server.ts`) and the remote Cloudflare Worker MCP (`doit-mcp-server/src/index.ts`):

| Tool | Method | Path | Category |
|------|--------|------|----------|
| `get_active_theme` | GET | `/analytics/v1/settings/active-theme` | Themes (partially covered → completes read coverage) |
| `get_insight` | GET | `/insights/v1/results/source/{sourceID}/insight/{insightKey}` | Insights (partially covered → completes read coverage) |

`get_active_theme` returns the theme currently active for the user (`themeId`; the sentinel `"default"` means the built-in default is in use). `get_insight` returns the metadata + aggregate summary (savings, risk counts, status) for a single insight identified by `source` + `key` — complementing the existing `get_insight_resources` (resource-level) and `list_optimization_recommendations` (list) tools.

## API references
- Get the active theme: https://developer.doit.com/reference/getactivetheme
- Retrieve an insight: https://developer.doit.com/reference/getinsightresult

## Related work
- Themes API coverage (list/get): [#179](https://github.com/doitintl/doit-mcp-server/pull/179)
- Most recent API-coverage PR (pattern reference): [#188](https://github.com/doitintl/doit-mcp-server/pull/188)

## Changes
- `src/tools/themes.ts`: `get_active_theme` tool + handler, `ACTIVE_THEME_URL`
- `src/tools/insights.ts`: `get_insight` tool + handler
- `src/types/themes.ts`: `ActiveTheme` type
- `src/utils/toolsHandler.ts`: dispatch cases (shared by local + remote)
- `src/server.ts` (local) + `doit-mcp-server/src/index.ts` (remote): registration
- Unit tests: `src/tools/__tests__/themes.test.ts`, new `src/tools/__tests__/insights.test.ts`
- Integration tests: fixtures (`analytics.ts`, `fixtures/index.ts`), MSW handlers (`mockedDoitApi/index.ts`), tool-call tests + sorted `tools/list` assertion (`stdio/tools.test.ts`); `src/__tests__/server.test.ts` kept in sync
- `README.md`: documented both tools

## Verification
- [x] `yarn check:dev` (type-check + lint)
- [x] `yarn test` (804 passed)
- [x] integration tests (`test/integration`, 133 passed)
- [x] `yarn build`

## Reviewer checklist
- [ ] Request/response schemas match the API reference (`ActiveTheme.themeId`; `InsightResponse` summary/status fields)
- [ ] Registered in **both** `src/server.ts` (local) and `doit-mcp-server/src/index.ts` (remote)
- [ ] Auth/permission scope (`read_data`) correct
- [ ] Test coverage (unit + integration) adequate
- [x] No DELETE endpoints; ≤2 endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)