### PR TITLE
feat(clouddiagrams): add list_cloud_diagram_layer_snapshots and get_cloud_diagram_layer_snapshot tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ This MCP server provides many tools including the following:
 - [`find_cloud_diagrams`](https://developer.doit.com/reference/findclouddiagrams): Returns diagram URLs matching the provided resource IDs from the DoiT Cloud Diagrams API
 - [`get_cloud_diagrams_stats`](https://developer.doit.com/reference/getclouddiagramsstats): Returns activity statistics for your cloud diagrams over a time period (`start`/`end` RFC3339 date-times) — node create/update/delete change counts grouped by cloud service, plus each diagram's import/sync state
 - [`search_cloud_diagrams`](https://developer.doit.com/reference/searchclouddiagrams): Searches your cloud diagrams and components by name or property, returning matching layers (`scheme`), components, and property-matched components (`prop`); optionally scope to a layer with `ss_id` and page with `from`/`size`
+- [`list_cloud_diagram_layer_snapshots`](https://developer.doit.com/reference/listclouddiagramlayersnapshots): Lists the saved snapshots (version history) of a cloud diagram layer (`id`), returning each snapshot's `_id`, `name`, `created_at`, and `prev_state`; optionally page with `offset`/`limit` and order with `sort`
+- [`get_cloud_diagram_layer_snapshot`](https://developer.doit.com/reference/getclouddiagramlayersnapshot): Returns a single cloud diagram layer snapshot by layer `id` and `snapshot_id`
 - [`list_reports`](https://developer.doit.com/reference/listreports): Lists Cloud Analytics reports that your account has access to
 - [`run_query`](https://developer.doit.com/reference/query): Runs a report query with the specified configuration without persisting it
 - [`get_report_results`](https://developer.doit.com/reference/getreport): Get the results of a specific report by ID

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -192,8 +192,12 @@ import {
 import {
   FindCloudDiagramsArgumentsSchema,
   findCloudDiagramsTool,
+  GetCloudDiagramLayerSnapshotArgumentsSchema,
+  getCloudDiagramLayerSnapshotTool,
   GetCloudDiagramsStatsArgumentsSchema,
   getCloudDiagramsStatsTool,
+  ListCloudDiagramLayerSnapshotsArgumentsSchema,
+  listCloudDiagramLayerSnapshotsTool,
   SearchCloudDiagramsArgumentsSchema,
   searchCloudDiagramsTool,
 } from "../../src/tools/cloudDiagrams.js";
@@ -984,6 +988,8 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(findCloudDiagramsTool, FindCloudDiagramsArgumentsSchema);
     this.registerTool(getCloudDiagramsStatsTool, GetCloudDiagramsStatsArgumentsSchema);
     this.registerTool(searchCloudDiagramsTool, SearchCloudDiagramsArgumentsSchema);
+    this.registerTool(listCloudDiagramLayerSnapshotsTool, ListCloudDiagramLayerSnapshotsArgumentsSchema);
+    this.registerTool(getCloudDiagramLayerSnapshotTool, GetCloudDiagramLayerSnapshotArgumentsSchema);
 
     // Budgets tools
     this.registerTool(listBudgetsTool, ListBudgetsArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -228,7 +228,13 @@ import { getAssetTool, listAssetsTool } from "../tools/assets.js";
 import { askAvaSyncTool } from "../tools/ava.js";
 import { getAwsAccountTool, getCloudConnectSupportedFeaturesTool } from "../tools/awsAccounts.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "../tools/budgets.js";
-import { findCloudDiagramsTool, getCloudDiagramsStatsTool, searchCloudDiagramsTool } from "../tools/cloudDiagrams.js";
+import {
+    findCloudDiagramsTool,
+    getCloudDiagramLayerSnapshotTool,
+    getCloudDiagramsStatsTool,
+    listCloudDiagramLayerSnapshotsTool,
+    searchCloudDiagramsTool,
+} from "../tools/cloudDiagrams.js";
 import { triggerCloudFlowTool } from "../tools/cloudflow.js";
 import { cloudIncidentsTool, cloudIncidentTool } from "../tools/cloudIncidents.js";
 import { getCommitmentTool, listCommitmentsTool } from "../tools/commitmentManager.js";
@@ -396,6 +402,8 @@ describe("ListToolsRequestSchema handler", () => {
                 findCloudDiagramsTool,
                 getCloudDiagramsStatsTool,
                 searchCloudDiagramsTool,
+                listCloudDiagramLayerSnapshotsTool,
+                getCloudDiagramLayerSnapshotTool,
                 listBudgetsTool,
                 getBudgetTool,
                 createBudgetTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,10 +62,14 @@ import {
 } from "./tools/budgets.js";
 import {
     findCloudDiagramsTool,
+    getCloudDiagramLayerSnapshotTool,
     getCloudDiagramsStatsTool,
     handleFindCloudDiagramsRequest,
+    handleGetCloudDiagramLayerSnapshotRequest,
     handleGetCloudDiagramsStatsRequest,
+    handleListCloudDiagramLayerSnapshotsRequest,
     handleSearchCloudDiagramsRequest,
+    listCloudDiagramLayerSnapshotsTool,
     searchCloudDiagramsTool,
 } from "./tools/cloudDiagrams.js";
 import { handleTriggerCloudFlowRequest, triggerCloudFlowTool } from "./tools/cloudflow.js";
@@ -268,6 +272,8 @@ export function createServer() {
                 findCloudDiagramsTool,
                 getCloudDiagramsStatsTool,
                 searchCloudDiagramsTool,
+                listCloudDiagramLayerSnapshotsTool,
+                getCloudDiagramLayerSnapshotTool,
                 listBudgetsTool,
                 getBudgetTool,
                 createBudgetTool,
@@ -403,6 +409,7 @@ export {
     handleGetAwsAccountRequest,
     handleGetBudgetRequest,
     handleGetCloudConnectSupportedFeaturesRequest,
+    handleGetCloudDiagramLayerSnapshotRequest,
     handleGetCloudDiagramsStatsRequest,
     handleGetCommitmentRequest,
     handleGetDatahubDatasetRequest,
@@ -422,6 +429,7 @@ export {
     handleListAnnotationsRequest,
     handleListAssetsRequest,
     handleListBudgetsRequest,
+    handleListCloudDiagramLayerSnapshotsRequest,
     handleListCommitmentsRequest,
     handleListDatahubDatasetsRequest,
     handleListFoldersRequest,

--- a/src/tools/__tests__/cloudDiagrams.test.ts
+++ b/src/tools/__tests__/cloudDiagrams.test.ts
@@ -2,10 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
 import {
     CLOUD_DIAGRAMS_BASE_URL,
+    CLOUD_DIAGRAMS_LAYERS_URL,
     CLOUD_DIAGRAMS_SEARCH_URL,
     CLOUD_DIAGRAMS_STATS_URL,
     handleFindCloudDiagramsRequest,
+    handleGetCloudDiagramLayerSnapshotRequest,
     handleGetCloudDiagramsStatsRequest,
+    handleListCloudDiagramLayerSnapshotsRequest,
     handleSearchCloudDiagramsRequest,
 } from "../cloudDiagrams.js";
 
@@ -237,5 +240,129 @@ describe("search_cloud_diagrams", () => {
 
         expect(response.isError).toBe(true);
         expect(response.content[0].text).toContain("search query string is required");
+    });
+});
+
+describe("list_cloud_diagram_layer_snapshots", () => {
+    const mockToken = "fake-token";
+
+    const mockSnapshots = [
+        { _id: "snap-2", name: "After EC2 add", created_at: "2026-04-28T10:00:00Z", prev_state: "snap-1" },
+        { _id: "snap-1", name: "Initial", created_at: "2026-04-27T10:00:00Z", prev_state: "" },
+    ];
+
+    it("should call makeDoitRequest with the layer snapshots URL and return snapshots", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockSnapshots);
+
+        const response = await handleListCloudDiagramLayerSnapshotsRequest({ id: "layer-1" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${CLOUD_DIAGRAMS_LAYERS_URL}/layer-1/snapshots`, mockToken, {
+            method: "GET",
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0]._id).toBe("snap-2");
+        expect(parsed[1].prev_state).toBe("");
+    });
+
+    it("should include offset, limit and sort query params and pass customerContext", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockSnapshots);
+
+        await handleListCloudDiagramLayerSnapshotsRequest(
+            { id: "layer-1", offset: 5, limit: 20, sort: "-createdAt", customerContext: "customer-123" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${CLOUD_DIAGRAMS_LAYERS_URL}/layer-1/snapshots?offset=5&limit=20&sort=-createdAt`,
+            mockToken,
+            { method: "GET", customerContext: "customer-123" }
+        );
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleListCloudDiagramLayerSnapshotsRequest({ id: "layer-1" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("layer snapshots") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when layer id is missing", async () => {
+        const response = await handleListCloudDiagramLayerSnapshotsRequest({ id: "" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("layer ID is required");
+    });
+});
+
+describe("get_cloud_diagram_layer_snapshot", () => {
+    const mockToken = "fake-token";
+
+    const mockSnapshot = {
+        _id: "snap-1",
+        name: "Initial",
+        created_at: "2026-04-27T10:00:00Z",
+        prev_state: "",
+    };
+
+    it("should call makeDoitRequest with the single snapshot URL and return the snapshot", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockSnapshot);
+
+        const response = await handleGetCloudDiagramLayerSnapshotRequest(
+            { id: "layer-1", snapshot_id: "snap-1" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${CLOUD_DIAGRAMS_LAYERS_URL}/layer-1/snapshots/snap-1`,
+            mockToken,
+            { method: "GET", customerContext: undefined }
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed._id).toBe("snap-1");
+        expect(parsed.name).toBe("Initial");
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockSnapshot);
+
+        await handleGetCloudDiagramLayerSnapshotRequest(
+            { id: "layer-1", snapshot_id: "snap-1", customerContext: "customer-123" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${CLOUD_DIAGRAMS_LAYERS_URL}/layer-1/snapshots/snap-1`,
+            mockToken,
+            { method: "GET", customerContext: "customer-123" }
+        );
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleGetCloudDiagramLayerSnapshotRequest(
+            { id: "layer-1", snapshot_id: "snap-1" },
+            mockToken
+        );
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("layer snapshot") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when snapshot id is missing", async () => {
+        const response = await handleGetCloudDiagramLayerSnapshotRequest({ id: "layer-1", snapshot_id: "" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("snapshot ID is required");
     });
 });

--- a/src/tools/cloudDiagrams.ts
+++ b/src/tools/cloudDiagrams.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import type {
     FindCloudDiagramsResponse,
+    GetCloudDiagramLayerSnapshotResponse,
     GetCloudDiagramsStatsResponse,
+    ListCloudDiagramLayerSnapshotsResponse,
     SearchCloudDiagramsResponse,
 } from "../types/cloudDiagrams.js";
 import { zodToMcpInputSchema } from "../utils/schemaHelpers.js";
@@ -17,6 +19,7 @@ import {
 export const CLOUD_DIAGRAMS_BASE_URL = `${DOIT_API_BASE}/clouddiagrams/v1/scheme/find`;
 export const CLOUD_DIAGRAMS_STATS_URL = `${DOIT_API_BASE}/clouddiagrams/v1/scheme/stats`;
 export const CLOUD_DIAGRAMS_SEARCH_URL = `${DOIT_API_BASE}/clouddiagrams/v1/scheme/search`;
+export const CLOUD_DIAGRAMS_LAYERS_URL = `${DOIT_API_BASE}/clouddiagrams/v1/layers`;
 
 export const FindCloudDiagramsArgumentsSchema = z.object({
     resources: z
@@ -169,5 +172,107 @@ export async function handleSearchCloudDiagramsRequest(args: any, token: string)
     } catch (error) {
         if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
         return handleGeneralError(error, "handling search cloud diagrams request");
+    }
+}
+
+export const ListCloudDiagramLayerSnapshotsArgumentsSchema = z.object({
+    id: z.string().min(1, "A layer ID is required.").describe("Layer ID to list snapshots for."),
+    offset: z.number().int().min(0).optional().describe("Number of snapshots to skip (default 0)."),
+    limit: z.number().int().min(1).optional().describe("Maximum number of snapshots to return (default 10)."),
+    sort: z.string().optional().describe('Sort expression, e.g. "-createdAt" for descending.'),
+});
+
+export const listCloudDiagramLayerSnapshotsTool = {
+    name: "list_cloud_diagram_layer_snapshots",
+    description:
+        "Use this when the user wants the saved snapshots (version history) of a specific cloud diagram layer. Returns each snapshot's id, name, creation time, and the previous snapshot in the chain. Requires the layer ID; optionally page with offset/limit and order with sort.",
+    inputSchema: zodToMcpInputSchema(ListCloudDiagramLayerSnapshotsArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Listing layer snapshots...",
+        "openai/toolInvocation/invoked": "Layer snapshots retrieved",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export async function handleListCloudDiagramLayerSnapshotsRequest(args: any, token: string) {
+    try {
+        const { id, offset, limit, sort } = ListCloudDiagramLayerSnapshotsArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const params = new URLSearchParams();
+        if (offset !== undefined) params.append("offset", offset.toString());
+        if (limit !== undefined) params.append("limit", limit.toString());
+        if (sort !== undefined) params.append("sort", sort);
+
+        const queryString = params.toString();
+        const url = `${CLOUD_DIAGRAMS_LAYERS_URL}/${encodeURIComponent(id)}/snapshots${
+            queryString ? `?${queryString}` : ""
+        }`;
+
+        const data = await makeDoitRequest<ListCloudDiagramLayerSnapshotsResponse>(url, token, {
+            method: "GET",
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to retrieve cloud diagram layer snapshots");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling list cloud diagram layer snapshots request");
+    }
+}
+
+export const GetCloudDiagramLayerSnapshotArgumentsSchema = z.object({
+    id: z.string().min(1, "A layer ID is required.").describe("Layer ID the snapshot belongs to."),
+    snapshot_id: z.string().min(1, "A snapshot ID is required.").describe("Snapshot ID to retrieve."),
+});
+
+export const getCloudDiagramLayerSnapshotTool = {
+    name: "get_cloud_diagram_layer_snapshot",
+    description:
+        "Use this when the user wants a single saved snapshot of a cloud diagram layer by its snapshot ID. Returns the snapshot's id, name, creation time, and previous snapshot in the chain. Requires both the layer ID and the snapshot ID.",
+    inputSchema: zodToMcpInputSchema(GetCloudDiagramLayerSnapshotArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Fetching layer snapshot...",
+        "openai/toolInvocation/invoked": "Layer snapshot retrieved",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export async function handleGetCloudDiagramLayerSnapshotRequest(args: any, token: string) {
+    try {
+        const { id, snapshot_id } = GetCloudDiagramLayerSnapshotArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const url = `${CLOUD_DIAGRAMS_LAYERS_URL}/${encodeURIComponent(id)}/snapshots/${encodeURIComponent(
+            snapshot_id
+        )}`;
+
+        const data = await makeDoitRequest<GetCloudDiagramLayerSnapshotResponse>(url, token, {
+            method: "GET",
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to retrieve cloud diagram layer snapshot");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling get cloud diagram layer snapshot request");
     }
 }

--- a/src/types/cloudDiagrams.ts
+++ b/src/types/cloudDiagrams.ts
@@ -69,3 +69,17 @@ export type SearchCloudDiagramsResponse = {
     component?: CloudDiagramComponentSearchItem[];
     prop?: CloudDiagramComponentSearchItem[];
 };
+
+// Cloud diagram layer snapshots
+// List — GET /clouddiagrams/v1/layers/{id}/snapshots
+// Get  — GET /clouddiagrams/v1/layers/{id}/snapshots/{snapshot_id}
+export type CloudDiagramLayerSnapshot = {
+    _id: string;
+    created_at?: string;
+    name?: string;
+    prev_state?: string;
+};
+
+export type ListCloudDiagramLayerSnapshotsResponse = CloudDiagramLayerSnapshot[];
+
+export type GetCloudDiagramLayerSnapshotResponse = CloudDiagramLayerSnapshot;

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -30,7 +30,9 @@ import {
 } from "../tools/budgets.js";
 import {
     handleFindCloudDiagramsRequest,
+    handleGetCloudDiagramLayerSnapshotRequest,
     handleGetCloudDiagramsStatsRequest,
+    handleListCloudDiagramLayerSnapshotsRequest,
     handleSearchCloudDiagramsRequest,
 } from "../tools/cloudDiagrams.js";
 import { handleTriggerCloudFlowRequest } from "../tools/cloudflow.js";
@@ -427,6 +429,12 @@ async function runOriginalDispatch(toolName: string, args: any, token: string): 
             break;
         case "search_cloud_diagrams":
             result = await handleSearchCloudDiagramsRequest(args, token);
+            break;
+        case "list_cloud_diagram_layer_snapshots":
+            result = await handleListCloudDiagramLayerSnapshotsRequest(args, token);
+            break;
+        case "get_cloud_diagram_layer_snapshot":
+            result = await handleGetCloudDiagramLayerSnapshotRequest(args, token);
             break;
         case "list_budgets":
             result = await handleListBudgetsRequest(args, token);

--- a/test/integration/fixtures/cloudDiagrams.ts
+++ b/test/integration/fixtures/cloudDiagrams.ts
@@ -32,6 +32,28 @@ export const cloudDiagramsStatsFixture = [
     },
 ];
 
+export const cloudDiagramLayerSnapshotsFixture = [
+    {
+        _id: "snap-2",
+        name: "After EC2 add",
+        created_at: "2026-04-28T10:00:00Z",
+        prev_state: "snap-1",
+    },
+    {
+        _id: "snap-1",
+        name: "Initial",
+        created_at: "2026-04-27T10:00:00Z",
+        prev_state: "",
+    },
+];
+
+export const cloudDiagramLayerSnapshotFixture = {
+    _id: "snap-1",
+    name: "Initial",
+    created_at: "2026-04-27T10:00:00Z",
+    prev_state: "",
+};
+
 export const cloudDiagramsSearchFixture = {
     scheme: [
         {

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -36,7 +36,13 @@ import {
 import { anomaliesFixture, anomalyFixture } from "./anomalies.js";
 import { avaAskSyncFixture, avaAskSyncWithConversationFixture } from "./ava.js";
 import { assetDetailedFixture, assetsFixture, invoiceFixture, invoicesFixture } from "./billing.js";
-import { cloudDiagramsFixture, cloudDiagramsSearchFixture, cloudDiagramsStatsFixture } from "./cloudDiagrams.js";
+import {
+    cloudDiagramLayerSnapshotFixture,
+    cloudDiagramLayerSnapshotsFixture,
+    cloudDiagramsFixture,
+    cloudDiagramsSearchFixture,
+    cloudDiagramsStatsFixture,
+} from "./cloudDiagrams.js";
 import { cloudflowTriggerFixture } from "./cloudflow.js";
 import { cloudIncidentFixture, cloudIncidentsFixture } from "./cloudIncidents.js";
 import {
@@ -115,6 +121,8 @@ export const fixtures = {
     cloudDiagrams: cloudDiagramsFixture,
     cloudDiagramsStats: cloudDiagramsStatsFixture,
     cloudDiagramsSearch: cloudDiagramsSearchFixture,
+    cloudDiagramLayerSnapshots: cloudDiagramLayerSnapshotsFixture,
+    cloudDiagramLayerSnapshot: cloudDiagramLayerSnapshotFixture,
 
     datahubDatasets: datahubDatasetsFixture,
     datahubDataset: datahubDatasetFixture,

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -285,6 +285,13 @@ export const mockedDoitApiHandlers = [
     http.post(`${API_BASE}/clouddiagrams/v1/scheme/search`, () => {
         return HttpResponse.json(fixtures.cloudDiagramsSearch);
     }),
+    // Register the single-snapshot path before the list path so the more specific route wins.
+    http.get(`${API_BASE}/clouddiagrams/v1/layers/:id/snapshots/:snapshotId`, () => {
+        return HttpResponse.json(fixtures.cloudDiagramLayerSnapshot);
+    }),
+    http.get(`${API_BASE}/clouddiagrams/v1/layers/:id/snapshots`, () => {
+        return HttpResponse.json(fixtures.cloudDiagramLayerSnapshots);
+    }),
 
     // CloudFlow trigger
     http.post(`${API_BASE}/cloudflow/v1/trigger/:flowId`, () => {

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -47,7 +47,9 @@ describe("MCP Tools Integration", () => {
                     "create_ticket_comment",
                     "find_cloud_diagrams",
                     "get_alert",
+                    "get_cloud_diagram_layer_snapshot",
                     "get_cloud_diagrams_stats",
+                    "list_cloud_diagram_layer_snapshots",
                     "get_allocation",
                     "get_annotation",
                     "get_anomalies",
@@ -1354,6 +1356,50 @@ describe("MCP Tools Integration", () => {
             const result = await client.callTool({
                 name: "search_cloud_diagrams",
                 arguments: {},
+            });
+            expect(result.isError).toBe(true);
+        });
+    });
+
+    describe("list_cloud_diagram_layer_snapshots", () => {
+        it("returns saved snapshots for a layer", async () => {
+            const result = await client.callTool({
+                name: "list_cloud_diagram_layer_snapshots",
+                arguments: { id: "layer-1", limit: 10, sort: "-createdAt" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed).toHaveLength(2);
+            expect(parsed[0]._id).toBe("snap-2");
+            expect(parsed[0].prev_state).toBe("snap-1");
+            expect(parsed[1]._id).toBe("snap-1");
+        });
+
+        it("returns a validation error when the layer id is missing", async () => {
+            const result = await client.callTool({
+                name: "list_cloud_diagram_layer_snapshots",
+                arguments: {},
+            });
+            expect(result.isError).toBe(true);
+        });
+    });
+
+    describe("get_cloud_diagram_layer_snapshot", () => {
+        it("returns a single snapshot by id", async () => {
+            const result = await client.callTool({
+                name: "get_cloud_diagram_layer_snapshot",
+                arguments: { id: "layer-1", snapshot_id: "snap-1" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed._id).toBe("snap-1");
+            expect(parsed.name).toBe("Initial");
+        });
+
+        it("returns a validation error when the snapshot id is missing", async () => {
+            const result = await client.callTool({
+                name: "get_cloud_diagram_layer_snapshot",
+                arguments: { id: "layer-1" },
             });
             expect(result.isError).toBe(true);
         });


### PR DESCRIPTION
## Summary

Adds two read-only **Cloud Diagrams** API endpoints to the MCP, completing snapshot (version-history) coverage for diagram layers. These are the next GET endpoints in the partially-covered Cloud Diagrams category (which already has `find_cloud_diagrams`, `get_cloud_diagrams_stats`, `search_cloud_diagrams`).

### Endpoints added (2)

| Tool | Method | Path | Reference |
|------|--------|------|-----------|
| `list_cloud_diagram_layer_snapshots` | GET | `/clouddiagrams/v1/layers/{id}/snapshots` (`offset`/`limit`/`sort`) | [listclouddiagramlayersnapshots](https://developer.doit.com/reference/listclouddiagramlayersnapshots) |
| `get_cloud_diagram_layer_snapshot` | GET | `/clouddiagrams/v1/layers/{id}/snapshots/{snapshot_id}` | [getclouddiagramlayersnapshot](https://developer.doit.com/reference/getclouddiagramlayersnapshot) |

Both return snapshot objects with `_id`, `name`, `created_at`, and `prev_state`. Field shapes were cross-checked against the `cloud_diagrams_snapshots` data source in [doitintl/terraform-provider-doit](https://github.com/doitintl/terraform-provider-doit) (generated from the same OpenAPI spec), which confirmed the list endpoint returns a direct JSON array and the snapshot object fields.

### What the reviewer should check
- **Schema correctness vs the API reference** — path params (`id`, `snapshot_id`), query params (`offset`, `limit`, `sort`), and the snapshot response fields.
- **Registration in BOTH MCPs** — local (`src/server.ts` + `src/utils/toolsHandler.ts`) and remote (`doit-mcp-server/src/index.ts`).
- **Auth/permission scope** — both declared `read_data` (read-only), matching sibling Cloud Diagrams tools.
- **Test coverage** — unit tests, integration fixtures + MSW handlers + tool-call tests, and the STDIO↔SSE parity / `tools/list` sync.

### Registration checklist
- [x] Tool + handler in `src/tools/cloudDiagrams.ts`
- [x] Types in `src/types/cloudDiagrams.ts`
- [x] Dispatch in `src/utils/toolsHandler.ts`
- [x] Registered in **local** MCP `src/server.ts`
- [x] Registered in **remote** MCP `doit-mcp-server/src/index.ts`
- [x] Unit tests (`src/tools/__tests__/cloudDiagrams.test.ts`)
- [x] Integration fixtures + MSW handler + tool-call tests (`test/integration/`)
- [x] `tools/list` assertion + STDIO↔SSE parity updated
- [x] `README.md` updated

### Verification
- `yarn check:dev` ✅
- `yarn test` ✅ (820 passed)
- Integration tests ✅ (141 passed)
- Build pipeline (widget build + inline + `tsc`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)