### PR TITLE
feat(cloudflow): add list_cloudflows tool

### DIFF
--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -139,6 +139,8 @@ import {
   listCloudFlowConnectionsTool,
   ListCloudFlowTemplatesArgumentsSchema,
   listCloudFlowTemplatesTool,
+  ListCloudFlowsArgumentsSchema,
+  listCloudFlowsTool,
   RefineCloudflowArgumentsSchema,
   TriggerCloudFlowArgumentsSchema,
   refineCloudflowTool,
@@ -995,6 +997,7 @@ export class DoitMCPAgent extends McpAgent {
 
     // CloudFlow tools
     this.registerTool(triggerCloudFlowTool, TriggerCloudFlowArgumentsSchema);
+    this.registerTool(listCloudFlowsTool, ListCloudFlowsArgumentsSchema);
     this.registerTool(listCloudFlowConnectionsTool, ListCloudFlowConnectionsArgumentsSchema);
     this.registerTool(getCloudFlowConnectionTool, GetCloudFlowConnectionArgumentsSchema);
     this.registerTool(listCloudFlowTemplatesTool, ListCloudFlowTemplatesArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -242,6 +242,7 @@ import {
     getCloudFlowConnectionTool,
     getCloudFlowTemplateTool,
     listCloudFlowConnectionsTool,
+    listCloudFlowsTool,
     listCloudFlowTemplatesTool,
     refineCloudflowTool,
     triggerCloudFlowTool,
@@ -386,6 +387,7 @@ describe("ListToolsRequestSchema handler", () => {
                 updateAlertTool,
 
                 triggerCloudFlowTool,
+                listCloudFlowsTool,
                 listCloudFlowConnectionsTool,
                 getCloudFlowConnectionTool,
                 listCloudFlowTemplatesTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,6 +86,7 @@ import {
     handleRefineCloudflowRequest,
     handleTriggerCloudFlowRequest,
     listCloudFlowConnectionsTool,
+    listCloudFlowsTool,
     listCloudFlowTemplatesTool,
     refineCloudflowTool,
     triggerCloudFlowTool,
@@ -263,6 +264,7 @@ export function createServer() {
                 updateAlertTool,
 
                 triggerCloudFlowTool,
+                listCloudFlowsTool,
                 listCloudFlowConnectionsTool,
                 getCloudFlowConnectionTool,
                 listCloudFlowTemplatesTool,

--- a/src/tools/cloudflow.ts
+++ b/src/tools/cloudflow.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type {
     CloudFlowConnection,
     CloudFlowConnectionsResponse,
+    CloudFlowListResponse,
     CloudFlowTemplate,
     CloudFlowTemplatesResponse,
 } from "../types/cloudflow.js";
@@ -20,9 +21,11 @@ const CLOUDFLOW_BASE_URL = `${DOIT_API_BASE}/cloudflow/v1`;
 export const CLOUDFLOW_TRIGGER_BASE_URL = `${CLOUDFLOW_BASE_URL}/trigger`;
 export const CLOUDFLOW_CONNECTIONS_BASE_URL = `${CLOUDFLOW_BASE_URL}/connections`;
 export const CLOUDFLOW_TEMPLATES_BASE_URL = `${CLOUDFLOW_BASE_URL}/templates`;
+export const CLOUDFLOW_FLOWS_BASE_URL = `${CLOUDFLOW_BASE_URL}/flows`;
 
 export const DEFAULT_MAX_RESULTS_CLOUDFLOW_CONNECTIONS = "50";
 export const DEFAULT_MAX_RESULTS_CLOUDFLOW_TEMPLATES = "50";
+export const DEFAULT_MAX_RESULTS_CLOUDFLOW_FLOWS = "50";
 
 export const TriggerCloudFlowArgumentsSchema = z.object({
     flowID: z.string().describe("The ID of the CloudFlow flow to trigger"),
@@ -430,5 +433,61 @@ export async function handleGetCloudFlowTemplateRequest(args: any, token: string
     } catch (error) {
         if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
         return handleGeneralError(error, "handling get CloudFlow template request");
+    }
+}
+
+// Schema and metadata for list CloudFlows
+export const ListCloudFlowsArgumentsSchema = z.object({
+    maxResults: z
+        .string()
+        .optional()
+        .describe(`Maximum number of flows to return (1–500). Defaults to ${DEFAULT_MAX_RESULTS_CLOUDFLOW_FLOWS}.`),
+    pageToken: z
+        .string()
+        .optional()
+        .describe("Pagination cursor returned by a previous call, to request the next page of results."),
+});
+
+export const listCloudFlowsTool = {
+    name: "list_cloudflows",
+    description:
+        "Use this when the user wants to see their CloudFlow automation flows. Returns a cursor-paginated list of flows with their metadata, status, and last execution info.",
+    inputSchema: zodToMcpInputSchema(ListCloudFlowsArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Loading CloudFlows...",
+        "openai/toolInvocation/invoked": "CloudFlows loaded",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export async function handleListCloudFlowsRequest(args: any, token: string) {
+    try {
+        const { maxResults, pageToken } = ListCloudFlowsArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const params = new URLSearchParams();
+        params.append("maxResults", maxResults || DEFAULT_MAX_RESULTS_CLOUDFLOW_FLOWS);
+        if (pageToken) params.append("pageToken", pageToken);
+
+        const url = `${CLOUDFLOW_FLOWS_BASE_URL}?${params}`;
+
+        const data = await makeDoitRequest<CloudFlowListResponse>(url, token, {
+            method: "GET",
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to retrieve CloudFlows");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling list CloudFlows request");
     }
 }

--- a/src/types/cloudflow.ts
+++ b/src/types/cloudflow.ts
@@ -73,3 +73,31 @@ export type CloudFlowTemplatesResponse = {
     pageToken?: string | null;
     rowCount?: number | null;
 };
+
+export type CloudFlowItem = {
+    id: string;
+    name: string;
+    description?: string;
+    instructions?: string | null;
+    published: boolean;
+    triggerType?: string | null;
+    createTime: string;
+    updateTime?: string | null;
+    lastExecutedTime?: string | null;
+    lastExecutionStatus?:
+        | "pending"
+        | "running"
+        | "complete"
+        | "pending-approval"
+        | "failed"
+        | "sleeping"
+        | "stopped"
+        | null;
+    nextRun?: string | null;
+};
+
+export type CloudFlowListResponse = {
+    items: CloudFlowItem[];
+    pageToken?: string | null;
+    rowCount: null;
+};

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -41,6 +41,7 @@ import {
     handleGetCloudFlowConnectionRequest,
     handleGetCloudFlowTemplateRequest,
     handleListCloudFlowConnectionsRequest,
+    handleListCloudFlowsRequest,
     handleListCloudFlowTemplatesRequest,
     handleRefineCloudflowRequest,
     handleTriggerCloudFlowRequest,
@@ -367,6 +368,9 @@ async function runOriginalDispatch(
             break;
         case "refine_cloudflow":
             result = await handleRefineCloudflowRequest(args, token, options?.onProgress);
+            break;
+        case "list_cloudflows":
+            result = await handleListCloudFlowsRequest(args, token);
             break;
         case "list_alerts":
             result = await handleListAlertsRequest(args, token);

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -107,6 +107,7 @@ describe("MCP Tools Integration", () => {
                     "send_datahub_events",
                     "refine_cloudflow",
                     "trigger_cloud_flow",
+                    "list_cloudflows",
                     "list_cloudflow_connections",
                     "get_cloudflow_connection",
                     "list_cloudflow_templates",


### PR DESCRIPTION
## Summary

- Adds `list_cloudflows` MCP tool wrapping the new `GET /cloudflow/v1/flows` endpoint ([doiteng/omni#57283](https://github.com/doiteng/omni/pull/57283))
- Adds `CloudFlowItem` and `CloudFlowListResponse` types to `src/types/cloudflow.ts`
- Supports `maxResults` (1–500, default 50) and cursor-based `pageToken` pagination

## Test plan

- [ ] Verify `list_cloudflows` returns a paginated list of flows for an authenticated customer
- [ ] Verify `maxResults` and `pageToken` query params are forwarded correctly
- [ ] Verify error handling for invalid params (out-of-range `maxResults`, malformed `pageToken`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)