### PR TITLE
feat(aws,ava): add create_aws_account_role and submit_ava_feedback tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ This MCP server provides many tools including the following:
 - [`list_commitments`](https://developer.doit.com/reference/listcommitments): Returns a list of commitments (reserved capacity or spend agreements) with cloud providers
 - [`get_commitment`](https://developer.doit.com/reference/getcommitment): Returns details of a specific commitment by ID, including periods and attainment data
 - [`ask_ava_sync`](https://developer.doit.com/reference/askavasync): Ask DoiT AVA, the cloud cost and infrastructure expert, a question about the user's DoiT account, cloud spending, or optimization opportunities. Note: AVA can take a long time to respond for complex questions.
+- [`submit_ava_feedback`](https://developer.doit.com/reference/avafeedback): Submit feedback (thumbs up/down with an optional comment) on a specific AVA answer, using the conversationId and answerId returned by a prior non-ephemeral `ask_ava_sync` call
 - [`list_organizations`](https://developer.doit.com/reference/listorganizations): Returns a list of organizations accessible to the authenticated user
 - [`list_platforms`](https://developer.doit.com/reference/listplatforms): Returns a list of all available platforms
 - [`list_users`](https://developer.doit.com/reference/listusers): Returns a list of all users in the organization
@@ -219,6 +220,7 @@ This MCP server provides many tools including the following:
 - [`update_resource_permissions`](https://developer.doit.com/reference/updateresourcepermissions): Updates the sharing settings for a specific alert, budget, report, or allocation. Accepts an optional `permissions` array of per-user role entries (owner/editor/viewer) and an optional `public` visibility level (`"editor"`, `"viewer"`, or `null` for private)
 - [`get_aws_account`](https://developer.doit.com/reference/getawsaccount): Returns the CloudConnect details of a connected AWS account (role ARN, billing S3 bucket, enabled and supported features) by AWS account ID
 - [`get_cloud_connect_supported_features`](https://developer.doit.com/reference/getcloudconnectsupportedfeatures): Returns the DoiT CloudConnect features supported for a connected cloud account (AWS account ID or Azure tenant ID) and whether the required permissions are present
+- [`create_aws_account_role`](https://developer.doit.com/reference/createaccountrole): Connects an AWS account to DoiT CloudConnect (or updates an existing connection) by registering the IAM role ARN and the DoiT features to enable; when `real-time-data` is enabled, the CloudTrail S3 bucket name and region are required
 - [`get_insight`](https://developer.doit.com/reference/getinsightresult): Returns the metadata and aggregate summary (savings, risk counts, status) of a single optimization insight identified by its source and key
 
 

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -35,6 +35,8 @@ import {
 import {
   AskAvaSyncArgumentsSchema,
   askAvaSyncTool,
+  SubmitAvaFeedbackArgumentsSchema,
+  submitAvaFeedbackTool,
 } from "../../src/tools/ava.js";
 import {
   CreateReportArgumentsSchema,
@@ -211,6 +213,8 @@ import {
   updateFolderTool,
 } from "../../src/tools/folders.js";
 import {
+  CreateAwsAccountRoleArgumentsSchema,
+  createAwsAccountRoleTool,
   GetAwsAccountArgumentsSchema,
   getAwsAccountTool,
   GetCloudConnectSupportedFeaturesArgumentsSchema,
@@ -1092,6 +1096,7 @@ export class DoitMCPAgent extends McpAgent {
     // AWS Account Management tools
     this.registerTool(getAwsAccountTool, GetAwsAccountArgumentsSchema);
     this.registerTool(getCloudConnectSupportedFeaturesTool, GetCloudConnectSupportedFeaturesArgumentsSchema);
+    this.registerTool(createAwsAccountRoleTool, CreateAwsAccountRoleArgumentsSchema);
 
     // DataHub Datasets tools
     this.registerTool(listDatahubDatasetsTool, ListDatahubDatasetsArgumentsSchema);
@@ -1128,6 +1133,7 @@ export class DoitMCPAgent extends McpAgent {
 
     // AVA tools
     this.registerTool(askAvaSyncTool, AskAvaSyncArgumentsSchema);
+    this.registerTool(submitAvaFeedbackTool, SubmitAvaFeedbackArgumentsSchema);
 
     // Auto-generated tools — every OpenAPI operation not already hand-covered above.
     // See src/tools/handWrittenTools.ts (coversEndpoint) for what's excluded.

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -226,8 +226,12 @@ import {
 } from "../tools/annotations.js";
 import { anomaliesTool, anomalyTool } from "../tools/anomalies.js";
 import { getAssetTool, listAssetsTool } from "../tools/assets.js";
-import { askAvaSyncTool } from "../tools/ava.js";
-import { getAwsAccountTool, getCloudConnectSupportedFeaturesTool } from "../tools/awsAccounts.js";
+import { askAvaSyncTool, submitAvaFeedbackTool } from "../tools/ava.js";
+import {
+    createAwsAccountRoleTool,
+    getAwsAccountTool,
+    getCloudConnectSupportedFeaturesTool,
+} from "../tools/awsAccounts.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "../tools/budgets.js";
 import {
     findCloudDiagramsTool,
@@ -438,6 +442,7 @@ describe("ListToolsRequestSchema handler", () => {
                 updateThemeTool,
                 getAwsAccountTool,
                 getCloudConnectSupportedFeaturesTool,
+                createAwsAccountRoleTool,
                 listDatahubDatasetsTool,
                 getDatahubDatasetTool,
                 createDatahubDatasetTool,
@@ -465,6 +470,7 @@ describe("ListToolsRequestSchema handler", () => {
                 getResourcePermissionsTool,
                 updateResourcePermissionsTool,
                 askAvaSyncTool,
+                submitAvaFeedbackTool,
                 // confirmActionTool, // disabled with the approval gate
                 ...generatedToolDefinitions,
             ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,8 +31,12 @@ import {
 } from "./tools/annotations.js";
 import { handleAnomaliesRequest, handleAnomalyRequest } from "./tools/anomalies.js";
 import { handleGetAssetRequest, handleListAssetsRequest } from "./tools/assets.js";
-import { handleAskAvaSyncRequest } from "./tools/ava.js";
-import { handleGetAwsAccountRequest, handleGetCloudConnectSupportedFeaturesRequest } from "./tools/awsAccounts.js";
+import { handleAskAvaSyncRequest, handleSubmitAvaFeedbackRequest } from "./tools/ava.js";
+import {
+    handleCreateAwsAccountRoleRequest,
+    handleGetAwsAccountRequest,
+    handleGetCloudConnectSupportedFeaturesRequest,
+} from "./tools/awsAccounts.js";
 import {
     handleCreateBudgetRequest,
     handleGetBudgetRequest,
@@ -280,6 +284,7 @@ export {
     handleCreateAlertRequest,
     handleCreateAllocationRequest,
     handleCreateAnnotationRequest,
+    handleCreateAwsAccountRoleRequest,
     handleCreateBudgetRequest,
     handleCreateCloudFlowConnectionRequest,
     handleCreateDatahubDatasetRequest,
@@ -348,6 +353,7 @@ export {
     handleSearchCustomersRequest,
     handleSendDatahubEventsRequest,
     handleSetActiveThemeRequest,
+    handleSubmitAvaFeedbackRequest,
     handleTriggerCloudFlowRequest,
     handleUpdateAlertRequest,
     handleUpdateAllocationRequest,

--- a/src/tools/__tests__/ava.test.ts
+++ b/src/tools/__tests__/ava.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
-import { AVA_BASE_URL, AVA_DEFAULT_TIMEOUT_MS, handleAskAvaSyncRequest } from "../ava.js";
+import {
+    AVA_BASE_URL,
+    AVA_DEFAULT_TIMEOUT_MS,
+    handleAskAvaSyncRequest,
+    handleSubmitAvaFeedbackRequest,
+    submitAvaFeedbackTool,
+} from "../ava.js";
 
 vi.mock("../../utils/util.js", async (importOriginal) => {
     const actual = await importOriginal();
@@ -169,6 +175,80 @@ describe("handleAskAvaSyncRequest", () => {
         expect(makeDoitRequest).not.toHaveBeenCalled();
         expect(response).toEqual({
             content: [{ type: "text", text: expect.stringContaining("conversationId") }],
+            isError: true,
+        });
+    });
+});
+
+describe("submitAvaFeedbackTool metadata", () => {
+    it("should be a write tool with the correct name and endpoint", () => {
+        expect(submitAvaFeedbackTool.annotations.readOnlyHint).toBe(false);
+        expect(submitAvaFeedbackTool.annotations.destructiveHint).toBe(false);
+        expect(submitAvaFeedbackTool.name).toBe("submit_ava_feedback");
+        expect(submitAvaFeedbackTool.coversEndpoint).toBe("post:/ava/v1/feedback");
+    });
+});
+
+describe("handleSubmitAvaFeedbackRequest", () => {
+    it("should POST feedback (without parsing the empty response) and confirm success", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        const response = await handleSubmitAvaFeedbackRequest(
+            { conversationId: "conv-abc123", answerId: "ans-xyz456", positive: true, text: "Great answer" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${AVA_BASE_URL}/feedback`, mockToken, {
+            method: "POST",
+            body: {
+                conversationId: "conv-abc123",
+                answerId: "ans-xyz456",
+                feedback: { positive: true, text: "Great answer" },
+            },
+            customerContext: undefined,
+            parseResponse: false,
+        });
+        expect(response.content[0].text).toContain("Successfully submitted");
+        expect(response.isError).toBeUndefined();
+    });
+
+    it("should omit text from the feedback body when not provided and pass customerContext", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        await handleSubmitAvaFeedbackRequest(
+            { conversationId: "conv-abc123", answerId: "ans-xyz456", positive: false, customerContext: "customer-123" },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${AVA_BASE_URL}/feedback`, mockToken, {
+            method: "POST",
+            body: {
+                conversationId: "conv-abc123",
+                answerId: "ans-xyz456",
+                feedback: { positive: false },
+            },
+            customerContext: "customer-123",
+            parseResponse: false,
+        });
+    });
+
+    it("should return error when required arguments are missing", async () => {
+        const response = await handleSubmitAvaFeedbackRequest({ conversationId: "conv-abc123" }, mockToken);
+
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleSubmitAvaFeedbackRequest(
+            { conversationId: "conv-abc123", answerId: "ans-xyz456", positive: true },
+            mockToken
+        );
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
             isError: true,
         });
     });

--- a/src/tools/__tests__/awsAccounts.test.ts
+++ b/src/tools/__tests__/awsAccounts.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
 import {
     CLOUDCONNECT_BASE_URL,
+    createAwsAccountRoleTool,
     getAwsAccountTool,
     getCloudConnectSupportedFeaturesTool,
+    handleCreateAwsAccountRoleRequest,
     handleGetAwsAccountRequest,
     handleGetCloudConnectSupportedFeaturesRequest,
 } from "../awsAccounts.js";
@@ -181,5 +183,142 @@ describe("get_cloud_connect_supported_features", () => {
         const response = await handleGetCloudConnectSupportedFeaturesRequest({}, mockToken);
 
         expect(response.isError).toBe(true);
+    });
+});
+
+describe("createAwsAccountRoleTool metadata", () => {
+    it("should be a write tool with the correct name", () => {
+        expect(createAwsAccountRoleTool.annotations.readOnlyHint).toBe(false);
+        expect(createAwsAccountRoleTool.annotations.destructiveHint).toBe(true);
+        expect(createAwsAccountRoleTool.name).toBe("create_aws_account_role");
+        expect(createAwsAccountRoleTool.coversEndpoint).toBe("post:/core/v1/cloudconnect/aws/accounts");
+    });
+});
+
+describe("create_aws_account_role", () => {
+    const mockToken = "fake-token";
+
+    const baseArgs = {
+        accountID: "123456789012",
+        roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+        enabledFeatures: ["core"],
+    };
+
+    const mockResponse = {
+        accountID: "123456789012",
+        roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+        enabledFeatures: ["core"],
+    };
+
+    it("should POST to the aws accounts endpoint with the body and return the response", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+        const response = await handleCreateAwsAccountRoleRequest(baseArgs, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${CLOUDCONNECT_BASE_URL}/aws/accounts`, mockToken, {
+            method: "POST",
+            body: {
+                accountID: "123456789012",
+                roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+                enabledFeatures: ["core"],
+            },
+            customerContext: undefined,
+        });
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.accountID).toBe("123456789012");
+    });
+
+    it("should include s3Bucket and s3BucketRegion when real-time-data is enabled", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
+
+        await handleCreateAwsAccountRoleRequest(
+            {
+                ...baseArgs,
+                enabledFeatures: ["real-time-data"],
+                s3Bucket: "doit-cloudtrail",
+                s3BucketRegion: "us-east-1",
+                customerContext: "customer-123",
+            },
+            mockToken
+        );
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(`${CLOUDCONNECT_BASE_URL}/aws/accounts`, mockToken, {
+            method: "POST",
+            body: {
+                accountID: "123456789012",
+                roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+                enabledFeatures: ["real-time-data"],
+                s3Bucket: "doit-cloudtrail",
+                s3BucketRegion: "us-east-1",
+            },
+            customerContext: "customer-123",
+        });
+    });
+
+    it("should error when real-time-data is enabled but the S3 bucket is missing", async () => {
+        const response = await handleCreateAwsAccountRoleRequest(
+            { ...baseArgs, enabledFeatures: ["real-time-data"] },
+            mockToken
+        );
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("real-time-data");
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should error when the S3 bucket is provided without real-time-data", async () => {
+        const response = await handleCreateAwsAccountRoleRequest(
+            { ...baseArgs, s3Bucket: "doit-cloudtrail", s3BucketRegion: "us-east-1" },
+            mockToken
+        );
+
+        expect(response.isError).toBe(true);
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should error when only one of s3Bucket / s3BucketRegion is provided", async () => {
+        const response = await handleCreateAwsAccountRoleRequest(
+            { ...baseArgs, enabledFeatures: ["real-time-data"], s3Bucket: "doit-cloudtrail" },
+            mockToken
+        );
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("together");
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should error when enabledFeatures is empty", async () => {
+        const response = await handleCreateAwsAccountRoleRequest({ ...baseArgs, enabledFeatures: [] }, mockToken);
+
+        expect(response.isError).toBe(true);
+    });
+
+    it("should error when accountID is missing", async () => {
+        const response = await handleCreateAwsAccountRoleRequest(
+            { roleArn: baseArgs.roleArn, enabledFeatures: ["core"] },
+            mockToken
+        );
+
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error response when API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleCreateAwsAccountRoleRequest(baseArgs, mockToken);
+
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return error response when makeDoitRequest throws", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+        const response = await handleCreateAwsAccountRoleRequest(baseArgs, mockToken);
+
+        expect(response).toEqual({
+            content: [{ type: "text", text: expect.stringContaining("Network error") }],
+            isError: true,
+        });
     });
 });

--- a/src/tools/ava.ts
+++ b/src/tools/ava.ts
@@ -93,3 +93,70 @@ export async function handleAskAvaSyncRequest(args: any, token: string) {
         return handleGeneralError(error, "handling ask AVA sync request");
     }
 }
+
+export const SubmitAvaFeedbackArgumentsSchema = z.object({
+    conversationId: z
+        .string()
+        .trim()
+        .min(1)
+        .describe(
+            "The conversation ID the feedback relates to. Obtained from a prior non-ephemeral ask_ava_sync response (call it with ephemeral: false)."
+        ),
+    answerId: z
+        .string()
+        .trim()
+        .min(1)
+        .describe("The specific answer ID within the conversation, from a prior non-ephemeral ask_ava_sync response."),
+    positive: z
+        .boolean()
+        .describe("Whether the feedback is positive (true = thumbs up) or negative (false = thumbs down)."),
+    text: z.string().optional().describe("Optional free-text providing additional feedback details."),
+});
+
+export const submitAvaFeedbackTool = {
+    name: "submit_ava_feedback",
+    coversEndpoint: "post:/ava/v1/feedback",
+    description:
+        "Submit feedback on a specific AVA answer (thumbs up/down with optional comment). Requires the conversationId and answerId returned by a prior non-ephemeral ask_ava_sync call (ephemeral: false). Use this only after the user expresses satisfaction or dissatisfaction with an AVA response — do not submit feedback automatically.",
+    inputSchema: zodToMcpInputSchema(SubmitAvaFeedbackArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Submitting feedback...",
+        "openai/toolInvocation/invoked": "Feedback submitted",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export async function handleSubmitAvaFeedbackRequest(args: any, token: string) {
+    try {
+        const { conversationId, answerId, positive, text } = SubmitAvaFeedbackArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const feedback: Record<string, unknown> = { positive };
+        if (text !== undefined) feedback.text = text;
+
+        // The endpoint returns an empty 200 body on success, so skip JSON parsing and
+        // treat a successful (non-throwing) request as confirmation.
+        const data = await makeDoitRequest(`${AVA_BASE_URL}/feedback`, token, {
+            method: "POST",
+            body: { conversationId, answerId, feedback },
+            customerContext,
+            parseResponse: false,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to submit AVA feedback");
+        }
+
+        return createSuccessResponse("Successfully submitted AVA feedback.");
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(formatZodError(error));
+        }
+        return handleGeneralError(error, "handling submit AVA feedback request");
+    }
+}

--- a/src/tools/awsAccounts.ts
+++ b/src/tools/awsAccounts.ts
@@ -102,3 +102,101 @@ export async function handleGetCloudConnectSupportedFeaturesRequest(args: any, t
         return handleGeneralError(error, "handling get CloudConnect supported features request");
     }
 }
+
+// The feature name that gates the S3 bucket requirement (see schema description below).
+export const REAL_TIME_FEATURE = "real-time-data";
+
+// Schema and metadata for create/update AWS account role
+export const CreateAwsAccountRoleArgumentsSchema = z.object({
+    accountID: z.string().trim().min(1).describe('The 12-digit AWS account ID to connect (e.g. "123456789012").'),
+    roleArn: z
+        .string()
+        .trim()
+        .min(1)
+        .describe('The ARN of the IAM role created for DoiT access (e.g. "arn:aws:iam::123456789012:role/DoiTRole").'),
+    enabledFeatures: z
+        .array(z.string().trim().min(1))
+        .min(1)
+        .describe(
+            'The DoiT CloudConnect features to enable for this account (e.g. ["real-time-data"]). Values must match supported feature names configured in DoiT. When "real-time-data" is included, s3Bucket and s3BucketRegion are required; when it is not included, they must be omitted.'
+        ),
+    s3Bucket: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+            'S3 bucket name for CloudTrail real-time anomaly detection. Required together with s3BucketRegion, and only allowed when enabledFeatures includes "real-time-data".'
+        ),
+    s3BucketRegion: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe('AWS region of the S3 bucket (e.g. "us-east-1"). Required together with s3Bucket.'),
+});
+
+export const createAwsAccountRoleTool = {
+    name: "create_aws_account_role",
+    coversEndpoint: "post:/core/v1/cloudconnect/aws/accounts",
+    description:
+        'Use this when the user wants to connect an AWS account to DoiT CloudConnect (or update an existing connection) by registering the IAM role ARN and declaring which DoiT features to enable. This creates or updates the CloudConnect document for the AWS account. Ask the user to confirm the account ID, role ARN, and features before executing. When enabling real-time anomaly detection ("real-time-data"), the CloudTrail S3 bucket name and region are required. Do NOT use this for Google Cloud or Azure accounts.',
+    inputSchema: zodToMcpInputSchema(CreateAwsAccountRoleArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Connecting AWS account...",
+        "openai/toolInvocation/invoked": "AWS account connected",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export async function handleCreateAwsAccountRoleRequest(args: any, token: string) {
+    try {
+        const { accountID, roleArn, enabledFeatures, s3Bucket, s3BucketRegion } =
+            CreateAwsAccountRoleArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        // The API requires s3Bucket and s3BucketRegion together, and only when the
+        // real-time-data feature is enabled. Validate here rather than in the Zod schema so
+        // the exported schema stays a plain object (the remote worker registers it via
+        // `schema.shape`, which ZodEffects from .refine() would not expose).
+        const hasRealTime = enabledFeatures.includes(REAL_TIME_FEATURE);
+        if ((s3Bucket === undefined) !== (s3BucketRegion === undefined)) {
+            return createErrorResponse("s3Bucket and s3BucketRegion must be provided together.");
+        }
+        if (hasRealTime && s3Bucket === undefined) {
+            return createErrorResponse(
+                `s3Bucket and s3BucketRegion are required when enabledFeatures includes "${REAL_TIME_FEATURE}".`
+            );
+        }
+        if (!hasRealTime && s3Bucket !== undefined) {
+            return createErrorResponse(
+                `s3Bucket and s3BucketRegion are only allowed when enabledFeatures includes "${REAL_TIME_FEATURE}".`
+            );
+        }
+
+        const body: Record<string, unknown> = { accountID, roleArn, enabledFeatures };
+        if (s3Bucket !== undefined) body.s3Bucket = s3Bucket;
+        if (s3BucketRegion !== undefined) body.s3BucketRegion = s3BucketRegion;
+
+        const url = `${CLOUDCONNECT_BASE_URL}/aws/accounts`;
+        const data = await makeDoitRequest<AwsAccount>(url, token, {
+            method: "POST",
+            body,
+            customerContext,
+        });
+
+        if (!data) {
+            return createErrorResponse("Failed to create or update AWS account role");
+        }
+
+        return createSuccessResponse(JSON.stringify(data, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) return createErrorResponse(formatZodError(error));
+        return handleGeneralError(error, "handling create AWS account role request");
+    }
+}

--- a/src/tools/handWrittenTools.ts
+++ b/src/tools/handWrittenTools.ts
@@ -4,8 +4,8 @@ import { createAllocationTool, getAllocationTool, listAllocationsTool, updateAll
 import { createAnnotationTool, getAnnotationTool, listAnnotationsTool, updateAnnotationTool } from "./annotations.js";
 import { anomaliesTool, anomalyTool } from "./anomalies.js";
 import { getAssetTool, listAssetsTool } from "./assets.js";
-import { askAvaSyncTool } from "./ava.js";
-import { getAwsAccountTool, getCloudConnectSupportedFeaturesTool } from "./awsAccounts.js";
+import { askAvaSyncTool, submitAvaFeedbackTool } from "./ava.js";
+import { createAwsAccountRoleTool, getAwsAccountTool, getCloudConnectSupportedFeaturesTool } from "./awsAccounts.js";
 import { createBudgetTool, getBudgetTool, listBudgetsTool, updateBudgetTool } from "./budgets.js";
 import {
     findCloudDiagramsTool,
@@ -158,6 +158,7 @@ export const HAND_WRITTEN_TOOLS: HandWrittenTool[] = [
     updateThemeTool,
     getAwsAccountTool,
     getCloudConnectSupportedFeaturesTool,
+    createAwsAccountRoleTool,
     listDatahubDatasetsTool,
     getDatahubDatasetTool,
     createDatahubDatasetTool,
@@ -185,6 +186,7 @@ export const HAND_WRITTEN_TOOLS: HandWrittenTool[] = [
     getResourcePermissionsTool,
     updateResourcePermissionsTool,
     askAvaSyncTool,
+    submitAvaFeedbackTool,
 ];
 
 export const COVERED_ENDPOINTS: Set<string> = new Set(

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -20,8 +20,12 @@ import {
 } from "../tools/annotations.js";
 import { handleAnomaliesRequest, handleAnomalyRequest } from "../tools/anomalies.js";
 import { handleGetAssetRequest, handleListAssetsRequest } from "../tools/assets.js";
-import { handleAskAvaSyncRequest } from "../tools/ava.js";
-import { handleGetAwsAccountRequest, handleGetCloudConnectSupportedFeaturesRequest } from "../tools/awsAccounts.js";
+import { handleAskAvaSyncRequest, handleSubmitAvaFeedbackRequest } from "../tools/ava.js";
+import {
+    handleCreateAwsAccountRoleRequest,
+    handleGetAwsAccountRequest,
+    handleGetCloudConnectSupportedFeaturesRequest,
+} from "../tools/awsAccounts.js";
 import {
     handleCreateBudgetRequest,
     handleGetBudgetRequest,
@@ -475,6 +479,9 @@ async function runOriginalDispatch(
         case "get_cloud_connect_supported_features":
             result = await handleGetCloudConnectSupportedFeaturesRequest(args, token);
             break;
+        case "create_aws_account_role":
+            result = await handleCreateAwsAccountRoleRequest(args, token);
+            break;
         case "list_themes":
             result = await handleListThemesRequest(args, token);
             break;
@@ -561,6 +568,9 @@ async function runOriginalDispatch(
             break;
         case "ask_ava_sync":
             result = await handleAskAvaSyncRequest(args, token);
+            break;
+        case "submit_ava_feedback":
+            result = await handleSubmitAvaFeedbackRequest(args, token);
             break;
         case "list_account_team":
             result = await handleListAccountTeamRequest(args, token);

--- a/test/integration/fixtures/cloudConnect.ts
+++ b/test/integration/fixtures/cloudConnect.ts
@@ -1,0 +1,7 @@
+export const createAwsAccountRoleFixture = {
+    accountID: "123456789012",
+    roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+    s3Bucket: "doit-cloudtrail",
+    s3BucketRegion: "us-east-1",
+    enabledFeatures: ["real-time-data"],
+};

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -42,6 +42,7 @@ import {
 import { anomaliesFixture, anomalyFixture } from "./anomalies.js";
 import { avaAskSyncFixture, avaAskSyncWithConversationFixture } from "./ava.js";
 import { assetDetailedFixture, assetsFixture, invoiceFixture, invoicesFixture } from "./billing.js";
+import { createAwsAccountRoleFixture } from "./cloudConnect.js";
 import {
     cloudDiagramActivityGroupsFixture,
     cloudDiagramComponentsFixture,
@@ -191,4 +192,6 @@ export const fixtures = {
 
     avaAskSync: avaAskSyncFixture,
     avaAskSyncWithConversation: avaAskSyncWithConversationFixture,
+
+    createAwsAccountRole: createAwsAccountRoleFixture,
 };

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -423,4 +423,14 @@ export const mockedDoitApiHandlers = [
         }
         return HttpResponse.json(fixtures.avaAskSync);
     }),
+    // AVA feedback returns an empty 200 body on success
+    http.post(`${API_BASE}/ava/v1/feedback`, () => {
+        return new HttpResponse(null, { status: 200 });
+    }),
+
+    // CloudConnect — create/update AWS account role
+    http.post(`${API_BASE}/core/v1/cloudconnect/aws/accounts`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ ...fixtures.createAwsAccountRole, ...body });
+    }),
 ];

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -1910,6 +1910,88 @@ describe("MCP Tools Integration", () => {
         });
     });
 
+    describe("create_aws_account_role", () => {
+        it("connects an AWS account and returns the created role from the mock API", async () => {
+            const result = await client.callTool({
+                name: "create_aws_account_role",
+                arguments: {
+                    accountID: "123456789012",
+                    roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+                    enabledFeatures: ["core"],
+                },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.accountID).toBe("123456789012");
+            expect(parsed.roleArn).toBe("arn:aws:iam::123456789012:role/DoiTRole");
+            expect(parsed.enabledFeatures).toEqual(["core"]);
+        });
+
+        it("accepts s3 bucket details when real-time-data is enabled", async () => {
+            const result = await client.callTool({
+                name: "create_aws_account_role",
+                arguments: {
+                    accountID: "123456789012",
+                    roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+                    enabledFeatures: ["real-time-data"],
+                    s3Bucket: "doit-cloudtrail",
+                    s3BucketRegion: "us-east-1",
+                },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.s3Bucket).toBe("doit-cloudtrail");
+            expect(parsed.s3BucketRegion).toBe("us-east-1");
+        });
+
+        it("rejects real-time-data without an S3 bucket", async () => {
+            const result = await client.callTool({
+                name: "create_aws_account_role",
+                arguments: {
+                    accountID: "123456789012",
+                    roleArn: "arn:aws:iam::123456789012:role/DoiTRole",
+                    enabledFeatures: ["real-time-data"],
+                },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("real-time-data");
+        });
+
+        it("rejects invalid arguments (missing accountID)", async () => {
+            const result = await client.callTool({
+                name: "create_aws_account_role",
+                arguments: { roleArn: "arn:aws:iam::123456789012:role/DoiTRole", enabledFeatures: ["core"] },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("Invalid arguments");
+        });
+    });
+
+    describe("submit_ava_feedback", () => {
+        it("submits feedback and returns a success confirmation", async () => {
+            const result = await client.callTool({
+                name: "submit_ava_feedback",
+                arguments: {
+                    conversationId: "conv-abc123",
+                    answerId: "ans-xyz456",
+                    positive: true,
+                    text: "Very helpful",
+                },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("Successfully submitted");
+        });
+
+        it("rejects invalid arguments (missing answerId)", async () => {
+            const result = await client.callTool({
+                name: "submit_ava_feedback",
+                arguments: { conversationId: "conv-abc123", positive: true },
+            });
+            const text = getTextContent(result);
+            expect(text).toContain("Invalid arguments");
+        });
+    });
+
     describe("error handling", () => {
         it("returns error for unknown tool", async () => {
             const result = await client.callTool({ name: "nonexistent_tool", arguments: {} });


### PR DESCRIPTION
## Summary

Adds MCP coverage for two DoiT API operations that were previously served only by the auto-generated OpenAPI fallback. Each completes a partially-covered category. **Max 2 endpoints**, no DELETE.

| Tool | Method + Path | Category | API Reference |
|------|---------------|----------|---------------|
| `create_aws_account_role` | `POST /core/v1/cloudconnect/aws/accounts` | AWS / CloudConnect | [createAccountRole](https://developer.doit.com/reference/createaccountrole) |
| `submit_ava_feedback` | `POST /ava/v1/feedback` | Ava | [avaFeedback](https://developer.doit.com/reference/avafeedback) |

## Details

**`create_aws_account_role`** — Connects an AWS account to DoiT CloudConnect (or updates an existing connection) by registering the IAM role ARN and the DoiT features to enable. The API's conditional rule is enforced in the handler: `s3Bucket` and `s3BucketRegion` must be provided together, and only when `enabledFeatures` includes `"real-time-data"`. The exported Zod schema is kept a plain object (validation in the handler, not `.refine()`) so the remote worker's `registerTool(schema.shape)` continues to work. Annotated `readOnlyHint: false`, `destructiveHint: true`.

**`submit_ava_feedback`** — Submits thumbs up/down (with optional comment) on a specific AVA answer, using the `conversationId` and `answerId` returned by a prior non-ephemeral `ask_ava_sync` call. The endpoint returns an empty 200; handled with `parseResponse: false` (mirrors `assign_objects_to_label`).

Both tools declare `coversEndpoint` so the OpenAPI generator skips the operation (no duplicate generated tool).

## Registration checklist
- [x] Tool + handler in `src/tools/awsAccounts.ts` / `src/tools/ava.ts`
- [x] Added to `HAND_WRITTEN_TOOLS` in `src/tools/handWrittenTools.ts` (`coversEndpoint` set)
- [x] Dispatch cases in `src/utils/toolsHandler.ts`
- [x] Registered in **local MCP** `src/server.ts` (re-exported handlers)
- [x] Registered in **remote MCP** `doit-mcp-server/src/index.ts` (`this.registerTool`)
- [x] Unit tests (`src/tools/__tests__/awsAccounts.test.ts`, `ava.test.ts`)
- [x] Integration: fixture (`test/integration/fixtures/cloudConnect.ts`), MSW handlers, tool-call tests, derived `tools/list` assertion
- [x] `src/__tests__/server.test.ts` ListTools assertion kept in sync
- [x] `README.md` updated

## Verification
- `yarn check:dev` ✅  ·  `yarn test` ✅ (934 passed)  ·  integration `yarn test` ✅ (181 passed)  ·  `tsc` ✅

## Research
No prior GitHub PRs / Jira tickets found for these two endpoints; schemas modeled directly from the DoiT OpenAPI spec (`src/tools/generated/openapi.json`) and the reference pages above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)