### PR TITLE
feat(themes): add set_active_theme and update_theme tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ This MCP server provides many tools including the following:
 - [`list_themes`](https://developer.doit.com/reference/listcustomthemes): Returns the custom color themes defined for your account
 - [`get_theme`](https://developer.doit.com/reference/getcustomtheme): Returns details of a specific custom color theme by ID or name
 - [`get_active_theme`](https://developer.doit.com/reference/getactivetheme): Returns the color theme currently active for the authenticated user (the sentinel `"default"` means the built-in default is in use)
+- [`set_active_theme`](https://developer.doit.com/reference/patchactivetheme): Sets the active color theme for the authenticated user; pass the sentinel `"default"` to revert to the built-in default
+- [`update_theme`](https://developer.doit.com/reference/patchcustomtheme): Updates an existing custom color theme (rename, change primary color, or replace the color palette) by ID or name
 - [`list_account_team`](https://developer.doit.com/reference/listaccountteam): Returns the DoiT account managers assigned to the customer, including name, email, role, and Calendly link
 - [`get_resource_permissions`](https://developer.doit.com/reference/getresourcepermission-2): Returns the sharing settings (per-user roles and public visibility) for a specific alert, budget, report, or allocation
 - [`get_aws_account`](https://developer.doit.com/reference/getawsaccount): Returns the CloudConnect details of a connected AWS account (role ARN, billing S3 bucket, enabled and supported features) by AWS account ID

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ This MCP server provides many tools including the following:
 - [`list_themes`](https://developer.doit.com/reference/listcustomthemes): Returns the custom color themes defined for your account
 - [`get_theme`](https://developer.doit.com/reference/getcustomtheme): Returns details of a specific custom color theme by ID or name
 - [`get_active_theme`](https://developer.doit.com/reference/getactivetheme): Returns the color theme currently active for the authenticated user (the sentinel `"default"` means the built-in default is in use)
-- [`set_active_theme`](https://developer.doit.com/reference/patchactivetheme): Sets the active color theme for the authenticated user; pass the sentinel `"default"` to revert to the built-in default
-- [`update_theme`](https://developer.doit.com/reference/patchcustomtheme): Updates an existing custom color theme (rename, change primary color, or replace the color palette) by ID or name
+- [`set_active_theme`](https://developer.doit.com/reference/setactivetheme): Sets the active color theme for the authenticated user; pass the sentinel `"default"` to revert to the built-in default
+- [`update_theme`](https://developer.doit.com/reference/updatecustomtheme): Updates an existing custom color theme (rename, change primary color, or replace the color palette) by ID or name
 - [`list_account_team`](https://developer.doit.com/reference/listaccountteam): Returns the DoiT account managers assigned to the customer, including name, email, role, and Calendly link
 - [`get_resource_permissions`](https://developer.doit.com/reference/getresourcepermission-2): Returns the sharing settings (per-user roles and public visibility) for a specific alert, budget, report, or allocation
 - [`get_aws_account`](https://developer.doit.com/reference/getawsaccount): Returns the CloudConnect details of a connected AWS account (role ARN, billing S3 bucket, enabled and supported features) by AWS account ID

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -213,6 +213,10 @@ import {
   getActiveThemeTool,
   ListThemesArgumentsSchema,
   listThemesTool,
+  SetActiveThemeArgumentsSchema,
+  setActiveThemeTool,
+  UpdateThemeArgumentsSchema,
+  updateThemeTool,
 } from "../../src/tools/themes.js";
 import {
   ListProductsArgumentsSchema,
@@ -1049,6 +1053,8 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(listThemesTool, ListThemesArgumentsSchema);
     this.registerTool(getThemeTool, GetThemeArgumentsSchema);
     this.registerTool(getActiveThemeTool, GetActiveThemeArgumentsSchema);
+    this.registerTool(setActiveThemeTool, SetActiveThemeArgumentsSchema);
+    this.registerTool(updateThemeTool, UpdateThemeArgumentsSchema);
 
     // AWS Account Management tools
     this.registerTool(getAwsAccountTool, GetAwsAccountArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -286,7 +286,13 @@ import {
 } from "../tools/reports.js";
 import { listRolesTool } from "../tools/roles.js";
 import { searchCustomersTool } from "../tools/searchCustomers.js";
-import { getActiveThemeTool, getThemeTool, listThemesTool } from "../tools/themes.js";
+import {
+    getActiveThemeTool,
+    getThemeTool,
+    listThemesTool,
+    setActiveThemeTool,
+    updateThemeTool,
+} from "../tools/themes.js";
 import {
     createTicketCommentTool,
     createTicketTool,
@@ -411,6 +417,8 @@ describe("ListToolsRequestSchema handler", () => {
                 listThemesTool,
                 getThemeTool,
                 getActiveThemeTool,
+                setActiveThemeTool,
+                updateThemeTool,
                 getAwsAccountTool,
                 getCloudConnectSupportedFeaturesTool,
                 listDatahubDatasetsTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -169,7 +169,11 @@ import {
     handleGetActiveThemeRequest,
     handleGetThemeRequest,
     handleListThemesRequest,
+    handleSetActiveThemeRequest,
+    handleUpdateThemeRequest,
     listThemesTool,
+    setActiveThemeTool,
+    updateThemeTool,
 } from "./tools/themes.js";
 import {
     createTicketCommentTool,
@@ -288,6 +292,8 @@ export function createServer() {
                 listThemesTool,
                 getThemeTool,
                 getActiveThemeTool,
+                setActiveThemeTool,
+                updateThemeTool,
                 getAwsAccountTool,
                 getCloudConnectSupportedFeaturesTool,
                 listDatahubDatasetsTool,
@@ -493,6 +499,7 @@ export {
     handleSearchCloudDiagramsRequest,
     handleSearchCustomersRequest,
     handleSendDatahubEventsRequest,
+    handleSetActiveThemeRequest,
     handleTriggerCloudFlowRequest,
     handleUpdateAlertRequest,
     handleUpdateAllocationRequest,
@@ -501,6 +508,7 @@ export {
     handleUpdateDatahubDatasetRequest,
     handleUpdateLabelRequest,
     handleUpdateReportRequest,
+    handleUpdateThemeRequest,
     handleUpdateUserRequest,
     handleValidateUserRequest,
 };

--- a/src/tools/__tests__/themes.test.ts
+++ b/src/tools/__tests__/themes.test.ts
@@ -7,8 +7,12 @@ import {
     handleGetActiveThemeRequest,
     handleGetThemeRequest,
     handleListThemesRequest,
+    handleSetActiveThemeRequest,
+    handleUpdateThemeRequest,
     listThemesTool,
+    setActiveThemeTool,
     THEMES_BASE_URL,
+    updateThemeTool,
 } from "../themes.js";
 
 vi.mock("../../utils/util.js", async (importOriginal) => {
@@ -264,5 +268,204 @@ describe("get_active_theme", () => {
             content: [{ type: "text", text: expect.stringContaining("Network error") }],
             isError: true,
         });
+    });
+});
+
+describe("setActiveThemeTool metadata", () => {
+    it("should be write-only and named set_active_theme", () => {
+        expect(setActiveThemeTool.annotations.readOnlyHint).toBe(false);
+        expect(setActiveThemeTool.name).toBe("set_active_theme");
+    });
+});
+
+describe("set_active_theme", () => {
+    const mockToken = "fake-token";
+
+    it("should call makeDoitRequest with PATCH method and themeId in body", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "theme-1" });
+
+        const response = await handleSetActiveThemeRequest({ themeId: "theme-1" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(ACTIVE_THEME_URL, mockToken, {
+            method: "PATCH",
+            body: { themeId: "theme-1" },
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.themeId).toBe("theme-1");
+    });
+
+    it("should support the default sentinel to revert to built-in default", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "default" });
+
+        const response = await handleSetActiveThemeRequest({ themeId: "default" }, mockToken);
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.themeId).toBe("default");
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "theme-1" });
+
+        await handleSetActiveThemeRequest({ themeId: "theme-1", customerContext: "customer-123" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(ACTIVE_THEME_URL, mockToken, {
+            method: "PATCH",
+            body: { themeId: "theme-1" },
+            customerContext: "customer-123",
+        });
+    });
+
+    it("should return error when themeId is missing", async () => {
+        const response = await handleSetActiveThemeRequest({}, mockToken);
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error when themeId is empty string", async () => {
+        const response = await handleSetActiveThemeRequest({ themeId: "" }, mockToken);
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleSetActiveThemeRequest({ themeId: "theme-1" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("active theme");
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleSetActiveThemeRequest({ themeId: "theme-1" }, mockToken);
+
+        expect(response.isError).toBe(true);
+    });
+});
+
+describe("updateThemeTool metadata", () => {
+    it("should be destructive and named update_theme", () => {
+        expect(updateThemeTool.annotations.readOnlyHint).toBe(false);
+        expect(updateThemeTool.annotations.destructiveHint).toBe(true);
+        expect(updateThemeTool.name).toBe("update_theme");
+    });
+});
+
+describe("update_theme", () => {
+    const mockToken = "fake-token";
+    const mockUpdatedTheme = {
+        id: "theme-1",
+        name: "Ocean Updated",
+        primaryColor: "#0B57D0",
+        colors: {
+            light: ["#0B57D0", "#34A853"],
+            dark: ["#0842A0", "#1E8E3E"],
+        },
+        createTime: "2026-01-01T00:00:00.000Z",
+        updateTime: "2026-03-01T00:00:00.000Z",
+    };
+
+    it("should call makeDoitRequest with PATCH method by id and return updated theme", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockUpdatedTheme);
+
+        const response = await handleUpdateThemeRequest({ id: "theme-1", newName: "Ocean Updated" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${THEMES_BASE_URL}/theme-1`, mockToken, {
+            method: "PATCH",
+            body: { name: "Ocean Updated" },
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.id).toBe("theme-1");
+        expect(parsed.name).toBe("Ocean Updated");
+    });
+
+    it("should resolve theme by name when id is not provided", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce({ rowCount: 1, themes: [mockTheme] })
+            .mockResolvedValueOnce(mockUpdatedTheme);
+
+        const response = await handleUpdateThemeRequest({ name: "Ocean", primaryColor: "#0B57D0" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenNthCalledWith(1, THEMES_BASE_URL, mockToken, {
+            method: "GET",
+            customerContext: undefined,
+        });
+        expect(makeDoitRequest).toHaveBeenNthCalledWith(2, `${THEMES_BASE_URL}/theme-1`, mockToken, {
+            method: "PATCH",
+            body: { primaryColor: "#0B57D0" },
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.id).toBe("theme-1");
+    });
+
+    it("should update colors palette when provided", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockUpdatedTheme);
+
+        const newColors = { light: ["#0B57D0"], dark: ["#0842A0"] };
+        await handleUpdateThemeRequest({ id: "theme-1", colors: newColors }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${THEMES_BASE_URL}/theme-1`, mockToken, {
+            method: "PATCH",
+            body: { colors: newColors },
+            customerContext: undefined,
+        });
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockUpdatedTheme);
+
+        await handleUpdateThemeRequest(
+            { id: "theme-1", newName: "New Name", customerContext: "customer-123" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${THEMES_BASE_URL}/theme-1`, mockToken, {
+            method: "PATCH",
+            body: { name: "New Name" },
+            customerContext: "customer-123",
+        });
+    });
+
+    it("should return error when neither id nor name is provided", async () => {
+        const response = await handleUpdateThemeRequest({ newName: "X" }, mockToken);
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("Either id or name must be provided");
+    });
+
+    it("should return error when no update fields are provided", async () => {
+        const response = await handleUpdateThemeRequest({ id: "theme-1" }, mockToken);
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error when name matches no theme", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ rowCount: 0, themes: [] });
+
+        const response = await handleUpdateThemeRequest({ name: "Nonexistent", newName: "X" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("No items found");
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleUpdateThemeRequest({ id: "theme-1", newName: "X" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("theme");
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleUpdateThemeRequest({ id: "theme-1", newName: "X" }, mockToken);
+
+        expect(response.isError).toBe(true);
     });
 });

--- a/src/tools/__tests__/themes.test.ts
+++ b/src/tools/__tests__/themes.test.ts
@@ -281,13 +281,13 @@ describe("setActiveThemeTool metadata", () => {
 describe("set_active_theme", () => {
     const mockToken = "fake-token";
 
-    it("should call makeDoitRequest with PATCH method and themeId in body", async () => {
+    it("should call makeDoitRequest with PUT method and themeId in body", async () => {
         (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ themeId: "theme-1" });
 
         const response = await handleSetActiveThemeRequest({ themeId: "theme-1" }, mockToken);
 
         expect(makeDoitRequest).toHaveBeenCalledWith(ACTIVE_THEME_URL, mockToken, {
-            method: "PATCH",
+            method: "PUT",
             body: { themeId: "theme-1" },
             customerContext: undefined,
         });
@@ -311,7 +311,7 @@ describe("set_active_theme", () => {
         await handleSetActiveThemeRequest({ themeId: "theme-1", customerContext: "customer-123" }, mockToken);
 
         expect(makeDoitRequest).toHaveBeenCalledWith(ACTIVE_THEME_URL, mockToken, {
-            method: "PATCH",
+            method: "PUT",
             body: { themeId: "theme-1" },
             customerContext: "customer-123",
         });

--- a/src/tools/themes.ts
+++ b/src/tools/themes.ts
@@ -200,7 +200,7 @@ export async function handleSetActiveThemeRequest(args: any, token: string) {
         const { customerContext } = args;
 
         const data = await makeDoitRequest<ActiveTheme>(ACTIVE_THEME_URL, token, {
-            method: "PATCH",
+            method: "PUT",
             body: { themeId: parsed.themeId },
             customerContext,
         });
@@ -249,30 +249,7 @@ export const updateThemeTool = {
     name: "update_theme",
     description:
         "Use this when the user wants to modify an existing custom color theme — rename it, change its primary color, or update its color palette. Accepts either the theme ID or a partial name match. Ask the user to confirm changes before executing. Do NOT use this for creating a new theme or changing which theme is active (use set_active_theme).",
-    inputSchema: {
-        type: "object",
-        properties: {
-            id: { type: "string", description: "The ID of the theme to update." },
-            name: {
-                type: "string",
-                description: "Partial name match (case-insensitive) used to find the theme when ID is unknown.",
-            },
-            newName: { type: "string", description: "New display name for the theme." },
-            primaryColor: {
-                type: "string",
-                description: "New primary hex color for the theme (e.g. #1A73E8).",
-            },
-            colors: {
-                type: "object",
-                description: "New color palette. Provide both light and dark arrays.",
-                properties: {
-                    light: { type: "array", items: { type: "string" }, description: "Hex colors for light mode." },
-                    dark: { type: "array", items: { type: "string" }, description: "Hex colors for dark mode." },
-                },
-                required: ["light", "dark"],
-            },
-        },
-    },
+    inputSchema: zodToMcpInputSchema(UpdateThemeArgumentsSchema),
     annotations: {
         readOnlyHint: false,
         destructiveHint: true,

--- a/src/tools/themes.ts
+++ b/src/tools/themes.ts
@@ -166,3 +166,162 @@ export async function handleGetActiveThemeRequest(args: any, token: string) {
         return handleGeneralError(error, "handling get active theme request");
     }
 }
+
+// Schema and metadata for set active theme
+export const SetActiveThemeArgumentsSchema = z.object({
+    themeId: z
+        .string()
+        .min(1)
+        .describe(
+            'The ID of the theme to set as active, or the reserved sentinel "default" to revert to the built-in default (no custom theme).'
+        ),
+});
+
+export const setActiveThemeTool = {
+    name: "set_active_theme",
+    description:
+        'Use this when the user wants to change or activate a custom color theme for their Cloud Analytics reports. Accepts a theme ID or the sentinel "default" to revert to the built-in default. Ask the user to confirm the change before executing. Do NOT use this to retrieve the current active theme (use get_active_theme) or to update theme colors (use update_theme).',
+    inputSchema: zodToMcpInputSchema(SetActiveThemeArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Setting active theme...",
+        "openai/toolInvocation/invoked": "Active theme set",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export async function handleSetActiveThemeRequest(args: any, token: string) {
+    try {
+        const parsed = SetActiveThemeArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const data = await makeDoitRequest<ActiveTheme>(ACTIVE_THEME_URL, token, {
+            method: "PATCH",
+            body: { themeId: parsed.themeId },
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to set active theme");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling set active theme request");
+    }
+}
+
+// Schema and metadata for update theme
+const ThemeColorsSchema = z.object({
+    light: z.array(z.string()).describe("Array of hex color values for light mode."),
+    dark: z.array(z.string()).describe("Array of hex color values for dark mode."),
+});
+
+export const UpdateThemeArgumentsSchema = z
+    .object({
+        id: z
+            .string()
+            .transform((val) => val.trim())
+            .pipe(z.string().min(1))
+            .optional()
+            .describe("The ID of the theme to update."),
+        name: z
+            .string()
+            .optional()
+            .describe("Partial name match (case-insensitive) used to find the theme when ID is unknown."),
+        newName: z.string().min(1).optional().describe("New display name for the theme."),
+        primaryColor: z.string().optional().describe("New primary hex color for the theme (e.g. #1A73E8)."),
+        colors: ThemeColorsSchema.optional().describe(
+            "New color palette for the theme. Provide both light and dark arrays."
+        ),
+    })
+    .refine((d) => d.id || d.name, { message: "Either id or name must be provided to identify the theme." })
+    .refine((d) => d.newName || d.primaryColor || d.colors, {
+        message: "At least one of newName, primaryColor, or colors must be provided.",
+    });
+
+export const updateThemeTool = {
+    name: "update_theme",
+    description:
+        "Use this when the user wants to modify an existing custom color theme — rename it, change its primary color, or update its color palette. Accepts either the theme ID or a partial name match. Ask the user to confirm changes before executing. Do NOT use this for creating a new theme or changing which theme is active (use set_active_theme).",
+    inputSchema: {
+        type: "object",
+        properties: {
+            id: { type: "string", description: "The ID of the theme to update." },
+            name: {
+                type: "string",
+                description: "Partial name match (case-insensitive) used to find the theme when ID is unknown.",
+            },
+            newName: { type: "string", description: "New display name for the theme." },
+            primaryColor: {
+                type: "string",
+                description: "New primary hex color for the theme (e.g. #1A73E8).",
+            },
+            colors: {
+                type: "object",
+                description: "New color palette. Provide both light and dark arrays.",
+                properties: {
+                    light: { type: "array", items: { type: "string" }, description: "Hex colors for light mode." },
+                    dark: { type: "array", items: { type: "string" }, description: "Hex colors for dark mode." },
+                },
+                required: ["light", "dark"],
+            },
+        },
+    },
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Updating theme...",
+        "openai/toolInvocation/invoked": "Theme updated",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export async function handleUpdateThemeRequest(args: any, token: string) {
+    try {
+        const parsed = UpdateThemeArgumentsSchema.parse(args);
+        const { customerContext } = args;
+        let resolvedId = parsed.id;
+
+        if (!resolvedId && parsed.name) {
+            const listData = await makeDoitRequest<ThemesResponse>(THEMES_BASE_URL, token, {
+                method: "GET",
+                customerContext,
+            });
+            const items = listData?.themes ?? [];
+            const result = matchByName(items, parsed.name);
+            if ("error" in result) return createErrorResponse(result.error);
+            resolvedId = result.resolved;
+        }
+
+        const { newName, primaryColor, colors } = parsed;
+        const body: Record<string, unknown> = {};
+        if (newName !== undefined) body.name = newName;
+        if (primaryColor !== undefined) body.primaryColor = primaryColor;
+        if (colors !== undefined) body.colors = colors;
+
+        const url = `${THEMES_BASE_URL}/${encodeURIComponent(resolvedId as string)}`;
+        const data = await makeDoitRequest<CustomTheme>(url, token, {
+            method: "PATCH",
+            body,
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to update theme");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling update theme request");
+    }
+}

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -93,7 +93,13 @@ import {
 } from "../tools/reports.js";
 import { handleListRolesRequest } from "../tools/roles.js";
 import { handleSearchCustomersRequest } from "../tools/searchCustomers.js";
-import { handleGetActiveThemeRequest, handleGetThemeRequest, handleListThemesRequest } from "../tools/themes.js";
+import {
+    handleGetActiveThemeRequest,
+    handleGetThemeRequest,
+    handleListThemesRequest,
+    handleSetActiveThemeRequest,
+    handleUpdateThemeRequest,
+} from "../tools/themes.js";
 import {
     // createTicketTool, // Re-enable alongside the WRITE_GATED_SUMMARIES entry below.
     handleCreateTicketCommentRequest,
@@ -444,6 +450,12 @@ async function runOriginalDispatch(
             break;
         case "get_active_theme":
             result = await handleGetActiveThemeRequest(args, token);
+            break;
+        case "set_active_theme":
+            result = await handleSetActiveThemeRequest(args, token);
+            break;
+        case "update_theme":
+            result = await handleUpdateThemeRequest(args, token);
             break;
         case "list_datahub_datasets":
             result = await handleListDatahubDatasetsRequest(args, token);

--- a/test/integration/fixtures/analytics.ts
+++ b/test/integration/fixtures/analytics.ts
@@ -504,6 +504,22 @@ export const activeThemeFixture = {
     themeId: "theme-1",
 };
 
+export const setActiveThemeFixture = {
+    themeId: "theme-2",
+};
+
+export const updateThemeFixture = {
+    id: "theme-1",
+    name: "Ocean Updated",
+    primaryColor: "#0B57D0",
+    colors: {
+        light: ["#0B57D0", "#34A853"],
+        dark: ["#0842A0", "#1E8E3E"],
+    },
+    createTime: "2026-01-01T00:00:00.000Z",
+    updateTime: "2026-03-01T00:00:00.000Z",
+};
+
 export const insightFixture = {
     key: "delete-ebs-volumes",
     source: "aws-cost-optimization-hub",

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -26,12 +26,14 @@ import {
     reportConfigFixture,
     reportResultsFixture,
     reportsFixture,
+    setActiveThemeFixture,
     updateAlertFixture,
     updateAllocationFixture,
     updateAnnotationFixture,
     updateBudgetFixture,
     updateLabelFixture,
     updateReportFixture,
+    updateThemeFixture,
 } from "./analytics.js";
 import { anomaliesFixture, anomalyFixture } from "./anomalies.js";
 import { avaAskSyncFixture, avaAskSyncWithConversationFixture } from "./ava.js";
@@ -166,6 +168,8 @@ export const fixtures = {
     commitments: commitmentsFixture,
 
     activeTheme: activeThemeFixture,
+    setActiveTheme: setActiveThemeFixture,
+    updateTheme: updateThemeFixture,
     insight: insightFixture,
 
     avaAskSync: avaAskSyncFixture,

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -361,6 +361,14 @@ export const mockedDoitApiHandlers = [
     http.get(`${API_BASE}/analytics/v1/settings/active-theme`, () => {
         return HttpResponse.json(fixtures.activeTheme);
     }),
+    http.patch(`${API_BASE}/analytics/v1/settings/active-theme`, () => {
+        return HttpResponse.json(fixtures.setActiveTheme);
+    }),
+
+    // Themes (custom)
+    http.patch(`${API_BASE}/analytics/v1/settings/themes/:id`, () => {
+        return HttpResponse.json(fixtures.updateTheme);
+    }),
 
     // Insights (retrieve a single insight by source + key)
     http.get(`${API_BASE}/insights/v1/results/source/:source/insight/:key`, ({ params }) => {

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -361,7 +361,7 @@ export const mockedDoitApiHandlers = [
     http.get(`${API_BASE}/analytics/v1/settings/active-theme`, () => {
         return HttpResponse.json(fixtures.activeTheme);
     }),
-    http.patch(`${API_BASE}/analytics/v1/settings/active-theme`, () => {
+    http.put(`${API_BASE}/analytics/v1/settings/active-theme`, () => {
         return HttpResponse.json(fixtures.setActiveTheme);
     }),
 

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -119,7 +119,9 @@ describe("MCP Tools Integration", () => {
                     "update_datahub_dataset",
                     "update_label",
                     "update_report",
+                    "update_theme",
                     "update_user",
+                    "set_active_theme",
                     "validate_user",
                 ].sort()
             );
@@ -260,6 +262,53 @@ describe("MCP Tools Integration", () => {
             const text = getTextContent(result);
             const parsed = JSON.parse(text);
             expect(parsed.themeId).toBe("theme-1");
+        });
+    });
+
+    describe("set_active_theme", () => {
+        it("sets the active theme and returns the updated active theme", async () => {
+            const result = await client.callTool({ name: "set_active_theme", arguments: { themeId: "theme-2" } });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.themeId).toBe("theme-2");
+        });
+
+        it("returns a validation error when themeId is missing", async () => {
+            const result = await client.callTool({ name: "set_active_theme", arguments: {} });
+            const text = getTextContent(result);
+            expect(text).toContain("themeId");
+        });
+    });
+
+    describe("update_theme", () => {
+        it("updates a theme by id and returns the updated theme", async () => {
+            const result = await client.callTool({
+                name: "update_theme",
+                arguments: { id: "theme-1", newName: "Ocean Updated" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.id).toBe("theme-1");
+            expect(parsed.name).toBe("Ocean Updated");
+            expect(parsed.primaryColor).toBe("#0B57D0");
+        });
+
+        it("returns a validation error when neither id nor name is provided", async () => {
+            const result = await client.callTool({
+                name: "update_theme",
+                arguments: { newName: "X" },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("Either id or name must be provided");
+        });
+
+        it("returns a validation error when no update fields are provided", async () => {
+            const result = await client.callTool({
+                name: "update_theme",
+                arguments: { id: "theme-1" },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("newName");
         });
     });
 


### PR DESCRIPTION
## Endpoints Added

- **`set_active_theme`** — `PATCH /analytics/v1/settings/active-theme`
  Sets the active color theme for the authenticated user. Accepts a theme ID or the reserved sentinel `"default"` to revert to the built-in default.
  API reference: https://developer.doit.com/reference/patchactivetheme

- **`update_theme`** — `PATCH /analytics/v1/settings/themes/{id}`
  Updates an existing custom color theme (rename, change primary color, or replace the color palette). Accepts either the theme ID or a partial name match (case-insensitive).
  API reference: https://developer.doit.com/reference/patchcustomtheme

## Related

These two tools complete the Themes CRUD coverage alongside the existing `list_themes`, `get_theme`, and `get_active_theme` tools.

No related GitHub PRs, Jira tickets, or Glean docs found specifically for these endpoints.

## Checklist

- [x] `set_active_theme` registered in `src/server.ts` (local stdio MCP)
- [x] `update_theme` registered in `src/server.ts` (local stdio MCP)
- [x] `set_active_theme` registered in `doit-mcp-server/src/index.ts` (remote Cloudflare Worker MCP)
- [x] `update_theme` registered in `doit-mcp-server/src/index.ts` (remote Cloudflare Worker MCP)
- [x] Unit tests added in `src/tools/__tests__/themes.test.ts`
- [x] Integration fixture added (`setActiveThemeFixture`, `updateThemeFixture`)
- [x] MSW handlers added for both endpoints
- [x] Integration tool-call tests added in `test/integration/stdio/tools.test.ts`
- [x] `tools/list` assertion updated (both new tool names added)
- [x] `src/__tests__/server.test.ts` in sync
- [x] `yarn check:dev`, `yarn test`, integration tests, and `yarn build` all pass
- [x] `README.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)