### PR TITLE
feat: add search_customers doer tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- feat: add `search_customers` tool — DoiT-internal (doer) search across all customers by classification, type, segment, tier package, domains, cloud asset platforms, Flexsave, monthly/invoiced spend, and active contracts (AND-combined). Calls the doer-gated console endpoint `POST /api/customers/v1/customers/search` via the console proxy.
+
 ## v0.14.0 (2026-06-19)
 
 ### Features

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -1,6 +1,13 @@
 import app from "./app";
-import { type BearerEnv, verifyBearer, wwwAuthenticateHeaderForResource } from "./oauth/bearerMiddleware";
-import { exchangeMcpTokenForUpstreamToken, type TokenExchangeEnv } from "./oauth/tokenExchange";
+import {
+  type BearerEnv,
+  verifyBearer,
+  wwwAuthenticateHeaderForResource,
+} from "./oauth/bearerMiddleware";
+import {
+  exchangeMcpTokenForUpstreamToken,
+  type TokenExchangeEnv,
+} from "./oauth/tokenExchange";
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { DurableObject } from "cloudflare:workers";
@@ -15,14 +22,20 @@ import {
   cloudIncidentTool,
   cloudIncidentsTool,
 } from "../../src/tools/cloudIncidents.js";
-import { cloudOverviewTool, CloudOverviewArgumentsSchema } from "../../src/tools/overview.js";
+import {
+  cloudOverviewTool,
+  CloudOverviewArgumentsSchema,
+} from "../../src/tools/overview.js";
 import {
   AnomaliesArgumentsSchema,
   AnomalyArgumentsSchema,
   anomaliesTool,
   anomalyTool,
 } from "../../src/tools/anomalies.js";
-import { AskAvaSyncArgumentsSchema, askAvaSyncTool } from "../../src/tools/ava.js";
+import {
+  AskAvaSyncArgumentsSchema,
+  askAvaSyncTool,
+} from "../../src/tools/ava.js";
 import {
   CreateReportArgumentsSchema,
   GetReportConfigArgumentsSchema,
@@ -97,6 +110,10 @@ import {
   ListAssetsArgumentsSchema,
   listAssetsTool,
 } from "../../src/tools/assets.js";
+import {
+  SearchCustomersArgumentsSchema,
+  searchCustomersTool,
+} from "../../src/tools/searchCustomers.js";
 import {
   CreateAlertArgumentsSchema,
   createAlertTool,
@@ -218,7 +235,11 @@ import {
 
 import type { ApprovalStore } from "../../src/utils/approval.js";
 import { executeToolHandler } from "../../src/utils/toolsHandler.js";
-import { type TrackingContext, runWithTracking } from "../../src/utils/util.js";
+import {
+  type TrackingContext,
+  runWithConsoleEnv,
+  runWithTracking,
+} from "../../src/utils/util.js";
 import { DurableObjectApprovalStore } from "./durableObjectApprovalStore.js";
 import {
   getErrorMessage,
@@ -235,8 +256,18 @@ import {
 } from "./mcpDiagnostics.js";
 import { adaptToolResponse } from "./responseAdapter.js";
 import { WIDGET_URI } from "./responseAdapter.js";
-import { promptsIncludingLegacyNames, resolvePromptMessages } from "../../src/prompts/index.js";
-import { resolveAuthServerUrl, resolveMcpResourceUrl, type DoitWorkerEnv, type UiDomainProvider } from "./runtimeEnv.js";
+import {
+  promptsIncludingLegacyNames,
+  resolvePromptMessages,
+} from "../../src/prompts/index.js";
+import {
+  resolveAuthServerUrl,
+  resolveMcpResourceUrl,
+  shouldUseConsoleProxy,
+  type ConsoleProxyBinding,
+  type DoitWorkerEnv,
+  type UiDomainProvider,
+} from "./runtimeEnv.js";
 import {
   buildFallbackWidgetResourceContent,
   buildWidgetResourceContent,
@@ -258,7 +289,7 @@ const MCP_NOTIFICATIONS_PING = {
 
 // SSE message to send the MCP ping notification and keep the connection alive.
 const SSE_KEEP_ALIVE_MESSAGE = new TextEncoder().encode(
-  `event: message\ndata: ${JSON.stringify(MCP_NOTIFICATIONS_PING)}\n\n`
+  `event: message\ndata: ${JSON.stringify(MCP_NOTIFICATIONS_PING)}\n\n`,
 );
 const SESSION_UI_DOMAIN_PROVIDER_KEY = "sessionUiDomainProvider";
 const MCP_CORS_ALLOW_HEADERS = [
@@ -294,7 +325,9 @@ function withMcpCorsHeaders(init?: HeadersInit): Headers {
   headers.set("Access-Control-Max-Age", "86400");
   headers.set(
     "Vary",
-    existingVary ? `${existingVary}, ${MCP_CORS_VARY_HEADERS}` : MCP_CORS_VARY_HEADERS
+    existingVary
+      ? `${existingVary}, ${MCP_CORS_VARY_HEADERS}`
+      : MCP_CORS_VARY_HEADERS,
   );
 
   return headers;
@@ -326,7 +359,7 @@ function logWidgetResourceError(
     hasPublicMcpUrl: boolean;
     hasClaudeUiDomain: boolean;
     hasOpenAiUiDomain: boolean;
-  }
+  },
 ) {
   console.error(
     message,
@@ -334,7 +367,7 @@ function logWidgetResourceError(
       reason: getErrorMessage(error),
       ...context,
     },
-    error
+    error,
   );
 }
 
@@ -371,7 +404,7 @@ export class DoitMCPAgent extends McpAgent {
       capabilities: {
         resources: {},
       },
-    }
+    },
   );
 
   // Per-instance MCP client info — stored on the DO instance, not a module global,
@@ -439,13 +472,16 @@ export class DoitMCPAgent extends McpAgent {
       return this.upstreamTokenCache.upstreamAccessToken;
     }
 
-    console.info("[mcp] exchanging OAuth MCP token for upstream DoiT API token", {
-      authMethod,
-      cachePresentForDifferentToken: Boolean(
-        this.upstreamTokenCache &&
+    console.info(
+      "[mcp] exchanging OAuth MCP token for upstream DoiT API token",
+      {
+        authMethod,
+        cachePresentForDifferentToken: Boolean(
+          this.upstreamTokenCache &&
           this.upstreamTokenCache.mcpAccessToken !== token,
-      ),
-    });
+        ),
+      },
+    );
     const exchanged = await exchangeMcpTokenForUpstreamToken({
       mcpToken: token,
       env: this.env as TokenExchangeEnv,
@@ -493,7 +529,7 @@ export class DoitMCPAgent extends McpAgent {
   }
 
   private async persistSessionUiDomainProvider(
-    provider: UiDomainProvider
+    provider: UiDomainProvider,
   ): Promise<void> {
     if (provider === "omit") {
       return;
@@ -508,7 +544,7 @@ export class DoitMCPAgent extends McpAgent {
   > {
     try {
       const provider = await this.ctx.storage.get<UiDomainProvider>(
-        SESSION_UI_DOMAIN_PROVIDER_KEY
+        SESSION_UI_DOMAIN_PROVIDER_KEY,
       );
 
       if (provider === "claude" || provider === "openai") {
@@ -521,7 +557,7 @@ export class DoitMCPAgent extends McpAgent {
         {
           reason: getErrorMessage(error),
         },
-        error
+        error,
       );
     }
 
@@ -538,14 +574,18 @@ export class DoitMCPAgent extends McpAgent {
       // ContextStorage (mirrors main); load it so a prior change_customer selection
       // is applied. Regular customer keys are pinned to their own domain (no
       // change_customer), and OAuth sessions keep the JWT-sealed context in memory.
-      if (this.props.authMethod === "apikey" && this.props.isDoitUser === "true") {
+      if (
+        this.props.authMethod === "apikey" &&
+        this.props.isDoitUser === "true"
+      ) {
         try {
-          customerContext = (await this.loadPersistedProps()) || customerContext;
+          customerContext =
+            (await this.loadPersistedProps()) || customerContext;
         } catch (error) {
           console.error(
             "[mcp] loadPersistedProps failed during tool call",
             { reason: getErrorMessage(error), toolName },
-            error
+            error,
           );
         }
       }
@@ -554,19 +594,35 @@ export class DoitMCPAgent extends McpAgent {
         ...args,
         customerContext,
       };
-      const result = await executeToolHandler(
-        toolName,
-        argsWithCustomerContext,
-        token,
-        {
-          trackingContext: this._mcpClientInfo,
-          convertResponse: (rawResult) => adaptToolResponse(toolName, rawResult),
-          // The identity the approval flow is bound to. `props.apiKey` is the
-          // OAuth-derived DoiT API key and is per-user, so staged actions cannot
-          // be consumed across users even if a token somehow leaked.
-          userKey: token,
-          approvalStore: this.getApprovalStore(),
-        }
+
+      // Console-targeting tools (e.g. search_customers) call console.doit.com /api/...
+      // which in prod must go through the CONSOLE_PROXY service binding. Expose that to
+      // the tool layer for the duration of this call; api.doit.com tools ignore it.
+      const workerEnv = this.env as DoitWorkerEnv & {
+        CONSOLE_PROXY?: ConsoleProxyBinding;
+      };
+      const consoleBaseUrl =
+        workerEnv.DOIT_CONSOLE_BASE ?? resolveAuthServerUrl(workerEnv);
+      const consoleProxy = workerEnv.CONSOLE_PROXY;
+      const consoleProxyFetch =
+        consoleProxy && shouldUseConsoleProxy(workerEnv, consoleBaseUrl)
+          ? (((input: any, init?: any) =>
+              consoleProxy.fetch(input, init)) as typeof fetch)
+          : undefined;
+
+      const result = await runWithConsoleEnv(
+        { baseUrl: consoleBaseUrl, proxyFetch: consoleProxyFetch },
+        () =>
+          executeToolHandler(toolName, argsWithCustomerContext, token, {
+            trackingContext: this._mcpClientInfo,
+            convertResponse: (rawResult) =>
+              adaptToolResponse(toolName, rawResult),
+            // The identity the approval flow is bound to. `props.apiKey` is the
+            // OAuth-derived DoiT API key and is per-user, so staged actions cannot
+            // be consumed across users even if a token somehow leaked.
+            userKey: token,
+            approvalStore: this.getApprovalStore(),
+          }),
       );
       return result;
     };
@@ -576,9 +632,8 @@ export class DoitMCPAgent extends McpAgent {
   private createChangeCustomerCallback() {
     return async (args: any) => {
       const token = await this.getToken();
-      const { handleChangeCustomerRequest } = await import(
-        "../../src/tools/changeCustomer.js"
-      );
+      const { handleChangeCustomerRequest } =
+        await import("../../src/tools/changeCustomer.js");
 
       // Update the customer context. Legacy API-key sessions persist the switch
       // per-apiKey in ContextStorage (mirrors main), so it survives reconnects.
@@ -592,14 +647,17 @@ export class DoitMCPAgent extends McpAgent {
       };
 
       // change_customer bypasses executeToolHandler, so wrap manually with tracking context.
-      return runWithTracking({ ...this._mcpClientInfo, mcpTool: "change_customer" }, async () => {
-        const response = await handleChangeCustomerRequest(
-          args,
-          token,
-          updateCustomerContext
-        );
-        return adaptToolResponse("change_customer", response);
-      });
+      return runWithTracking(
+        { ...this._mcpClientInfo, mcpTool: "change_customer" },
+        async () => {
+          const response = await handleChangeCustomerRequest(
+            args,
+            token,
+            updateCustomerContext,
+          );
+          return adaptToolResponse("change_customer", response);
+        },
+      );
     };
   }
 
@@ -620,7 +678,7 @@ export class DoitMCPAgent extends McpAgent {
           ui: { ...(tool._meta?.ui ?? {}), resourceUri: WIDGET_URI },
         },
       },
-      this.createToolCallback(tool.name)
+      this.createToolCallback(tool.name),
     );
     this._registeredToolCount += 1;
   }
@@ -632,10 +690,7 @@ export class DoitMCPAgent extends McpAgent {
       WIDGET_URI,
       { mimeType: WIDGET_RESOURCE_MIME_TYPE },
       async () => {
-        if (
-          !this._mcpClientInfo.mcpClient &&
-          !this._sessionUiDomainProvider
-        ) {
+        if (!this._mcpClientInfo.mcpClient && !this._sessionUiDomainProvider) {
           await this.loadPersistedSessionUiDomainProvider();
         }
         const logContext = {
@@ -656,7 +711,7 @@ export class DoitMCPAgent extends McpAgent {
           logWidgetResourceError(
             "[widget] config resolution failed",
             error,
-            logContext
+            logContext,
           );
           return {
             contents: [buildFallbackWidgetResourceContent(WIDGET_URI)],
@@ -684,14 +739,14 @@ export class DoitMCPAgent extends McpAgent {
           logWidgetResourceError(
             "[widget] resource content build failed",
             error,
-            logContext
+            logContext,
           );
           resourceContent = buildFallbackWidgetResourceContent(WIDGET_URI);
         }
         return {
           contents: [resourceContent],
         };
-      }
+      },
     );
     this._registeredResourceCount += 1;
   }
@@ -740,7 +795,7 @@ export class DoitMCPAgent extends McpAgent {
         void this.persistSessionUiDomainProvider(provider).catch((error) => {
           console.error(
             "[mcp] failed to persist session UI domain provider",
-            error
+            error,
           );
         });
       }
@@ -781,8 +836,14 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(costBreakdownTool, CostBreakdownArgumentsSchema);
     this.registerTool(costTrendTool, CostTrendArgumentsSchema);
     this.registerTool(compareSpendTool, CompareSpendArgumentsSchema);
-    this.registerTool(listOptimizationRecommendationsTool, ListInsightsArgumentsSchema);
-    this.registerTool(getInsightResourcesTool, GetInsightResourcesArgumentsSchema);
+    this.registerTool(
+      listOptimizationRecommendationsTool,
+      ListInsightsArgumentsSchema,
+    );
+    this.registerTool(
+      getInsightResourcesTool,
+      GetInsightResourcesArgumentsSchema,
+    );
     this.registerTool(getReportResultsTool, GetReportResultsArgumentsSchema);
     this.registerTool(getReportConfigTool, GetReportConfigArgumentsSchema);
     this.registerTool(createReportTool, CreateReportArgumentsSchema);
@@ -798,8 +859,14 @@ export class DoitMCPAgent extends McpAgent {
     // Tickets tools
     this.registerTool(listTicketsTool, ListTicketsArgumentsSchema);
     this.registerTool(getTicketTool, GetTicketArgumentsSchema);
-    this.registerTool(listTicketCommentsTool, ListTicketCommentsArgumentsSchema);
-    this.registerTool(createTicketCommentTool, CreateTicketCommentArgumentsSchema);
+    this.registerTool(
+      listTicketCommentsTool,
+      ListTicketCommentsArgumentsSchema,
+    );
+    this.registerTool(
+      createTicketCommentTool,
+      CreateTicketCommentArgumentsSchema,
+    );
     this.registerTool(createTicketTool, CreateTicketArgumentsSchema);
 
     // Invoices tools
@@ -815,6 +882,7 @@ export class DoitMCPAgent extends McpAgent {
     // Assets tools
     this.registerTool(listAssetsTool, ListAssetsArgumentsSchema);
     this.registerTool(getAssetTool, GetAssetArgumentsSchema);
+    this.registerTool(searchCustomersTool, SearchCustomersArgumentsSchema);
 
     // CloudFlow tools
     this.registerTool(triggerCloudFlowTool, TriggerCloudFlowArgumentsSchema);
@@ -824,7 +892,6 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(getAlertTool, GetAlertArgumentsSchema);
     this.registerTool(createAlertTool, CreateAlertArgumentsSchema);
     this.registerTool(updateAlertTool, UpdateAlertArgumentsSchema);
-
 
     // Organizations tools
     this.registerTool(listOrganizationsTool, ListOrganizationsArgumentsSchema);
@@ -848,8 +915,14 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(getLabelTool, GetLabelArgumentsSchema);
     this.registerTool(createLabelTool, CreateLabelArgumentsSchema);
     this.registerTool(updateLabelTool, UpdateLabelArgumentsSchema);
-    this.registerTool(getLabelAssignmentsTool, GetLabelAssignmentsArgumentsSchema);
-    this.registerTool(assignObjectsToLabelTool, AssignObjectsToLabelArgumentsSchema);
+    this.registerTool(
+      getLabelAssignmentsTool,
+      GetLabelAssignmentsArgumentsSchema,
+    );
+    this.registerTool(
+      assignObjectsToLabelTool,
+      AssignObjectsToLabelArgumentsSchema,
+    );
 
     // Folders tools
     this.registerTool(listFoldersTool, ListFoldersArgumentsSchema);
@@ -860,10 +933,19 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(getThemeTool, GetThemeArgumentsSchema);
 
     // DataHub Datasets tools
-    this.registerTool(listDatahubDatasetsTool, ListDatahubDatasetsArgumentsSchema);
+    this.registerTool(
+      listDatahubDatasetsTool,
+      ListDatahubDatasetsArgumentsSchema,
+    );
     this.registerTool(getDatahubDatasetTool, GetDatahubDatasetArgumentsSchema);
-    this.registerTool(createDatahubDatasetTool, CreateDatahubDatasetArgumentsSchema);
-    this.registerTool(updateDatahubDatasetTool, UpdateDatahubDatasetArgumentsSchema);
+    this.registerTool(
+      createDatahubDatasetTool,
+      CreateDatahubDatasetArgumentsSchema,
+    );
+    this.registerTool(
+      updateDatahubDatasetTool,
+      UpdateDatahubDatasetArgumentsSchema,
+    );
     this.registerTool(sendDatahubEventsTool, SendDatahubEventsArgumentsSchema);
 
     // Cloud Diagrams tools
@@ -908,10 +990,13 @@ export class DoitMCPAgent extends McpAgent {
             ...changeCustomerTool._meta,
             "ui/resourceUri": WIDGET_URI,
             "openai/outputTemplate": WIDGET_URI,
-            ui: { ...((changeCustomerTool._meta as any)?.ui ?? {}), resourceUri: WIDGET_URI },
+            ui: {
+              ...((changeCustomerTool._meta as any)?.ui ?? {}),
+              resourceUri: WIDGET_URI,
+            },
           },
         },
-        this.createChangeCustomerCallback()
+        this.createChangeCustomerCallback(),
       );
       this._registeredToolCount += 1;
     }
@@ -924,7 +1009,7 @@ export class DoitMCPAgent extends McpAgent {
         {
           reason: getErrorMessage(error),
         },
-        error
+        error,
       );
     }
     this.installMcpMethodDiagnostics();
@@ -960,18 +1045,15 @@ export class DoitMCPAgent extends McpAgent {
 function wrapSSEResponseWithKeepAlive(
   response: Response,
   traceId: string,
-  keepAliveIntervalMs: number = KEEP_ALIVE_INTERVAL_MS
+  keepAliveIntervalMs: number = KEEP_ALIVE_INTERVAL_MS,
 ): Response {
   const originalBody = response.body;
 
   if (!originalBody) {
-    console.log(
-      getMcpDiagnosticsMessage("sse stream missing body", traceId),
-      {
-        ...getMcpTraceContext(traceId),
-        status: response.status,
-      }
-    );
+    console.log(getMcpDiagnosticsMessage("sse stream missing body", traceId), {
+      ...getMcpTraceContext(traceId),
+      status: response.status,
+    });
     return response;
   }
 
@@ -1008,7 +1090,7 @@ function wrapSSEResponseWithKeepAlive(
                 ...getMcpTraceContext(traceId),
                 reason: getErrorMessage(error),
               },
-              error
+              error,
             );
             isStreamActive = false;
           }
@@ -1038,7 +1120,7 @@ function wrapSSEResponseWithKeepAlive(
             ...getMcpTraceContext(traceId),
             reason: getErrorMessage(error),
           },
-          error
+          error,
         );
         streamErrored = true;
         controller.error(error);
@@ -1067,7 +1149,7 @@ function wrapSSEResponseWithKeepAlive(
         keepAliveTimer = null;
       }
       return originalReader.cancel();
-    }
+    },
   });
 
   // Return a new Response with the transformed stream and original headers
@@ -1078,6 +1160,16 @@ function wrapSSEResponseWithKeepAlive(
   });
 }
 
+const DURABLE_OBJECT_STORAGE_TIMEOUT =
+  "Durable Object storage operation exceeded timeout";
+
+function isDurableObjectStorageTimeout(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(DURABLE_OBJECT_STORAGE_TIMEOUT)
+  );
+}
+
 async function handleMcpRequest(req: Request, env: Env, ctx: ExecutionContext) {
   const url = new URL(req.url);
   const { pathname } = url;
@@ -1085,19 +1177,40 @@ async function handleMcpRequest(req: Request, env: Env, ctx: ExecutionContext) {
 
   // SSE transport: GET /sse opens the event stream; POST /sse/message sends messages
   if (pathname === "/sse" && req.method === "GET") {
-    const response = await logMcpRoute(
-      traceId,
-      "sse-open",
-      req,
-      () => DoitMCPAgent.serveSSE("/sse").fetch(req, env, ctx),
-      { wrapsKeepAlive: true }
-    );
+    let response: Response;
+    try {
+      response = await logMcpRoute(
+        traceId,
+        "sse-open",
+        req,
+        () => DoitMCPAgent.serveSSE("/sse").fetch(req, env, ctx),
+        { wrapsKeepAlive: true },
+      );
+    } catch (error) {
+      if (isDurableObjectStorageTimeout(error)) {
+        return new Response("Service temporarily unavailable", {
+          status: 503,
+          headers: { "Retry-After": "5" },
+        });
+      }
+      throw error;
+    }
     return wrapSSEResponseWithKeepAlive(response, traceId);
   }
   if (pathname === "/sse/message") {
-    return logMcpRoute(traceId, "sse-message", req, () =>
-      DoitMCPAgent.serveSSE("/sse").fetch(req, env, ctx)
-    );
+    try {
+      return await logMcpRoute(traceId, "sse-message", req, () =>
+        DoitMCPAgent.serveSSE("/sse").fetch(req, env, ctx),
+      );
+    } catch (error) {
+      if (isDurableObjectStorageTimeout(error)) {
+        return new Response("Service temporarily unavailable", {
+          status: 503,
+          headers: { "Retry-After": "5" },
+        });
+      }
+      throw error;
+    }
   }
 
   // StreamableHTTP transport: POST /mcp (native) or POST /sse (ChatGPT tries the
@@ -1109,29 +1222,55 @@ async function handleMcpRequest(req: Request, env: Env, ctx: ExecutionContext) {
       pathname === "/sse"
         ? new Request(
             Object.assign(new URL(req.url), { pathname: "/mcp" }).toString(),
-            req
+            req,
           )
         : req;
-    return logMcpRoute(
-      traceId,
-      "streamable-http",
-      req,
-      () => DoitMCPAgent.serve("/mcp").fetch(mcpReq, env, ctx),
-      {
-        rewrittenPathname,
-        isRewrite: pathname === "/sse",
-        rewrittenUrlPathname: new URL(mcpReq.url).pathname,
-        rewrittenHasAuthorization: Boolean(mcpReq.headers.get("authorization")),
-        rewrittenHasMcpSessionId: Boolean(mcpReq.headers.get("mcp-session-id")),
+    try {
+      return await logMcpRoute(
+        traceId,
+        "streamable-http",
+        req,
+        () => DoitMCPAgent.serve("/mcp").fetch(mcpReq, env, ctx),
+        {
+          rewrittenPathname,
+          isRewrite: pathname === "/sse",
+          rewrittenUrlPathname: new URL(mcpReq.url).pathname,
+          rewrittenHasAuthorization: Boolean(
+            mcpReq.headers.get("authorization"),
+          ),
+          rewrittenHasMcpSessionId: Boolean(
+            mcpReq.headers.get("mcp-session-id"),
+          ),
+        },
+      );
+    } catch (error) {
+      if (isDurableObjectStorageTimeout(error)) {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32603, message: "Service temporarily unavailable" },
+          }),
+          {
+            status: 503,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "5",
+            },
+          },
+        );
       }
-    );
+      throw error;
+    }
   }
 
-  return logMcpRoute(traceId, "not-found", req, async () =>
-    new Response("Not found", { status: 404 })
+  return logMcpRoute(
+    traceId,
+    "not-found",
+    req,
+    async () => new Response("Not found", { status: 404 }),
   );
 }
-
 
 // Workers types `ExecutionContext.props` as readonly, but McpAgent receives the
 // per-connection auth context via ctx.props. Assign through a writable view and
@@ -1139,7 +1278,7 @@ async function handleMcpRequest(req: Request, env: Env, ctx: ExecutionContext) {
 // @cloudflare/workers-oauth-provider package; we now own it.)
 function assignCtxProps(
   ctx: ExecutionContext,
-  props: Record<string, unknown>
+  props: Record<string, unknown>,
 ): void {
   const mutable = ctx as unknown as { props?: Record<string, unknown> };
   mutable.props = { ...(mutable.props ?? {}), ...props };
@@ -1160,7 +1299,7 @@ function extractTokenFromAuthHeader(authHeader: string): string | null {
 async function handleRequest(
   req: Request,
   env: Env,
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
 ): Promise<Response> {
   const url = new URL(req.url);
   const startedAt = Date.now();
@@ -1168,9 +1307,13 @@ async function handleRequest(
     ? getMcpTraceId(req)
     : undefined;
   const authHeader = req.headers.get("Authorization");
-  const mcpResourceUrl = resolveMcpResourceUrl(env as { MCP_RESOURCE_URL?: string });
+  const mcpResourceUrl = resolveMcpResourceUrl(
+    env as { MCP_RESOURCE_URL?: string },
+  );
   const isMcpPath =
-    url.pathname === "/sse" || url.pathname === "/sse/message" || url.pathname === "/mcp";
+    url.pathname === "/sse" ||
+    url.pathname === "/sse/message" ||
+    url.pathname === "/mcp";
 
   try {
     // Serve the RFC 9728 protected-resource metadata unauthenticated at ANY path
@@ -1179,8 +1322,12 @@ async function handleRequest(
     // here before the MCP auth check runs. The metadata points clients to the real
     // authorization server (auth.doit.com).
     if (isMcpDiscoveryPath(url.pathname)) {
-      const authServerUrl = resolveAuthServerUrl(env as { AUTH_SERVER_URL?: string });
-      const resource = resolveMcpResourceUrl(env as { MCP_RESOURCE_URL?: string });
+      const authServerUrl = resolveAuthServerUrl(
+        env as { AUTH_SERVER_URL?: string },
+      );
+      const resource = resolveMcpResourceUrl(
+        env as { MCP_RESOURCE_URL?: string },
+      );
       const response = Response.json({
         resource,
         authorization_servers: [authServerUrl],
@@ -1222,7 +1369,11 @@ async function handleRequest(
             userId: "demo",
             isDoitUser: "false",
           });
-          const response = await handleMcpRequest(withMcpTraceId(req, traceId), env, ctx);
+          const response = await handleMcpRequest(
+            withMcpTraceId(req, traceId),
+            env,
+            ctx,
+          );
           if (response.status >= 400) {
             logMcpRequestComplete(traceId, response, startedAt);
           }
@@ -1234,12 +1385,15 @@ async function handleRequest(
 
         if (!result.ok) {
           if (result.reason === "verification_unavailable") {
-            const response = new Response("Authentication service unavailable", {
-              status: 503,
-              headers: {
-                "Retry-After": "30",
+            const response = new Response(
+              "Authentication service unavailable",
+              {
+                status: 503,
+                headers: {
+                  "Retry-After": "30",
+                },
               },
-            });
+            );
             logMcpRequestComplete(traceId, response, startedAt);
             return response;
           }
@@ -1275,7 +1429,8 @@ async function handleRequest(
           const response = new Response("Unauthorized", {
             status: 401,
             headers: {
-              "WWW-Authenticate": wwwAuthenticateHeaderForResource(mcpResourceUrl),
+              "WWW-Authenticate":
+                wwwAuthenticateHeaderForResource(mcpResourceUrl),
             },
           });
           logMcpRequestComplete(traceId, response, startedAt);
@@ -1297,7 +1452,11 @@ async function handleRequest(
 
         // Dispatch through main's handleMcpRequest so we get its routing,
         // diagnostics, and SSE keep-alive wrapping.
-        const response = await handleMcpRequest(withMcpTraceId(req, traceId), env, ctx);
+        const response = await handleMcpRequest(
+          withMcpTraceId(req, traceId),
+          env,
+          ctx,
+        );
         if (response.status >= 400) {
           logMcpRequestComplete(traceId, response, startedAt);
         }
@@ -1307,11 +1466,7 @@ async function handleRequest(
 
     // Non-MCP, non-discovery requests (home page, widget, well-known metadata)
     // are served by the Hono app.
-    const response = await app.fetch(
-      withMcpTraceId(req, traceId),
-      env,
-      ctx
-    );
+    const response = await app.fetch(withMcpTraceId(req, traceId), env, ctx);
     if (response.status >= 400) {
       logMcpRequestComplete(traceId, response, startedAt);
     }
@@ -1327,7 +1482,11 @@ async function handleRequest(
 // worker cross-origin: answer the preflight, and expose WWW-Authenticate on the
 // 401 challenge so the client can discover the authorization server.
 export default {
-  async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(
+    req: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
     if (req.method === "OPTIONS") {
       return mcpCorsPreflightResponse();
     }

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -968,14 +968,8 @@ export class DoitMCPAgent extends McpAgent {
     // Tickets tools
     this.registerTool(listTicketsTool, ListTicketsArgumentsSchema);
     this.registerTool(getTicketTool, GetTicketArgumentsSchema);
-    this.registerTool(
-      listTicketCommentsTool,
-      ListTicketCommentsArgumentsSchema,
-    );
-    this.registerTool(
-      createTicketCommentTool,
-      CreateTicketCommentArgumentsSchema,
-    );
+    this.registerTool(listTicketCommentsTool, ListTicketCommentsArgumentsSchema);
+    this.registerTool(createTicketCommentTool, CreateTicketCommentArgumentsSchema);
     this.registerTool(createTicketTool, CreateTicketArgumentsSchema);
 
     // Invoices tools
@@ -1032,14 +1026,8 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(getLabelTool, GetLabelArgumentsSchema);
     this.registerTool(createLabelTool, CreateLabelArgumentsSchema);
     this.registerTool(updateLabelTool, UpdateLabelArgumentsSchema);
-    this.registerTool(
-      getLabelAssignmentsTool,
-      GetLabelAssignmentsArgumentsSchema,
-    );
-    this.registerTool(
-      assignObjectsToLabelTool,
-      AssignObjectsToLabelArgumentsSchema,
-    );
+    this.registerTool(getLabelAssignmentsTool, GetLabelAssignmentsArgumentsSchema);
+    this.registerTool(assignObjectsToLabelTool, AssignObjectsToLabelArgumentsSchema);
 
     // Folders tools
     this.registerTool(listFoldersTool, ListFoldersArgumentsSchema);
@@ -1055,19 +1043,10 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(getCloudConnectSupportedFeaturesTool, GetCloudConnectSupportedFeaturesArgumentsSchema);
 
     // DataHub Datasets tools
-    this.registerTool(
-      listDatahubDatasetsTool,
-      ListDatahubDatasetsArgumentsSchema,
-    );
+    this.registerTool(listDatahubDatasetsTool, ListDatahubDatasetsArgumentsSchema);
     this.registerTool(getDatahubDatasetTool, GetDatahubDatasetArgumentsSchema);
-    this.registerTool(
-      createDatahubDatasetTool,
-      CreateDatahubDatasetArgumentsSchema,
-    );
-    this.registerTool(
-      updateDatahubDatasetTool,
-      UpdateDatahubDatasetArgumentsSchema,
-    );
+    this.registerTool(createDatahubDatasetTool, CreateDatahubDatasetArgumentsSchema);
+    this.registerTool(updateDatahubDatasetTool, UpdateDatahubDatasetArgumentsSchema);
     this.registerTool(sendDatahubEventsTool, SendDatahubEventsArgumentsSchema);
 
     // Cloud Diagrams tools

--- a/doit-mcp-server/src/runtimeEnv.ts
+++ b/doit-mcp-server/src/runtimeEnv.ts
@@ -10,6 +10,9 @@ export interface RuntimeEnvVars {
   OPENAI_UI_DOMAIN?: string;
   MCP_RESOURCE_URL?: string;
   AUTH_SERVER_URL?: string;
+  // Base URL for doer console-data endpoints (e.g. search_customers); falls back to
+  // AUTH_SERVER_URL. Lets local dev point console tools at a local customers service.
+  DOIT_CONSOLE_BASE?: string;
 }
 
 export type DoitWorkerEnv = Env & RuntimeEnvVars;

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -225,6 +225,7 @@ import {
 } from "../tools/annotations.js";
 import { anomaliesTool, anomalyTool } from "../tools/anomalies.js";
 import { getAssetTool, listAssetsTool } from "../tools/assets.js";
+import { searchCustomersTool } from "../tools/searchCustomers.js";
 import { askAvaSyncTool } from "../tools/ava.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "../tools/budgets.js";
 import { findCloudDiagramsTool } from "../tools/cloudDiagrams.js";
@@ -359,6 +360,7 @@ describe("ListToolsRequestSchema handler", () => {
                 updateAllocationTool,
                 listAssetsTool,
                 getAssetTool,
+                searchCustomersTool,
                 listAlertsTool,
                 getAlertTool,
                 createAlertTool,

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -225,7 +225,6 @@ import {
 } from "../tools/annotations.js";
 import { anomaliesTool, anomalyTool } from "../tools/anomalies.js";
 import { getAssetTool, listAssetsTool } from "../tools/assets.js";
-import { searchCustomersTool } from "../tools/searchCustomers.js";
 import { askAvaSyncTool } from "../tools/ava.js";
 import { getAwsAccountTool, getCloudConnectSupportedFeaturesTool } from "../tools/awsAccounts.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "../tools/budgets.js";
@@ -277,6 +276,7 @@ import {
     updateReportTool,
 } from "../tools/reports.js";
 import { listRolesTool } from "../tools/roles.js";
+import { searchCustomersTool } from "../tools/searchCustomers.js";
 import { getActiveThemeTool, getThemeTool, listThemesTool } from "../tools/themes.js";
 import {
     createTicketCommentTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ import {
 import { anomaliesTool, anomalyTool, handleAnomaliesRequest, handleAnomalyRequest } from "./tools/anomalies.js";
 import { getAssetTool, handleGetAssetRequest, handleListAssetsRequest, listAssetsTool } from "./tools/assets.js";
 import { askAvaSyncTool, handleAskAvaSyncRequest } from "./tools/ava.js";
+import { handleSearchCustomersRequest, searchCustomersTool } from "./tools/searchCustomers.js";
 import {
     createBudgetTool,
     getBudgetTool,
@@ -211,6 +212,7 @@ export function createServer() {
                 updateAllocationTool,
                 listAssetsTool,
                 getAssetTool,
+                searchCustomersTool,
                 listAlertsTool,
                 getAlertTool,
                 createAlertTool,
@@ -401,6 +403,7 @@ export {
     handleListUsersRequest,
     handleReportsRequest,
     handleRunQueryRequest,
+    handleSearchCustomersRequest,
     handleSendDatahubEventsRequest,
     handleTriggerCloudFlowRequest,
     handleUpdateAlertRequest,

--- a/src/tools/__tests__/searchCustomers.test.ts
+++ b/src/tools/__tests__/searchCustomers.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeConsoleRequest } from "../../utils/util.js";
+import { handleSearchCustomersRequest, SEARCH_CUSTOMERS_PATH } from "../searchCustomers.js";
+
+vi.mock("../../utils/util.js", async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, makeConsoleRequest: vi.fn() };
+});
+
+beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+const mockToken = "test-token";
+
+describe("handleSearchCustomersRequest", () => {
+    it("posts assembled filters to the console search endpoint and returns JSON", async () => {
+        const apiResponse = {
+            customers: [{ id: "c1", name: "Acme", primaryDomain: "acme.com" }],
+            nextPageToken: "tok",
+            truncated: false,
+        };
+        (makeConsoleRequest as ReturnType<typeof vi.fn>).mockResolvedValue(apiResponse);
+
+        const response = await handleSearchCustomersRequest(
+            {
+                classification: ["strategic"],
+                assetPlatforms: ["amazon-web-services"],
+                hasFlexsave: true,
+                minMonthlyCloudSpend: 1000,
+                invoicedFromMonth: "2026-01",
+                invoicedToMonth: "2026-03",
+                invoicedMinTotal: 500,
+                contractsActive: true,
+                pageSize: 25,
+            },
+            mockToken
+        );
+
+        expect(makeConsoleRequest).toHaveBeenCalledWith(SEARCH_CUSTOMERS_PATH, mockToken, {
+            method: "POST",
+            body: {
+                filters: {
+                    classification: ["strategic"],
+                    assetPlatforms: ["amazon-web-services"],
+                    hasFlexsave: true,
+                    spend: {
+                        minMonthlyCloudSpend: 1000,
+                        invoiced: {
+                            fromMonth: "2026-01",
+                            toMonth: "2026-03",
+                            minTotal: 500,
+                        },
+                    },
+                    contracts: { active: true },
+                },
+                pageSize: 25,
+            },
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.customers).toHaveLength(1);
+        expect(parsed.nextPageToken).toBe("tok");
+    });
+
+    it("omits empty filters and spend when nothing is set", async () => {
+        (makeConsoleRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+            customers: [],
+            nextPageToken: "",
+            truncated: false,
+        });
+
+        await handleSearchCustomersRequest({}, mockToken);
+
+        expect(makeConsoleRequest).toHaveBeenCalledWith(SEARCH_CUSTOMERS_PATH, mockToken, {
+            method: "POST",
+            body: { filters: {} },
+        });
+    });
+
+    it("surfaces upstream errors (e.g. 403 for non-doers)", async () => {
+        (makeConsoleRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("HTTP 403: doers only"));
+
+        const response = await handleSearchCustomersRequest({ classification: ["business"] }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("403");
+    });
+
+    it("returns a validation error for an invalid classification", async () => {
+        const response = await handleSearchCustomersRequest({ classification: ["not-a-class"] }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(makeConsoleRequest).not.toHaveBeenCalled();
+    });
+});

--- a/src/tools/searchCustomers.ts
+++ b/src/tools/searchCustomers.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import type { SearchCustomersResponse } from "../types/searchCustomers.js";
+import { zodToMcpInputSchema } from "../utils/schemaHelpers.js";
+import {
+    createErrorResponse,
+    createSuccessResponse,
+    formatZodError,
+    handleGeneralError,
+    makeConsoleRequest,
+} from "../utils/util.js";
+
+// Doer-only console endpoint (console.doit.com). Reached via makeConsoleRequest, NOT
+// makeDoitRequest, because it is not on the public api.doit.com surface.
+export const SEARCH_CUSTOMERS_PATH = "/api/customers/v1/customers/search";
+
+const ASSET_PLATFORMS = ["amazon-web-services", "google-cloud", "g-suite", "office-365", "microsoft-azure"] as const;
+
+const CLASSIFICATIONS = ["business", "strategic", "terminated", "inactive", "suspendedForNonPayment"] as const;
+
+export const SearchCustomersArgumentsSchema = z.object({
+    classification: z
+        .array(z.enum(CLASSIFICATIONS))
+        .optional()
+        .describe("Match customers in any of these classifications (the customer 'kind')."),
+    type: z
+        .array(z.string())
+        .optional()
+        .describe(
+            "Match any of these customer types, e.g. 'procurement-only', 'product-only', 'procurement-and-product'."
+        ),
+    segment: z
+        .array(z.string())
+        .optional()
+        .describe("Match any of these customer segments, e.g. 'Invest', 'Incubate', 'Accelerate'."),
+    tierPackages: z
+        .array(z.string())
+        .optional()
+        .describe("Match customers subscribed to any of these tier packages, e.g. 'navigator', 'solve'."),
+    domains: z
+        .array(z.string())
+        .optional()
+        .describe("Match customers whose primary or secondary domain is any of these."),
+    assetPlatforms: z
+        .array(z.enum(ASSET_PLATFORMS))
+        .optional()
+        .describe(
+            "Match customers that have at least one asset on any of these cloud platforms (g-suite = Google Workspace, office-365 = Microsoft 365)."
+        ),
+    hasFlexsave: z
+        .boolean()
+        .optional()
+        .describe("If set, match customers that do (true) or do not (false) have Flexsave enabled on any cloud."),
+    standalone: z
+        .boolean()
+        .optional()
+        .describe(
+            "If set, match customers that do (true) or do not (false) have at least one standalone (direct self-serve) cloud asset. true keeps standalone/hybrid customers, false keeps resold-only ones."
+        ),
+    minMonthlyCloudSpend: z
+        .number()
+        .optional()
+        .describe("Minimum denormalized monthly cloud spend (cheap, from the customer record)."),
+    maxMonthlyCloudSpend: z.number().optional().describe("Maximum denormalized monthly cloud spend."),
+    invoicedFromMonth: z
+        .string()
+        .optional()
+        .describe("Start month (YYYY-MM) for the authoritative invoiced-total spend filter. Requires invoicedToMonth."),
+    invoicedToMonth: z
+        .string()
+        .optional()
+        .describe("End month (YYYY-MM) for the invoiced-total spend filter. Requires invoicedFromMonth."),
+    invoicedMinTotal: z.number().optional().describe("Minimum summed invoice total over the invoiced month range."),
+    invoicedMaxTotal: z.number().optional().describe("Maximum summed invoice total over the invoiced month range."),
+    contractsActive: z
+        .boolean()
+        .optional()
+        .describe("If true, match only customers that have at least one active/expired contract."),
+    pageSize: z
+        .number()
+        .int()
+        .positive()
+        .max(200)
+        .optional()
+        .describe("Maximum customers to return per page (default 50, max 200)."),
+    pageToken: z
+        .string()
+        .optional()
+        .describe("Opaque page token from a previous response's nextPageToken, to fetch the next page."),
+});
+
+export const searchCustomersTool = {
+    name: "search_customers",
+    description:
+        "DoiT-internal (doer) tool: search across ALL DoiT customers by what they have — classification/kind, customer type, segment, tier package, domains, cloud asset platforms (AWS, GCP, Google Workspace, Office 365, Azure), Flexsave, standalone (direct self-serve) cloud assets, monthly cloud spend, invoiced spend over a month range, and active contracts. All provided conditions are AND-combined; within a list field the match is any-of. Returns matching customers with a summary and a nextPageToken for paging. Requires DoiT employee access (non-doers get an authorization error). Use this to FIND customers across the base; use other tools to drill into a specific customer.",
+    inputSchema: zodToMcpInputSchema(SearchCustomersArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Searching customers...",
+        "openai/toolInvocation/invoked": "Customer search complete",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export async function handleSearchCustomersRequest(args: any, token: string) {
+    try {
+        const parsed = SearchCustomersArgumentsSchema.parse(args);
+
+        const filters: Record<string, unknown> = {};
+
+        if (parsed.classification?.length) filters.classification = parsed.classification;
+        if (parsed.type?.length) filters.type = parsed.type;
+        if (parsed.segment?.length) filters.segment = parsed.segment;
+        if (parsed.tierPackages?.length) filters.tierPackages = parsed.tierPackages;
+        if (parsed.domains?.length) filters.domains = parsed.domains;
+        if (parsed.assetPlatforms?.length) filters.assetPlatforms = parsed.assetPlatforms;
+        if (parsed.hasFlexsave !== undefined) filters.hasFlexsave = parsed.hasFlexsave;
+        if (parsed.standalone !== undefined) filters.standalone = parsed.standalone;
+
+        const spend: Record<string, unknown> = {};
+        if (parsed.minMonthlyCloudSpend !== undefined) spend.minMonthlyCloudSpend = parsed.minMonthlyCloudSpend;
+        if (parsed.maxMonthlyCloudSpend !== undefined) spend.maxMonthlyCloudSpend = parsed.maxMonthlyCloudSpend;
+
+        if (
+            parsed.invoicedFromMonth !== undefined ||
+            parsed.invoicedToMonth !== undefined ||
+            parsed.invoicedMinTotal !== undefined ||
+            parsed.invoicedMaxTotal !== undefined
+        ) {
+            const invoiced: Record<string, unknown> = {};
+            if (parsed.invoicedFromMonth !== undefined) invoiced.fromMonth = parsed.invoicedFromMonth;
+            if (parsed.invoicedToMonth !== undefined) invoiced.toMonth = parsed.invoicedToMonth;
+            if (parsed.invoicedMinTotal !== undefined) invoiced.minTotal = parsed.invoicedMinTotal;
+            if (parsed.invoicedMaxTotal !== undefined) invoiced.maxTotal = parsed.invoicedMaxTotal;
+            spend.invoiced = invoiced;
+        }
+
+        if (Object.keys(spend).length > 0) filters.spend = spend;
+        if (parsed.contractsActive) filters.contracts = { active: true };
+
+        const body: Record<string, unknown> = { filters };
+        if (parsed.pageSize !== undefined) body.pageSize = parsed.pageSize;
+        if (parsed.pageToken) body.pageToken = parsed.pageToken;
+
+        const data = await makeConsoleRequest<SearchCustomersResponse>(SEARCH_CUSTOMERS_PATH, token, {
+            method: "POST",
+            body,
+        });
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling search customers request");
+    }
+}

--- a/src/types/searchCustomers.ts
+++ b/src/types/searchCustomers.ts
@@ -1,0 +1,27 @@
+interface FlexsaveSummary {
+    aws: boolean;
+    gcp: boolean;
+}
+
+interface CustomerSummary {
+    id: string;
+    name: string;
+    primaryDomain: string;
+    domains?: string[];
+    classification?: string;
+    type?: string;
+    segment?: string;
+    monthlyCloudSpend?: number;
+    tierPackages?: string[];
+    assetPlatforms?: string[];
+    accountTeam?: string[];
+    flexsave?: FlexsaveSummary;
+    invoicedTotal?: number;
+    matched?: string[];
+}
+
+export interface SearchCustomersResponse {
+    customers: CustomerSummary[];
+    nextPageToken: string;
+    truncated: boolean;
+}

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -20,6 +20,7 @@ import {
 } from "../tools/annotations.js";
 import { handleAnomaliesRequest, handleAnomalyRequest } from "../tools/anomalies.js";
 import { handleGetAssetRequest, handleListAssetsRequest } from "../tools/assets.js";
+import { handleSearchCustomersRequest } from "../tools/searchCustomers.js";
 import { handleAskAvaSyncRequest } from "../tools/ava.js";
 import {
     handleCreateBudgetRequest,
@@ -314,6 +315,9 @@ async function runOriginalDispatch(toolName: string, args: any, token: string): 
             break;
         case "get_asset":
             result = await handleGetAssetRequest(args, token);
+            break;
+        case "search_customers":
+            result = await handleSearchCustomersRequest(args, token);
             break;
         case "trigger_cloud_flow":
             result = await handleTriggerCloudFlowRequest(args, token);

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -20,7 +20,6 @@ import {
 } from "../tools/annotations.js";
 import { handleAnomaliesRequest, handleAnomalyRequest } from "../tools/anomalies.js";
 import { handleGetAssetRequest, handleListAssetsRequest } from "../tools/assets.js";
-import { handleSearchCustomersRequest } from "../tools/searchCustomers.js";
 import { handleAskAvaSyncRequest } from "../tools/ava.js";
 import { handleGetAwsAccountRequest, handleGetCloudConnectSupportedFeaturesRequest } from "../tools/awsAccounts.js";
 import {
@@ -89,6 +88,7 @@ import {
     handleUpdateReportRequest,
 } from "../tools/reports.js";
 import { handleListRolesRequest } from "../tools/roles.js";
+import { handleSearchCustomersRequest } from "../tools/searchCustomers.js";
 import { handleGetActiveThemeRequest, handleGetThemeRequest, handleListThemesRequest } from "../tools/themes.js";
 import {
     // createTicketTool, // Re-enable alongside the WRITE_GATED_SUMMARIES entry below.

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -48,6 +48,29 @@ export function getTrackingContext(): TrackingContext | undefined {
     return trackingStore.getStore();
 }
 
+// --- Console request context ---
+// A few tools (e.g. search_customers) call DoiT *console* endpoints (console.doit.com
+// /api/...) rather than the public api.doit.com. In the Cloudflare worker those calls
+// must go through the CONSOLE_PROXY service binding (a same-zone fetch of console.doit.com
+// bypasses the console-worker route), so the worker sets this request-scoped env around
+// tool execution. Outside the worker (stdio) the store is empty and makeConsoleRequest
+// falls back to the DOIT_CONSOLE_BASE / AUTH_SERVER_URL env vars with a plain fetch.
+
+export interface ConsoleRequestEnv {
+    baseUrl: string;
+    proxyFetch?: typeof fetch;
+}
+
+const consoleEnvStore = new AsyncLocalStorage<ConsoleRequestEnv>();
+
+export function runWithConsoleEnv<T>(env: ConsoleRequestEnv, fn: () => T): T {
+    return consoleEnvStore.run(env, fn);
+}
+
+export function getConsoleEnv(): ConsoleRequestEnv | undefined {
+    return consoleEnvStore.getStore();
+}
+
 /**
  * Debug levels for controlling log verbosity
  */
@@ -283,23 +306,7 @@ export async function makeDoitRequest<T>(
         }
 
         // add mcp tracking params to the url
-        const tracking = getTrackingContext();
-        const sep = requestUrl.includes("?") ? "&" : "?";
-        requestUrl += `${sep}mcp=true`;
-        requestUrl += `&mcpVersion=${encodeURIComponent(SERVER_VERSION)}`;
-
-        if (tracking?.mcpTool) {
-            requestUrl += `&mcpTool=${encodeURIComponent(tracking.mcpTool)}`;
-        }
-        if (tracking?.mcpClient) {
-            requestUrl += `&mcpClient=${encodeURIComponent(tracking.mcpClient)}`;
-        }
-        if (tracking?.mcpClientVersion) {
-            requestUrl += `&mcpClientVersion=${encodeURIComponent(tracking.mcpClientVersion)}`;
-        }
-        if (tracking?.mcpProtocolVersion) {
-            requestUrl += `&mcpProtocolVersion=${encodeURIComponent(tracking.mcpProtocolVersion)}`;
-        }
+        requestUrl = appendTrackingParams(requestUrl);
 
         if (!process.env.CUSTOMER_CONTEXT) {
             // request from the sse server
@@ -310,18 +317,7 @@ export async function makeDoitRequest<T>(
         const response = await fetch(requestUrl, requestOptions);
 
         if (!response.ok) {
-            const bodyText = await response.text();
-            let detail = bodyText;
-            try {
-                const parsed = JSON.parse(bodyText);
-                detail =
-                    parsed.message ||
-                    parsed.error ||
-                    (typeof parsed.detail === "string" ? parsed.detail : JSON.stringify(parsed));
-            } catch {
-                // use bodyText as-is
-            }
-            throw new Error(`HTTP ${response.status}: ${detail || response.statusText}`);
+            await throwHttpError(response);
         }
         if (!parseResponse) {
             return {} as T;
@@ -335,6 +331,112 @@ export async function makeDoitRequest<T>(
         console.error(`Error making DoiT API ${method} request to ${requestUrl}:`, error);
         return null;
     }
+}
+
+// appendTrackingParams appends the shared MCP tracking query params (mcp, mcpVersion, plus any
+// mcpTool/mcpClient/mcpClientVersion/mcpProtocolVersion present in the tracking context) to a URL.
+function appendTrackingParams(url: string): string {
+    const tracking = getTrackingContext();
+    const sep = url.includes("?") ? "&" : "?";
+    let out = `${url}${sep}mcp=true&mcpVersion=${encodeURIComponent(SERVER_VERSION)}`;
+
+    if (tracking?.mcpTool) {
+        out += `&mcpTool=${encodeURIComponent(tracking.mcpTool)}`;
+    }
+    if (tracking?.mcpClient) {
+        out += `&mcpClient=${encodeURIComponent(tracking.mcpClient)}`;
+    }
+    if (tracking?.mcpClientVersion) {
+        out += `&mcpClientVersion=${encodeURIComponent(tracking.mcpClientVersion)}`;
+    }
+    if (tracking?.mcpProtocolVersion) {
+        out += `&mcpProtocolVersion=${encodeURIComponent(tracking.mcpProtocolVersion)}`;
+    }
+
+    return out;
+}
+
+// throwHttpError reads a non-OK response body, extracts the most specific message available,
+// and throws an Error carrying the HTTP status.
+async function throwHttpError(response: Response): Promise<never> {
+    const bodyText = await response.text();
+    let detail = bodyText;
+    try {
+        const parsed = JSON.parse(bodyText);
+        detail =
+            parsed.message ||
+            parsed.error ||
+            (typeof parsed.detail === "string" ? parsed.detail : JSON.stringify(parsed));
+    } catch {
+        // use bodyText as-is
+    }
+
+    throw new Error(`HTTP ${response.status}: ${detail || response.statusText}`);
+}
+
+function resolveConsoleBase(): { baseUrl: string; doFetch: typeof fetch } {
+    const scoped = getConsoleEnv();
+    if (scoped?.baseUrl) {
+        return {
+            baseUrl: scoped.baseUrl.replace(/\/$/, ""),
+            doFetch: scoped.proxyFetch ?? fetch,
+        };
+    }
+
+    const fallback = process.env.DOIT_CONSOLE_BASE || process.env.AUTH_SERVER_URL || "https://console.doit.com";
+
+    return { baseUrl: fallback.replace(/\/$/, ""), doFetch: fetch };
+}
+
+/**
+ * Calls a DoiT *console* endpoint (console.doit.com /api/...) rather than the public
+ * api.doit.com that makeDoitRequest targets. In the worker it routes through the
+ * CONSOLE_PROXY service binding (set via runWithConsoleEnv); elsewhere it uses the
+ * DOIT_CONSOLE_BASE / AUTH_SERVER_URL env vars. It does NOT append a customerContext
+ * (these endpoints are cross-customer) and, unlike makeDoitRequest, throws on HTTP and
+ * network errors so callers can surface the upstream message (e.g. 403 for non-doers).
+ */
+export async function makeConsoleRequest<T>(
+    path: string,
+    token: string,
+    options: { method?: string; body?: any; timeoutMs?: number } = {}
+): Promise<T> {
+    const { method = "GET", body = undefined, timeoutMs } = options;
+    const { baseUrl, doFetch } = resolveConsoleBase();
+
+    if (token === DEMO_TOKEN) {
+        return {} as T;
+    }
+
+    let requestUrl = `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+
+    requestUrl = appendTrackingParams(requestUrl);
+
+    const requestOptions: RequestInit = {
+        method,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+    };
+
+    if (timeoutMs !== undefined) {
+        requestOptions.signal = AbortSignal.timeout(timeoutMs);
+    }
+
+    if (method !== "GET" && body !== undefined) {
+        requestOptions.body = JSON.stringify(body);
+    }
+
+    debugLog("Console API request URL: ", DebugLevel.VERBOSE, requestUrl);
+    const response = await doFetch(requestUrl, requestOptions);
+
+    if (!response.ok) {
+        await throwHttpError(response);
+    }
+
+    return (await response.json()) as T;
 }
 
 /**

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -103,6 +103,7 @@ describe("MCP Tools Integration", () => {
                     "list_cloud_diagram_activity_groups",
                     "list_cloud_diagram_node_activities",
                     "search_cloud_diagrams",
+                    "search_customers",
                     "send_datahub_events",
                     "trigger_cloud_flow",
                     "list_cloudflow_connections",


### PR DESCRIPTION
## What

Adds a DoiT-employee-only `search_customers` MCP tool that finds customers across the whole base via the console search endpoint `POST /api/customers/v1/customers/search`, reached with `makeConsoleRequest` (not the public `api.doit.com` surface). Filters: classification, type, segment, tier package, domains, asset platforms, Flexsave, standalone (self-serve) assets, monthly cloud spend, invoiced spend and active contracts. Paged via `nextPageToken`.

## Notable changes

- New `src/tools/searchCustomers.ts` (+ `types/searchCustomers.ts`, tests), registered on both the worker and the stdio server.
- `util.ts`: adds the console-request layer (`makeConsoleRequest` + request-scoped console env), and extracts shared `appendTrackingParams` / `throwHttpError` helpers used by both `makeDoitRequest` and `makeConsoleRequest` (removes ~30 lines of duplication).
- The worker resolves the console-data base from `DOIT_CONSOLE_BASE` (falling back to the auth server), so it can be pointed at a local customers service in dev.

## How validated

- `tsc --noEmit` clean.
- Full vitest suite: **768 passed / 3 skipped (40 files)**.
- Exercised end-to-end against a local customers service + the dev dataset.

## Companion

Server-side endpoint: doiteng/omni#57292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
