### PR TITLE
feat(users): add cancel_invite and resend_invite tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ This MCP server provides many tools including the following:
 - [`list_users`](https://developer.doit.com/reference/listusers): Returns a list of all users in the organization
 - [`update_user`](https://developer.doit.com/reference/updateuser): Updates user information including name, job function, phone, language, and role
 - [`invite_user`](https://developer.doit.com/reference/inviteuser): Invites a new user to the organization by email, optionally assigning a role and organization
+- [`cancel_invite`](https://developer.doit.com/reference/cancelinvite): Cancels a pending user invitation, invalidating its token while keeping the invite record visible
+- [`resend_invite`](https://developer.doit.com/reference/resendinvite): Resends a pending user invitation, resetting its expiry
 - [`list_roles`](https://developer.doit.com/reference/listroles): Returns a list of all IAM roles, including both preset and custom roles
 - [`list_products`](https://developer.doit.com/reference/listproducts): Lists products available for different platforms, optionally filtered by platform name
 - [`list_datahub_datasets`](https://developer.doit.com/reference/listdatahubdatasets): Returns a list of all DataHub datasets for the customer

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -161,10 +161,14 @@ import {
   listPlatformsTool,
 } from "../../src/tools/platforms.js";
 import {
+  CancelInviteArgumentsSchema,
+  cancelInviteTool,
   InviteUserArgumentsSchema,
   inviteUserTool,
   ListUsersArgumentsSchema,
   listUsersTool,
+  ResendInviteArgumentsSchema,
+  resendInviteTool,
   UpdateUserArgumentsSchema,
   updateUserTool,
 } from "../../src/tools/users.js";
@@ -1020,6 +1024,8 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(listUsersTool, ListUsersArgumentsSchema);
     this.registerTool(updateUserTool, UpdateUserArgumentsSchema);
     this.registerTool(inviteUserTool, InviteUserArgumentsSchema);
+    this.registerTool(cancelInviteTool, CancelInviteArgumentsSchema);
+    this.registerTool(resendInviteTool, ResendInviteArgumentsSchema);
 
     // Roles tools
     this.registerTool(listRolesTool, ListRolesArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -294,7 +294,7 @@ import {
     listTicketCommentsTool,
     listTicketsTool,
 } from "../tools/tickets.js";
-import { inviteUserTool, listUsersTool, updateUserTool } from "../tools/users.js";
+import { cancelInviteTool, inviteUserTool, listUsersTool, resendInviteTool, updateUserTool } from "../tools/users.js";
 import { validateUserTool } from "../tools/validateUser.js";
 import * as utilModule from "../utils/util.js";
 
@@ -398,6 +398,8 @@ describe("ListToolsRequestSchema handler", () => {
                 listUsersTool,
                 updateUserTool,
                 inviteUserTool,
+                cancelInviteTool,
+                resendInviteTool,
                 listRolesTool,
                 listProductsTool,
                 listLabelsTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -184,11 +184,15 @@ import {
     listTicketsTool,
 } from "./tools/tickets.js";
 import {
+    cancelInviteTool,
+    handleCancelInviteRequest,
     handleInviteUserRequest,
     handleListUsersRequest,
+    handleResendInviteRequest,
     handleUpdateUserRequest,
     inviteUserTool,
     listUsersTool,
+    resendInviteTool,
     updateUserTool,
 } from "./tools/users.js";
 import { handleValidateUserRequest, validateUserTool } from "./tools/validateUser.js";
@@ -275,6 +279,8 @@ export function createServer() {
                 listUsersTool,
                 updateUserTool,
                 inviteUserTool,
+                cancelInviteTool,
+                resendInviteTool,
                 listRolesTool,
                 listProductsTool,
                 listLabelsTool,
@@ -424,6 +430,7 @@ export {
     handleAnomalyRequest,
     handleAskAvaSyncRequest,
     handleAssignObjectsToLabelRequest,
+    handleCancelInviteRequest,
     handleCloudIncidentRequest,
     handleCloudIncidentsRequest,
     handleCreateAlertRequest,
@@ -489,6 +496,7 @@ export {
     handleListUsersRequest,
     handleRefineCloudflowRequest,
     handleReportsRequest,
+    handleResendInviteRequest,
     handleRunQueryRequest,
     handleSearchCloudDiagramsRequest,
     handleSearchCustomersRequest,

--- a/src/tools/__tests__/users.test.ts
+++ b/src/tools/__tests__/users.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
 import {
+    handleCancelInviteRequest,
     handleInviteUserRequest,
     handleListUsersRequest,
+    handleResendInviteRequest,
     handleUpdateUserRequest,
     USERS_BASE_URL,
     USERS_INVITE_URL,
@@ -386,5 +388,160 @@ describe("handleInviteUserRequest", () => {
                 body: { email: "newuser@example.com" },
             })
         );
+    });
+});
+
+describe("handleCancelInviteRequest", () => {
+    const mockToken = "fake-token";
+    const mockResponse = { id: "user-3", email: "invited@example.com", inviteStatus: "Cancelled" };
+
+    it("should call makeDoitRequest with POST and correct cancel URL", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+        await handleCancelInviteRequest({ id: "user-3" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("/user-3/cancel-invite"),
+            mockToken,
+            expect.objectContaining({
+                method: "POST",
+                additionalHeaders: expect.objectContaining({ "Idempotency-Key": expect.any(String) }),
+            })
+        );
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+        await handleCancelInviteRequest({ id: "user-3", customerContext: "customer-123" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ customerContext: "customer-123" })
+        );
+    });
+
+    it("should include dryRun query param when provided", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+        await handleCancelInviteRequest({ id: "user-3", dryRun: true }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("dryRun=true"),
+            mockToken,
+            expect.any(Object)
+        );
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(null);
+
+        const response = await handleCancelInviteRequest({ id: "user-3" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("cancel invite") }],
+            isError: true,
+        });
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as vi.Mock).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleCancelInviteRequest({ id: "user-3" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
+    });
+
+    it("should return validation error for empty id", async () => {
+        const response = await handleCancelInviteRequest({ id: "  " }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("User ID is required") }],
+            isError: true,
+        });
+    });
+});
+
+describe("handleResendInviteRequest", () => {
+    const mockToken = "fake-token";
+    const mockResponse = {
+        id: "user-3",
+        email: "invited@example.com",
+        inviteStatus: "Pending",
+        inviteExpiry: "2026-07-11T00:00:00Z",
+    };
+
+    it("should call makeDoitRequest with POST and correct resend URL", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+        await handleResendInviteRequest({ id: "user-3" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("/user-3/resend-invite"),
+            mockToken,
+            expect.objectContaining({
+                method: "POST",
+                additionalHeaders: expect.objectContaining({ "Idempotency-Key": expect.any(String) }),
+            })
+        );
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+        await handleResendInviteRequest({ id: "user-3", customerContext: "customer-123" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ customerContext: "customer-123" })
+        );
+    });
+
+    it("should include dryRun query param when provided", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+        await handleResendInviteRequest({ id: "user-3", dryRun: true }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("dryRun=true"),
+            mockToken,
+            expect.any(Object)
+        );
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue(null);
+
+        const response = await handleResendInviteRequest({ id: "user-3" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("resend invite") }],
+            isError: true,
+        });
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as vi.Mock).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleResendInviteRequest({ id: "user-3" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
+    });
+
+    it("should return validation error for empty id", async () => {
+        const response = await handleResendInviteRequest({ id: "" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("User ID is required") }],
+            isError: true,
+        });
     });
 });

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -206,3 +206,109 @@ export async function handleListUsersRequest(args: any, token: string) {
         return handleGeneralError(error, "handling list users request");
     }
 }
+
+export const CancelInviteArgumentsSchema = z.object({
+    id: z
+        .string()
+        .transform((val) => val.trim())
+        .pipe(z.string().min(1, "User ID is required and cannot be empty."))
+        .describe("The unique ID of the invited user whose invite should be cancelled."),
+    dryRun: z
+        .boolean()
+        .optional()
+        .describe("If true, validates and simulates the operation without committing changes."),
+});
+
+export const cancelInviteTool = {
+    name: "cancel_invite",
+    description:
+        "Use this when the user wants to cancel a pending invitation. Ask the user to confirm before executing. The invite document remains visible with inviteStatus: Cancelled, but the token becomes invalid. Do NOT use this for resending invites (use resend_invite) or inviting new users (use invite_user).",
+    inputSchema: zodToMcpInputSchema(CancelInviteArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Cancelling invite...",
+        "openai/toolInvocation/invoked": "Invite cancelled",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export const ResendInviteArgumentsSchema = z.object({
+    id: z
+        .string()
+        .transform((val) => val.trim())
+        .pipe(z.string().min(1, "User ID is required and cannot be empty."))
+        .describe("The unique ID of the invited user whose invite should be resent."),
+    dryRun: z
+        .boolean()
+        .optional()
+        .describe("If true, validates and simulates the operation without committing changes."),
+});
+
+export const resendInviteTool = {
+    name: "resend_invite",
+    description:
+        "Use this when the user wants to resend a pending invitation to reset its expiry. Ask the user to confirm before executing. Do NOT use this for cancelling invites (use cancel_invite) or inviting new users (use invite_user).",
+    inputSchema: zodToMcpInputSchema(ResendInviteArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Resending invite...",
+        "openai/toolInvocation/invoked": "Invite resent",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export async function handleCancelInviteRequest(args: any, token: string) {
+    try {
+        const { id, dryRun } = CancelInviteArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const params = new URLSearchParams();
+        if (dryRun !== undefined) params.append("dryRun", String(dryRun));
+        const query = params.toString();
+        const url = `${USERS_BASE_URL}/${encodeURIComponent(id)}/cancel-invite${query ? `?${query}` : ""}`;
+
+        const data = await makeDoitRequest(url, token, {
+            method: "POST",
+            customerContext,
+            additionalHeaders: { "Idempotency-Key": crypto.randomUUID() },
+        });
+
+        if (!data) return createErrorResponse("Failed to cancel invite");
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling cancel invite request");
+    }
+}
+
+export async function handleResendInviteRequest(args: any, token: string) {
+    try {
+        const { id, dryRun } = ResendInviteArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const params = new URLSearchParams();
+        if (dryRun !== undefined) params.append("dryRun", String(dryRun));
+        const query = params.toString();
+        const url = `${USERS_BASE_URL}/${encodeURIComponent(id)}/resend-invite${query ? `?${query}` : ""}`;
+
+        const data = await makeDoitRequest(url, token, {
+            method: "POST",
+            customerContext,
+            additionalHeaders: { "Idempotency-Key": crypto.randomUUID() },
+        });
+
+        if (!data) return createErrorResponse("Failed to resend invite");
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling resend invite request");
+    }
+}

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import type { UsersResponse } from "../types/users.js";
 import { JOB_FUNCTION_VALUES, LANGUAGE_VALUES } from "../types/users.js";
@@ -278,7 +279,7 @@ export async function handleCancelInviteRequest(args: any, token: string) {
         const data = await makeDoitRequest(url, token, {
             method: "POST",
             customerContext,
-            additionalHeaders: { "Idempotency-Key": crypto.randomUUID() },
+            additionalHeaders: { "Idempotency-Key": randomUUID() },
         });
 
         if (!data) return createErrorResponse("Failed to cancel invite");
@@ -302,7 +303,7 @@ export async function handleResendInviteRequest(args: any, token: string) {
         const data = await makeDoitRequest(url, token, {
             method: "POST",
             customerContext,
-            additionalHeaders: { "Idempotency-Key": crypto.randomUUID() },
+            additionalHeaders: { "Idempotency-Key": randomUUID() },
         });
 
         if (!data) return createErrorResponse("Failed to resend invite");

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -102,7 +102,13 @@ import {
     handleListTicketCommentsRequest,
     handleListTicketsRequest,
 } from "../tools/tickets.js";
-import { handleInviteUserRequest, handleListUsersRequest, handleUpdateUserRequest } from "../tools/users.js";
+import {
+    handleCancelInviteRequest,
+    handleInviteUserRequest,
+    handleListUsersRequest,
+    handleResendInviteRequest,
+    handleUpdateUserRequest,
+} from "../tools/users.js";
 import { handleValidateUserRequest } from "../tools/validateUser.js";
 import { APPROVAL_TTL_MS, type ApprovalStore, buildApprovalResponse, mintApprovalToken } from "./approval.js";
 import {
@@ -399,6 +405,12 @@ async function runOriginalDispatch(
             break;
         case "invite_user":
             result = await handleInviteUserRequest(args, token);
+            break;
+        case "cancel_invite":
+            result = await handleCancelInviteRequest(args, token);
+            break;
+        case "resend_invite":
+            result = await handleResendInviteRequest(args, token);
             break;
         case "list_roles":
             result = await handleListRolesRequest(args, token);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -252,6 +252,7 @@ export async function makeDoitRequest<T>(
         customerContext?: string;
         parseResponse?: boolean;
         timeoutMs?: number;
+        additionalHeaders?: Record<string, string>;
     } = {}
 ): Promise<T | null> {
     const {
@@ -261,6 +262,7 @@ export async function makeDoitRequest<T>(
         customerContext,
         parseResponse = true,
         timeoutMs,
+        additionalHeaders,
     } = options;
 
     const resolvedUrl = applyRuntimeDoiTApiBase(url);
@@ -281,10 +283,11 @@ export async function makeDoitRequest<T>(
         return {} as T;
     }
 
-    const headers = {
+    const headers: Record<string, string> = {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
         Accept: "application/json",
+        ...additionalHeaders,
     };
 
     let requestUrl = appendParams ? appendUrlParameters(resolvedUrl, customerContext) : resolvedUrl;

--- a/test/integration/fixtures/iam.ts
+++ b/test/integration/fixtures/iam.ts
@@ -123,3 +123,18 @@ export const resourcePermissionsFixture = {
     ],
     public: "viewer",
 };
+
+export const cancelInviteFixture = {
+    id: "user-3",
+    email: "invited@example.com",
+    status: "invited",
+    inviteStatus: "Cancelled",
+};
+
+export const resendInviteFixture = {
+    id: "user-3",
+    email: "invited@example.com",
+    status: "invited",
+    inviteStatus: "Pending",
+    inviteExpiry: "2026-07-11T00:00:00Z",
+};

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -62,8 +62,10 @@ import {
 } from "./datahub.js";
 import {
     accountTeamFixture,
+    cancelInviteFixture,
     inviteUserFixture,
     organizationsFixture,
+    resendInviteFixture,
     resourcePermissionsFixture,
     rolesFixture,
     updateUserFixture,
@@ -88,6 +90,8 @@ export const fixtures = {
     products: productsFixture,
     validateUser: validateUserFixture,
     inviteUser: inviteUserFixture,
+    cancelInvite: cancelInviteFixture,
+    resendInvite: resendInviteFixture,
     accountTeam: accountTeamFixture,
     resourcePermissions: resourcePermissionsFixture,
 

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -29,9 +29,15 @@ export const mockedDoitApiHandlers = [
         return new HttpResponse(null, { status: 404 });
     }),
 
-    // Users
+    // Users — register specific paths before the :id catch-all
     http.post(`${API_BASE}/iam/v1/users/invite`, () => {
         return HttpResponse.json(fixtures.inviteUser, { status: 201 });
+    }),
+    http.post(`${API_BASE}/iam/v1/users/:id/cancel-invite`, () => {
+        return HttpResponse.json(fixtures.cancelInvite);
+    }),
+    http.post(`${API_BASE}/iam/v1/users/:id/resend-invite`, () => {
+        return HttpResponse.json(fixtures.resendInvite);
     }),
     http.patch(`${API_BASE}/iam/v1/users/:id`, () => {
         return HttpResponse.json(fixtures.updateUser);

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -76,6 +76,7 @@ describe("MCP Tools Integration", () => {
                     "get_resource_permissions",
                     "get_theme",
                     "get_ticket",
+                    "cancel_invite",
                     "invite_user",
                     "list_account_team",
                     "list_alerts",
@@ -120,6 +121,7 @@ describe("MCP Tools Integration", () => {
                     "update_label",
                     "update_report",
                     "update_user",
+                    "resend_invite",
                     "validate_user",
                 ].sort()
             );
@@ -368,6 +370,73 @@ describe("MCP Tools Integration", () => {
             });
             const text = getTextContent(result);
             expect(text).toContain("Invalid arguments");
+        });
+    });
+
+    describe("cancel_invite", () => {
+        it("returns cancelled invite response from mock API", async () => {
+            const result = await client.callTool({
+                name: "cancel_invite",
+                arguments: { id: "user-3" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("user-3");
+            expect(parsed.inviteStatus).toBe("Cancelled");
+        });
+
+        it("rejects missing id", async () => {
+            const result = await client.callTool({
+                name: "cancel_invite",
+                arguments: {},
+            });
+            const text = getTextContent(result);
+            expect(result.isError).toBe(true);
+            expect(text).toBeTruthy();
+        });
+
+        it("rejects empty id", async () => {
+            const result = await client.callTool({
+                name: "cancel_invite",
+                arguments: { id: "  " },
+            });
+            const text = getTextContent(result);
+            expect(result.isError).toBe(true);
+            expect(text).toContain("User ID is required");
+        });
+    });
+
+    describe("resend_invite", () => {
+        it("returns resent invite response from mock API", async () => {
+            const result = await client.callTool({
+                name: "resend_invite",
+                arguments: { id: "user-3" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("user-3");
+            expect(parsed.inviteStatus).toBe("Pending");
+            expect(parsed.inviteExpiry).toBeTruthy();
+        });
+
+        it("rejects missing id", async () => {
+            const result = await client.callTool({
+                name: "resend_invite",
+                arguments: {},
+            });
+            const text = getTextContent(result);
+            expect(result.isError).toBe(true);
+            expect(text).toBeTruthy();
+        });
+
+        it("rejects empty id", async () => {
+            const result = await client.callTool({
+                name: "resend_invite",
+                arguments: { id: "" },
+            });
+            const text = getTextContent(result);
+            expect(result.isError).toBe(true);
+            expect(text).toContain("User ID is required");
         });
     });
 


### PR DESCRIPTION
## Summary

Adds `cancel_invite` and `resend_invite` MCP tools to complete the user invite management lifecycle. These tools pair with the existing `invite_user` tool.

**Endpoints added (2):**
- `POST /iam/v1/users/{id}/cancel-invite` → `cancel_invite` tool
- `POST /iam/v1/users/{id}/resend-invite` → `resend_invite` tool

**API Reference:**
- [cancel_invite](https://developer.doit.com/reference/cancelinvite)
- [resend_invite](https://developer.doit.com/reference/resendinvite)

## Implementation Details

- Both tools accept `id` (required) and optional `dryRun` parameters
- An `Idempotency-Key` header is auto-generated per request (as required by the API) using `crypto.randomUUID()`
- Extended `makeDoitRequest` to accept `additionalHeaders` option (backwards-compatible)
- Both tools have `destructiveHint: true` and include confirmation guidance in their descriptions

## Registration Checklist

- [x] Registered in `src/server.ts` (STDIO local MCP)
- [x] Registered in `doit-mcp-server/src/index.ts` (SSE remote Cloudflare Worker MCP)
- [x] Case handlers added in `src/utils/toolsHandler.ts` dispatch switch
- [x] Unit tests added in `src/tools/__tests__/users.test.ts`
- [x] Integration fixtures added in `test/integration/fixtures/iam.ts`
- [x] MSW handlers added in `test/integration/mockedDoitApi/index.ts`
- [x] Tool-call tests added in `test/integration/stdio/tools.test.ts`
- [x] Tool names added to sorted list assertions in `test/integration/stdio/tools.test.ts` and `src/__tests__/server.test.ts`
- [x] `README.md` updated

## Reviewer Notes

Please check:
1. Schema correctness vs the API reference (path params, `dryRun` query param, `Idempotency-Key` header)
2. Auth/permission scope — requires `usersManager` permission per the API docs
3. Tool registered in BOTH `src/server.ts` and `doit-mcp-server/src/index.ts`
4. Test coverage for both happy path and validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)