### PR TITLE
feat(support): add list_ticket_tags and add_ticket_tags tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ This MCP server provides many tools including the following:
 - [`get_ticket`](https://developer.doit.com/reference/idofticketget): Get details of a specific support ticket by its ID
 - [`list_ticket_comments`](https://developer.doit.com/reference/idofticketcommentslist): List all comments on a support ticket by its ID. Customers see only public comments; DoiT employees see both public and private comments
 - [`create_ticket_comment`](https://developer.doit.com/reference/idofticketcommentspost): Add a comment to an existing support ticket. For customers, comments are always public. For DoiT employees, comments can be marked as private internal notes
+- [`list_ticket_tags`](https://developer.doit.com/reference/listtickettags): List the tags currently set on a support ticket. Customers see only their own namespaced tags (prefix stripped); DoiT employees see the full tag set verbatim
+- [`add_ticket_tags`](https://developer.doit.com/reference/idoftickettagsadd): Add one or more tags to an existing support ticket. Additive — existing tags are preserved and re-adding a tag is a no-op; returns the tags actually stored after normalization
 - [`list_invoices`](https://developer.doit.com/reference/listinvoices): List all current and historical invoices for your organization from the DoiT API
 - [`get_invoice`](https://developer.doit.com/reference/getinvoice): Retrieve the full details of an invoice specified by the invoice number from the DoiT API
 - [`list_allocations`](https://developer.doit.com/reference/listallocations): List allocations for report or run_query configuration that your account has access to from the DoiT API

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -79,6 +79,8 @@ import {
   dimensionTool,
 } from "../../src/tools/dimension.js";
 import {
+  AddTicketTagsArgumentsSchema,
+  addTicketTagsTool,
   CreateTicketArgumentsSchema,
   createTicketTool,
   CreateTicketCommentArgumentsSchema,
@@ -89,6 +91,8 @@ import {
   listTicketCommentsTool,
   ListTicketsArgumentsSchema,
   listTicketsTool,
+  ListTicketTagsArgumentsSchema,
+  listTicketTagsTool,
 } from "../../src/tools/tickets.js";
 import {
   ListInvoicesArgumentsSchema,
@@ -991,6 +995,8 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(listTicketCommentsTool, ListTicketCommentsArgumentsSchema);
     this.registerTool(createTicketCommentTool, CreateTicketCommentArgumentsSchema);
     this.registerTool(createTicketTool, CreateTicketArgumentsSchema);
+    this.registerTool(listTicketTagsTool, ListTicketTagsArgumentsSchema);
+    this.registerTool(addTicketTagsTool, AddTicketTagsArgumentsSchema);
 
     // Invoices tools
     this.registerTool(listInvoicesTool, ListInvoicesArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -295,11 +295,13 @@ import {
     updateThemeTool,
 } from "../tools/themes.js";
 import {
+    addTicketTagsTool,
     createTicketCommentTool,
     createTicketTool,
     getTicketTool,
     listTicketCommentsTool,
     listTicketsTool,
+    listTicketTagsTool,
 } from "../tools/tickets.js";
 import { inviteUserTool, listUsersTool, updateUserTool } from "../tools/users.js";
 import { validateUserTool } from "../tools/validateUser.js";
@@ -379,6 +381,8 @@ describe("ListToolsRequestSchema handler", () => {
                 listTicketCommentsTool,
                 createTicketCommentTool,
                 createTicketTool,
+                listTicketTagsTool,
+                addTicketTagsTool,
                 listInvoicesTool,
                 getInvoiceTool,
                 listAllocationsTool,

--- a/src/server.ts
+++ b/src/server.ts
@@ -192,16 +192,20 @@ import {
     updateThemeTool,
 } from "./tools/themes.js";
 import {
+    addTicketTagsTool,
     createTicketCommentTool,
     createTicketTool,
     getTicketTool,
+    handleAddTicketTagsRequest,
     handleCreateTicketCommentRequest,
     handleCreateTicketRequest,
     handleGetTicketRequest,
     handleListTicketCommentsRequest,
     handleListTicketsRequest,
+    handleListTicketTagsRequest,
     listTicketCommentsTool,
     listTicketsTool,
+    listTicketTagsTool,
 } from "./tools/tickets.js";
 import {
     handleInviteUserRequest,
@@ -269,6 +273,8 @@ export function createServer() {
                 listTicketCommentsTool,
                 createTicketCommentTool,
                 createTicketTool,
+                listTicketTagsTool,
+                addTicketTagsTool,
                 listInvoicesTool,
                 getInvoiceTool,
                 listAllocationsTool,
@@ -446,6 +452,7 @@ export const server = createServer();
 export {
     createErrorResponse,
     formatZodError,
+    handleAddTicketTagsRequest,
     handleAnomaliesRequest,
     handleAnomalyRequest,
     handleAskAvaSyncRequest,
@@ -514,6 +521,7 @@ export {
     handleListThemesRequest,
     handleListTicketCommentsRequest,
     handleListTicketsRequest,
+    handleListTicketTagsRequest,
     handleListUsersRequest,
     handleRefineCloudflowRequest,
     handleReportsRequest,

--- a/src/tools/__tests__/tickets.test.ts
+++ b/src/tools/__tests__/tickets.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
 import {
+    handleAddTicketTagsRequest,
     handleCreateTicketCommentRequest,
     handleGetTicketRequest,
     handleListTicketCommentsRequest,
     handleListTicketsRequest,
+    handleListTicketTagsRequest,
     TICKETS_BASE_URL,
 } from "../tickets.js";
 
@@ -405,6 +407,139 @@ describe("handleCreateTicketCommentRequest", () => {
 
     it("should return error when ticketId is non-numeric", async () => {
         const response = await handleCreateTicketCommentRequest({ ticketId: "ticket-abc", body: "test" }, mockToken);
+
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("numeric") }],
+            isError: true,
+        });
+    });
+});
+
+describe("handleListTicketTagsRequest", () => {
+    const mockToken = "fake-token";
+
+    it("should call makeDoitRequest with correct URL and return data", async () => {
+        const mockResponse = { tags: ["billing", "urgent"] };
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+        const response = await handleListTicketTagsRequest({ ticketId: "12345" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${TICKETS_BASE_URL}/12345/tags`, mockToken, {
+            method: "GET",
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.tags).toEqual(["billing", "urgent"]);
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ tags: [] });
+
+        await handleListTicketTagsRequest({ ticketId: "12345", customerContext: "customer-abc" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(expect.any(String), mockToken, {
+            method: "GET",
+            customerContext: "customer-abc",
+        });
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleListTicketTagsRequest({ ticketId: "12345" }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("ticket tags") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when ticketId is missing", async () => {
+        const response = await handleListTicketTagsRequest({}, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Required") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when ticketId is non-numeric and not call makeDoitRequest", async () => {
+        const response = await handleListTicketTagsRequest({ ticketId: "ticket-abc" }, mockToken);
+
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("numeric") }],
+            isError: true,
+        });
+    });
+});
+
+describe("handleAddTicketTagsRequest", () => {
+    const mockToken = "fake-token";
+    const validArgs = { ticketId: "12345", tags: ["billing", "urgent"] };
+
+    it("should call makeDoitRequest with POST, correct URL, and body", async () => {
+        const mockResponse = { applied_tags: ["customer_tag/billing", "customer_tag/urgent"] };
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+        const response = await handleAddTicketTagsRequest(validArgs, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${TICKETS_BASE_URL}/12345/tags`, mockToken, {
+            method: "POST",
+            body: { tags: ["billing", "urgent"] },
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.applied_tags).toEqual(["customer_tag/billing", "customer_tag/urgent"]);
+    });
+
+    it("should pass customerContext to makeDoitRequest", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ applied_tags: [] });
+
+        await handleAddTicketTagsRequest({ ...validArgs, customerContext: "customer-abc" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ customerContext: "customer-abc" })
+        );
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleAddTicketTagsRequest(validArgs, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("ticket tags") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when ticketId is missing", async () => {
+        const response = await handleAddTicketTagsRequest({ tags: ["billing"] }, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Required") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when tags is empty and not call makeDoitRequest", async () => {
+        const response = await handleAddTicketTagsRequest({ ticketId: "12345", tags: [] }, mockToken);
+
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("At least one tag") }],
+            isError: true,
+        });
+    });
+
+    it("should return error when ticketId is non-numeric and not call makeDoitRequest", async () => {
+        const response = await handleAddTicketTagsRequest({ ticketId: "ticket-abc", tags: ["billing"] }, mockToken);
 
         expect(makeDoitRequest).not.toHaveBeenCalled();
         expect(response).toEqual({

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -341,3 +341,111 @@ export async function handleCreateTicketCommentRequest(args: any, token: string)
         return handleGeneralError(error, "handling create ticket comment request");
     }
 }
+
+// Response shape for GET /support/v1/tickets/{ticketId}/tags
+export interface TicketTagsResponse {
+    tags: string[];
+}
+
+// Response shape for POST /support/v1/tickets/{ticketId}/tags
+export interface AddTicketTagsResponse {
+    applied_tags: string[];
+}
+
+// Arguments schema for listing ticket tags
+export const ListTicketTagsArgumentsSchema = z.object({
+    ticketId: ListTicketCommentsArgumentsSchema.shape.ticketId.describe(
+        "The numeric ID of the support ticket whose tags to retrieve."
+    ),
+});
+
+// Tool definition for listing ticket tags
+export const listTicketTagsTool = {
+    name: "list_ticket_tags",
+    description:
+        "Returns the tags currently set on a support ticket. For customers, only tags under the customer namespace are returned (with the prefix stripped). For DoiT employees, the full tag set is returned verbatim, including internal namespaces. Do NOT use this for ticket comments (use list_ticket_comments) or ticket details (use get_ticket).",
+    inputSchema: zodToMcpInputSchema(ListTicketTagsArgumentsSchema),
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Loading ticket tags...",
+        "openai/toolInvocation/invoked": "Ticket tags loaded",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+// Handler for listing ticket tags
+export async function handleListTicketTagsRequest(args: any, token: string) {
+    try {
+        const { ticketId } = ListTicketTagsArgumentsSchema.parse(args);
+        const { customerContext } = args;
+        const url = `${TICKETS_BASE_URL}/${encodeURIComponent(ticketId)}/tags`;
+        const data = await makeDoitRequest<TicketTagsResponse>(url, token, {
+            method: "GET",
+            customerContext,
+        });
+        if (!data) {
+            return createErrorResponse("Failed to retrieve ticket tags");
+        }
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling list ticket tags request");
+    }
+}
+
+// Arguments schema for adding ticket tags
+export const AddTicketTagsArgumentsSchema = z.object({
+    ticketId: ListTicketCommentsArgumentsSchema.shape.ticketId.describe(
+        "The numeric ID of the support ticket to add tags to."
+    ),
+    tags: z
+        .array(z.string().min(1, "A tag cannot be empty.").max(80, "A tag cannot exceed 80 characters."))
+        .min(1, "At least one tag is required.")
+        .max(50, "No more than 50 tags can be added at once.")
+        .describe(
+            "The tags to add. The operation is additive — existing tags are preserved and re-adding an existing tag is a no-op. Tags are normalized (trimmed + lowercased) server-side; customer tags are auto-prefixed with a customer namespace."
+        ),
+});
+
+// Tool definition for adding ticket tags
+export const addTicketTagsTool = {
+    name: "add_ticket_tags",
+    description:
+        "Adds one or more tags to an existing support ticket. The operation is additive — only the listed tags are added and existing tags are preserved; re-adding a tag that is already present is a successful no-op. Returns the tags that were actually stored after server-side normalization. Do NOT use this to replace or remove tags.",
+    inputSchema: zodToMcpInputSchema(AddTicketTagsArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Adding tags to ticket...",
+        "openai/toolInvocation/invoked": "Tags added",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+// Handler for adding ticket tags
+export async function handleAddTicketTagsRequest(args: any, token: string) {
+    try {
+        const { ticketId, tags } = AddTicketTagsArgumentsSchema.parse(args);
+        const { customerContext } = args;
+        const url = `${TICKETS_BASE_URL}/${encodeURIComponent(ticketId)}/tags`;
+        const data = await makeDoitRequest<AddTicketTagsResponse>(url, token, {
+            method: "POST",
+            body: { tags },
+            customerContext,
+        });
+        if (!data) {
+            return createErrorResponse("Failed to add ticket tags");
+        }
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling add ticket tags request");
+    }
+}

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -108,11 +108,13 @@ import {
 } from "../tools/themes.js";
 import {
     // createTicketTool, // Re-enable alongside the WRITE_GATED_SUMMARIES entry below.
+    handleAddTicketTagsRequest,
     handleCreateTicketCommentRequest,
     handleCreateTicketRequest,
     handleGetTicketRequest,
     handleListTicketCommentsRequest,
     handleListTicketsRequest,
+    handleListTicketTagsRequest,
 } from "../tools/tickets.js";
 import { handleInviteUserRequest, handleListUsersRequest, handleUpdateUserRequest } from "../tools/users.js";
 import { handleValidateUserRequest } from "../tools/validateUser.js";
@@ -335,6 +337,12 @@ async function runOriginalDispatch(
             break;
         case "create_ticket":
             result = await handleCreateTicketRequest(args, token);
+            break;
+        case "list_ticket_tags":
+            result = await handleListTicketTagsRequest(args, token);
+            break;
+        case "add_ticket_tags":
+            result = await handleAddTicketTagsRequest(args, token);
             break;
         case "list_invoices":
             result = await handleListInvoicesRequest(args, token);

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -79,12 +79,14 @@ import {
     validateUserFixture,
 } from "./iam.js";
 import {
+    addTicketTagsFixture,
     createTicketCommentFixture,
     platformsFixture,
     productsFixture,
     ticketCommentsFixture,
     ticketDetailFixture,
     ticketsFixture,
+    ticketTagsFixture,
 } from "./support.js";
 
 export const fixtures = {
@@ -134,6 +136,8 @@ export const fixtures = {
     ticketDetail: ticketDetailFixture,
     ticketComments: ticketCommentsFixture,
     createTicketComment: createTicketCommentFixture,
+    ticketTags: ticketTagsFixture,
+    addTicketTags: addTicketTagsFixture,
 
     cloudDiagrams: cloudDiagramsFixture,
     cloudDiagramsStats: cloudDiagramsStatsFixture,

--- a/test/integration/fixtures/support.ts
+++ b/test/integration/fixtures/support.ts
@@ -73,3 +73,11 @@ export const createTicketCommentFixture = {
     created: 1700030000000,
     attachments: [],
 };
+
+export const ticketTagsFixture = {
+    tags: ["billing", "urgent"],
+};
+
+export const addTicketTagsFixture = {
+    applied_tags: ["customer_tag/billing", "customer_tag/urgent"],
+};

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -143,6 +143,20 @@ export const mockedDoitApiHandlers = [
         }
         return new HttpResponse(null, { status: 404 });
     }),
+    // Tags routes must be registered before the catch-all /:ticketId route
+    http.post(`${API_BASE}/support/v1/tickets/:ticketId/tags`, async ({ params, request }) => {
+        if (params.ticketId === "12345") {
+            const body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ ...fixtures.addTicketTags, _requestBody: body });
+        }
+        return new HttpResponse(null, { status: 404 });
+    }),
+    http.get(`${API_BASE}/support/v1/tickets/:ticketId/tags`, ({ params }) => {
+        if (params.ticketId === "12345") {
+            return HttpResponse.json(fixtures.ticketTags);
+        }
+        return new HttpResponse(null, { status: 404 });
+    }),
     http.get(`${API_BASE}/support/v1/tickets/:ticketId`, ({ params }) => {
         if (params.ticketId === "12345") {
             return HttpResponse.json(fixtures.ticketDetail);

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -30,6 +30,7 @@ describe("MCP Tools Integration", () => {
 
             expect(names).toEqual(
                 [
+                    "add_ticket_tags",
                     "ask_ava_sync",
                     "assign_objects_to_label",
                     "compare_spend",
@@ -98,6 +99,7 @@ describe("MCP Tools Integration", () => {
                     "list_roles",
                     "list_themes",
                     "list_ticket_comments",
+                    "list_ticket_tags",
                     "list_tickets",
                     "list_users",
                     "run_query",
@@ -801,6 +803,70 @@ describe("MCP Tools Integration", () => {
             const result = await client.callTool({
                 name: "create_ticket_comment",
                 arguments: { ticketId: "ticket-abc", body: "test" },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("numeric");
+        });
+    });
+
+    describe("list_ticket_tags", () => {
+        it("returns tags for a ticket", async () => {
+            const result = await client.callTool({ name: "list_ticket_tags", arguments: { ticketId: "12345" } });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.tags).toEqual(["billing", "urgent"]);
+        });
+
+        it("rejects missing ticketId", async () => {
+            const result = await client.callTool({ name: "list_ticket_tags", arguments: {} });
+            const text = getTextContent(result);
+            expect(text).toContain("ticketId");
+        });
+
+        it("rejects non-numeric ticketId", async () => {
+            const result = await client.callTool({
+                name: "list_ticket_tags",
+                arguments: { ticketId: "ticket-abc" },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("numeric");
+        });
+    });
+
+    describe("add_ticket_tags", () => {
+        it("returns applied tags and sends correct POST body", async () => {
+            const result = await client.callTool({
+                name: "add_ticket_tags",
+                arguments: { ticketId: "12345", tags: ["billing", "urgent"] },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.applied_tags).toEqual(["customer_tag/billing", "customer_tag/urgent"]);
+            expect(parsed._requestBody.tags).toEqual(["billing", "urgent"]);
+        });
+
+        it("rejects missing ticketId", async () => {
+            const result = await client.callTool({
+                name: "add_ticket_tags",
+                arguments: { tags: ["billing"] },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("ticketId");
+        });
+
+        it("rejects empty tags array", async () => {
+            const result = await client.callTool({
+                name: "add_ticket_tags",
+                arguments: { ticketId: "12345", tags: [] },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("At least one tag");
+        });
+
+        it("rejects non-numeric ticketId", async () => {
+            const result = await client.callTool({
+                name: "add_ticket_tags",
+                arguments: { ticketId: "ticket-abc", tags: ["billing"] },
             });
             const text = getTextContent(result);
             expect(text).toContain("numeric");


### PR DESCRIPTION
## Summary
Adds MCP coverage for the two DoiT **Support Requests** tag endpoints (the third, `DELETE …/tags`, is intentionally out of scope — this MCP exposes no DELETE operations). Completes the previously partial Support category.

| Tool | Method | Path |
|------|--------|------|
| `list_ticket_tags` | GET | `/support/v1/tickets/{ticketId}/tags` |
| `add_ticket_tags` | POST | `/support/v1/tickets/{ticketId}/tags` |

- `list_ticket_tags` — read-only; returns the tags on a ticket. Customers see only their namespaced tags (prefix stripped); DoiT employees see the full set verbatim.
- `add_ticket_tags` — additive write; existing tags are preserved and re-adding is a no-op. Body `{ tags: string[] }` (1–50 items, each 1–80 chars). Returns `{ applied_tags }` echoing the stored strings after server-side normalization.

## API reference
- List tags: https://developer.doit.com/reference/listtickettags
- Add tags: https://developer.doit.com/reference/idoftickettagsadd

## Related context
- Mirrors the existing ticket tools in `src/tools/tickets.ts` (`list_ticket_comments`, `create_ticket_comment`) — same numeric `ticketId` validation and request patterns.
- Prior Support/ticket coverage: #206, #207 lineage of the API-coverage loop.

## Registration checklist
- [x] Tool + handler in `src/tools/tickets.ts`
- [x] Dispatch in `src/utils/toolsHandler.ts`
- [x] Registered in LOCAL MCP `src/server.ts`
- [x] Registered in REMOTE MCP `doit-mcp-server/src/index.ts`
- [x] Unit tests `src/tools/__tests__/tickets.test.ts`
- [x] Integration: fixtures + MSW handler + tool-call tests + `tools/list` assertion (and `src/__tests__/server.test.ts` kept in sync)
- [x] README updated

## Verification
- `yarn check:dev` ✅
- `yarn test` ✅ (903 passed)
- `cd test/integration && yarn test` ✅ (176 passed)
- `yarn build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)