### PR TITLE
feat(insights): add post_insight_result and update_insight_status tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ This MCP server provides many tools including the following:
 - [`get_aws_account`](https://developer.doit.com/reference/getawsaccount): Returns the CloudConnect details of a connected AWS account (role ARN, billing S3 bucket, enabled and supported features) by AWS account ID
 - [`get_cloud_connect_supported_features`](https://developer.doit.com/reference/getcloudconnectsupportedfeatures): Returns the DoiT CloudConnect features supported for a connected cloud account (AWS account ID or Azure tenant ID) and whether the required permissions are present
 - [`get_insight`](https://developer.doit.com/reference/getinsightresult): Returns the metadata and aggregate summary (savings, risk counts, status) of a single optimization insight identified by its source and key
+- [`post_insight_result`](https://developer.doit.com/reference/postinsightresult): Creates or updates the metadata of a single custom insight (title, description, categories, status, remediation links). Only insights owned by the `public-api` source can be managed; supported categories are `FinOps` and `Security`
+- [`update_insight_status`](https://developer.doit.com/reference/updateinsightstatus): Updates the display status of an existing `public-api` insight (e.g. `acknowledged`, `in progress`, `optimized`, `dismissed`), with optional dismissal reason and comment
 
 
 ## Usage Examples

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -62,9 +62,13 @@ import {
   ListInsightsArgumentsSchema,
   GetInsightResourcesArgumentsSchema,
   GetInsightArgumentsSchema,
+  PostInsightResultArgumentsSchema,
+  UpdateInsightStatusArgumentsSchema,
   listOptimizationRecommendationsTool,
   getInsightResourcesTool,
   getInsightTool,
+  postInsightResultTool,
+  updateInsightStatusTool,
 } from "../../src/tools/insights.js";
 import {
   ValidateUserArgumentsSchema,
@@ -993,6 +997,8 @@ export class DoitMCPAgent extends McpAgent {
     this.registerTool(listOptimizationRecommendationsTool, ListInsightsArgumentsSchema);
     this.registerTool(getInsightResourcesTool, GetInsightResourcesArgumentsSchema);
     this.registerTool(getInsightTool, GetInsightArgumentsSchema);
+    this.registerTool(postInsightResultTool, PostInsightResultArgumentsSchema);
+    this.registerTool(updateInsightStatusTool, UpdateInsightStatusArgumentsSchema);
     this.registerTool(getReportResultsTool, GetReportResultsArgumentsSchema);
     this.registerTool(getReportConfigTool, GetReportConfigArgumentsSchema);
     this.registerTool(createReportTool, CreateReportArgumentsSchema);

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -264,7 +264,13 @@ import { dimensionTool } from "../tools/dimension.js";
 import { dimensionsTool } from "../tools/dimensions.js";
 import { createFolderTool, getFolderTool, listFoldersTool, updateFolderTool } from "../tools/folders.js";
 import { generatedTools } from "../tools/generated/registry.js";
-import { getInsightResourcesTool, getInsightTool, listOptimizationRecommendationsTool } from "../tools/insights.js";
+import {
+    getInsightResourcesTool,
+    getInsightTool,
+    listOptimizationRecommendationsTool,
+    postInsightResultTool,
+    updateInsightStatusTool,
+} from "../tools/insights.js";
 import { getInvoiceTool, listInvoicesTool } from "../tools/invoices.js";
 import {
     assignObjectsToLabelTool,
@@ -379,6 +385,8 @@ describe("ListToolsRequestSchema handler", () => {
                 listOptimizationRecommendationsTool,
                 getInsightResourcesTool,
                 getInsightTool,
+                postInsightResultTool,
+                updateInsightStatusTool,
                 getReportResultsTool,
                 getReportConfigTool,
                 createReportTool,

--- a/src/tools/__tests__/insights.test.ts
+++ b/src/tools/__tests__/insights.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDoitRequest } from "../../utils/util.js";
-import { getInsightTool, handleGetInsightRequest, INSIGHTS_BASE_URL } from "../insights.js";
+import {
+    getInsightTool,
+    handleGetInsightRequest,
+    handlePostInsightResultRequest,
+    handleUpdateInsightStatusRequest,
+    INSIGHTS_BASE_URL,
+    postInsightResultTool,
+    updateInsightStatusTool,
+} from "../insights.js";
 
 vi.mock("../../utils/util.js", async (importOriginal) => {
     const actual = await importOriginal();
@@ -116,5 +124,161 @@ describe("get_insight", () => {
             content: [{ type: "text", text: expect.stringContaining("Network error") }],
             isError: true,
         });
+    });
+});
+
+describe("postInsightResultTool metadata", () => {
+    it("should be a write tool named post_insight_result", () => {
+        expect(postInsightResultTool.annotations.readOnlyHint).toBe(false);
+        expect(postInsightResultTool.name).toBe("post_insight_result");
+        expect(postInsightResultTool.coversEndpoint).toBe(
+            "post:/insights/v1/results/source/{sourceID}/insight/{insightKey}"
+        );
+    });
+});
+
+describe("post_insight_result", () => {
+    const mockToken = "fake-token";
+
+    const validArgs = {
+        key: "idle-ec2",
+        title: "Idle EC2 instances",
+        shortDescription: "Stop idle EC2 instances to save cost.",
+        cloudProvider: "aws",
+        categories: ["FinOps"],
+    };
+
+    it("should POST to the source/key URL with the request body and default source public-api", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ ...validArgs, source: "public-api" });
+
+        const response = await handlePostInsightResultRequest(validArgs, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${INSIGHTS_BASE_URL}/results/source/public-api/insight/idle-ec2`,
+            mockToken,
+            {
+                method: "POST",
+                body: {
+                    key: "idle-ec2",
+                    title: "Idle EC2 instances",
+                    shortDescription: "Stop idle EC2 instances to save cost.",
+                    cloudProvider: "aws",
+                    categories: ["FinOps"],
+                },
+                customerContext: undefined,
+            }
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.key).toBe("idle-ec2");
+    });
+
+    it("should include optional fields in the body when provided", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({ ...validArgs, source: "public-api" });
+
+        await handlePostInsightResultRequest(
+            { ...validArgs, status: "dismissed", dismissalDetails: { reason: "not relevant" }, reportUrl: "https://x" },
+            mockToken
+        );
+
+        const call = (makeDoitRequest as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[2].body.status).toBe("dismissed");
+        expect(call[2].body.dismissalDetails).toEqual({ reason: "not relevant" });
+        expect(call[2].body.reportUrl).toBe("https://x");
+    });
+
+    it("should return a validation error when required fields are missing", async () => {
+        const response = await handlePostInsightResultRequest({ key: "idle-ec2" }, mockToken);
+        expect(response.isError).toBe(true);
+    });
+
+    it("should reject an invalid category", async () => {
+        const response = await handlePostInsightResultRequest(
+            { ...validArgs, categories: ["NotACategory"] },
+            mockToken
+        );
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return an error response when the API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handlePostInsightResultRequest(validArgs, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("idle-ec2");
+    });
+});
+
+describe("updateInsightStatusTool metadata", () => {
+    it("should be a write tool named update_insight_status", () => {
+        expect(updateInsightStatusTool.annotations.readOnlyHint).toBe(false);
+        expect(updateInsightStatusTool.name).toBe("update_insight_status");
+        expect(updateInsightStatusTool.coversEndpoint).toBe(
+            "put:/insights/v1/results/source/{sourceID}/insight/{insightKey}/status"
+        );
+    });
+});
+
+describe("update_insight_status", () => {
+    const mockToken = "fake-token";
+
+    it("should PUT to the status URL with the status body and not parse the 204 response", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        const response = await handleUpdateInsightStatusRequest({ key: "idle-ec2", status: "acknowledged" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            `${INSIGHTS_BASE_URL}/results/source/public-api/insight/idle-ec2/status`,
+            mockToken,
+            {
+                method: "PUT",
+                body: { status: "acknowledged" },
+                customerContext: undefined,
+                parseResponse: false,
+            }
+        );
+
+        const parsed = JSON.parse(response.content[0].text);
+        expect(parsed.success).toBe(true);
+        expect(parsed.status).toBe("acknowledged");
+    });
+
+    it("should include dismissalDetails in the body when dismissing", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        await handleUpdateInsightStatusRequest(
+            {
+                key: "idle-ec2",
+                status: "dismissed",
+                dismissalDetails: { reason: "not worth the effort", comment: "x" },
+            },
+            mockToken
+        );
+
+        const call = (makeDoitRequest as ReturnType<typeof vi.fn>).mock.calls[0];
+        expect(call[2].body).toEqual({
+            status: "dismissed",
+            dismissalDetails: { reason: "not worth the effort", comment: "x" },
+        });
+    });
+
+    it("should return a validation error when status is missing", async () => {
+        const response = await handleUpdateInsightStatusRequest({ key: "idle-ec2" }, mockToken);
+        expect(response.isError).toBe(true);
+    });
+
+    it("should reject an invalid status", async () => {
+        const response = await handleUpdateInsightStatusRequest({ key: "idle-ec2", status: "bogus" }, mockToken);
+        expect(response.isError).toBe(true);
+    });
+
+    it("should return an error response when the API returns null", async () => {
+        (makeDoitRequest as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+        const response = await handleUpdateInsightStatusRequest({ key: "idle-ec2", status: "acknowledged" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("idle-ec2");
     });
 });

--- a/src/tools/handWrittenTools.ts
+++ b/src/tools/handWrittenTools.ts
@@ -40,7 +40,13 @@ import { sendDatahubEventsTool } from "./datahubEvents.js";
 import { dimensionTool } from "./dimension.js";
 import { dimensionsTool } from "./dimensions.js";
 import { createFolderTool, getFolderTool, listFoldersTool, updateFolderTool } from "./folders.js";
-import { getInsightResourcesTool, getInsightTool, listOptimizationRecommendationsTool } from "./insights.js";
+import {
+    getInsightResourcesTool,
+    getInsightTool,
+    listOptimizationRecommendationsTool,
+    postInsightResultTool,
+    updateInsightStatusTool,
+} from "./insights.js";
 import { getInvoiceTool, listInvoicesTool } from "./invoices.js";
 import {
     assignObjectsToLabelTool,
@@ -100,6 +106,8 @@ export const HAND_WRITTEN_TOOLS: HandWrittenTool[] = [
     listOptimizationRecommendationsTool,
     getInsightResourcesTool,
     getInsightTool,
+    postInsightResultTool,
+    updateInsightStatusTool,
     getReportResultsTool,
     getReportConfigTool,
     createReportTool,

--- a/src/tools/insights.ts
+++ b/src/tools/insights.ts
@@ -129,6 +129,78 @@ export const GetInsightArgumentsSchema = z.object({
         ),
 });
 
+// Only insights created via the public API can be created/updated; the API accepts a single
+// source value ("public-api"). Kept as an enum with a default so callers rarely need to set it.
+const InsightSourceEnum = z.enum(["public-api"]);
+
+// Categories allowed when creating an insight via the public API (narrower than the read-side
+// InsightCategoryEnum used for filtering).
+const CreatableInsightCategoryEnum = z.enum(["FinOps", "Security"]);
+
+// The full set of display statuses the API accepts on writes.
+const InsightWriteStatusEnum = z.enum([
+    "actionable",
+    "acknowledged",
+    "optimized",
+    "dismissed",
+    "in progress",
+    "upgrade needed",
+    "permissions needed",
+]);
+
+const InsightDismissalDetailsSchema = z.object({
+    reason: z
+        .enum([
+            "not relevant",
+            "not enough information",
+            "not worth the effort",
+            "inaccurate optimization opportunities",
+        ])
+        .optional()
+        .describe("The reason the insight was dismissed."),
+    comment: z.string().optional().describe("An optional free-text comment providing additional context."),
+});
+
+export const PostInsightResultArgumentsSchema = z.object({
+    source: InsightSourceEnum.default("public-api").describe(
+        "The source that owns the insight. Only 'public-api' insights can be managed via this endpoint."
+    ),
+    key: z
+        .string()
+        .describe("A unique key identifying the insight within the source. Used as both the path key and body key."),
+    title: z.string().describe("The display title of the insight."),
+    shortDescription: z.string().describe("A brief summary of the insight."),
+    cloudProvider: z.string().describe("The cloud provider associated with the insight (e.g. 'aws', 'gcp', 'azure')."),
+    categories: z
+        .array(CreatableInsightCategoryEnum)
+        .min(1)
+        .describe("One or more categories this insight belongs to. Possible values: FinOps, Security."),
+    detailedDescriptionMdx: z.string().optional().describe("A detailed description of the insight in MDX format."),
+    reportUrl: z.string().optional().describe("URL to an external report related to this insight."),
+    cloudFlowTemplateId: z
+        .string()
+        .optional()
+        .describe("ID of a CloudFlow template that can automate the remediation of this insight."),
+    easyWinDescription: z.string().optional().describe("A description of why this insight is considered an easy win."),
+    status: InsightWriteStatusEnum.optional().describe("The display status of the insight."),
+    dismissalDetails: InsightDismissalDetailsSchema.optional().describe(
+        "Details for why the insight was dismissed (only relevant when status is 'dismissed')."
+    ),
+});
+
+export const UpdateInsightStatusArgumentsSchema = z.object({
+    source: InsightSourceEnum.default("public-api").describe(
+        "The source that owns the insight. Only 'public-api' insights can be managed via this endpoint."
+    ),
+    key: z.string().describe("The unique key identifying the insight to update."),
+    status: InsightWriteStatusEnum.describe(
+        "The new display status of the insight. Possible values: actionable, acknowledged, optimized, dismissed, in progress, upgrade needed, permissions needed."
+    ),
+    dismissalDetails: InsightDismissalDetailsSchema.optional().describe(
+        "Details for why the insight was dismissed (only relevant when status is 'dismissed')."
+    ),
+});
+
 // ── Tool metadata ───────────────────────────────────────────────────────────
 
 export const listOptimizationRecommendationsTool = {
@@ -194,6 +266,49 @@ export const getInsightTool = {
         "openai/toolInvocation/invoked": "Insight ready",
     },
     securitySchemes: [{ type: "oauth2", scopes: ["read_data"] }],
+};
+
+export const postInsightResultTool = {
+    name: "post_insight_result",
+    coversEndpoint: "post:/insights/v1/results/source/{sourceID}/insight/{insightKey}",
+    description:
+        "Use this when the user wants to create a new custom insight or update an existing one's metadata " +
+        "(title, description, categories, status, remediation links). Only insights owned by the " +
+        "'public-api' source can be managed. This manages the insight's metadata only — the individual " +
+        "affected resources are managed separately (post_insight_resource_results). Do NOT use this only to " +
+        "change an insight's status (use update_insight_status).",
+    inputSchema: zodToMcpInputSchema(PostInsightResultArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Saving insight...",
+        "openai/toolInvocation/invoked": "Insight saved",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+export const updateInsightStatusTool = {
+    name: "update_insight_status",
+    coversEndpoint: "put:/insights/v1/results/source/{sourceID}/insight/{insightKey}/status",
+    description:
+        "Use this when the user wants to change the display status of an existing insight (e.g. mark it " +
+        "acknowledged, in progress, optimized, or dismissed). Only insights owned by the 'public-api' " +
+        "source can be managed. When dismissing, an optional reason and comment can be supplied. Do NOT " +
+        "use this to edit an insight's title/description or create one (use post_insight_result).",
+    inputSchema: zodToMcpInputSchema(UpdateInsightStatusArgumentsSchema),
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Updating insight status...",
+        "openai/toolInvocation/invoked": "Insight status updated",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
 // ── Handlers ────────────────────────────────────────────────────────────────
@@ -342,5 +457,97 @@ export async function handleGetInsightRequest(args: any, token: string) {
             return createErrorResponse(formatZodError(error));
         }
         return handleGeneralError(error, "handling get_insight request");
+    }
+}
+
+export async function handlePostInsightResultRequest(args: any, token: string) {
+    try {
+        const {
+            source,
+            key,
+            title,
+            shortDescription,
+            cloudProvider,
+            categories,
+            detailedDescriptionMdx,
+            reportUrl,
+            cloudFlowTemplateId,
+            easyWinDescription,
+            status,
+            dismissalDetails,
+        } = PostInsightResultArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const insightUrl = `${INSIGHTS_BASE_URL}/results/source/${encodeURIComponent(source)}/insight/${encodeURIComponent(key)}`;
+
+        const body: Record<string, unknown> = {
+            key,
+            title,
+            shortDescription,
+            cloudProvider,
+            categories,
+        };
+        if (detailedDescriptionMdx !== undefined) body.detailedDescriptionMdx = detailedDescriptionMdx;
+        if (reportUrl !== undefined) body.reportUrl = reportUrl;
+        if (cloudFlowTemplateId !== undefined) body.cloudFlowTemplateId = cloudFlowTemplateId;
+        if (easyWinDescription !== undefined) body.easyWinDescription = easyWinDescription;
+        if (status !== undefined) body.status = status;
+        if (dismissalDetails !== undefined) body.dismissalDetails = dismissalDetails;
+
+        try {
+            const data = await makeDoitRequest<InsightResult>(insightUrl, token, {
+                method: "POST",
+                body,
+                customerContext,
+            });
+
+            if (!data) {
+                return createErrorResponse(`Failed to create or update insight ${key} (source: ${source})`);
+            }
+
+            return createSuccessResponse(JSON.stringify(data, null, 2));
+        } catch (error) {
+            return handleGeneralError(error, "making DoiT Insights API request");
+        }
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(formatZodError(error));
+        }
+        return handleGeneralError(error, "handling post_insight_result request");
+    }
+}
+
+export async function handleUpdateInsightStatusRequest(args: any, token: string) {
+    try {
+        const { source, key, status, dismissalDetails } = UpdateInsightStatusArgumentsSchema.parse(args);
+        const { customerContext } = args;
+
+        const statusUrl = `${INSIGHTS_BASE_URL}/results/source/${encodeURIComponent(source)}/insight/${encodeURIComponent(key)}/status`;
+
+        const body: Record<string, unknown> = { status };
+        if (dismissalDetails !== undefined) body.dismissalDetails = dismissalDetails;
+
+        try {
+            // The API returns 204 No Content on success, so there is no body to parse.
+            const data = await makeDoitRequest<Record<string, never>>(statusUrl, token, {
+                method: "PUT",
+                body,
+                customerContext,
+                parseResponse: false,
+            });
+
+            if (!data) {
+                return createErrorResponse(`Failed to update status for insight ${key} (source: ${source})`);
+            }
+
+            return createSuccessResponse(JSON.stringify({ success: true, source, key, status }, null, 2));
+        } catch (error) {
+            return handleGeneralError(error, "making DoiT Insights API request");
+        }
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(formatZodError(error));
+        }
+        return handleGeneralError(error, "handling update_insight_status request");
     }
 }

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -73,6 +73,8 @@ import {
     handleGetInsightRequest,
     handleGetInsightResourcesRequest,
     handleListInsightsRequest,
+    handlePostInsightResultRequest,
+    handleUpdateInsightStatusRequest,
 } from "../tools/insights.js";
 import { handleGetInvoiceRequest, handleListInvoicesRequest } from "../tools/invoices.js";
 import {
@@ -311,6 +313,12 @@ async function runOriginalDispatch(
             break;
         case "get_insight":
             result = await handleGetInsightRequest(args, token);
+            break;
+        case "post_insight_result":
+            result = await handlePostInsightResultRequest(args, token);
+            break;
+        case "update_insight_status":
+            result = await handleUpdateInsightStatusRequest(args, token);
             break;
         case "get_report_results":
             result = await handleGetReportResultsRequest(args, token);

--- a/test/integration/fixtures/analytics.ts
+++ b/test/integration/fixtures/analytics.ts
@@ -541,6 +541,19 @@ export const insightFixture = {
     tags: [],
 };
 
+// Response body returned by POST /insights/v1/results/source/{sourceID}/insight/{insightKey}
+// (create or update a single insight's metadata).
+export const postInsightResultFixture = {
+    source: "public-api",
+    key: "idle-ec2",
+    title: "Idle EC2 instances",
+    shortDescription: "Stop idle EC2 instances to save cost.",
+    displayStatus: "actionable",
+    cloudProvider: "aws",
+    categories: ["FinOps"],
+    lastUpdated: "2026-07-01T00:00:00.000Z",
+};
+
 export const folderFixture = {
     id: "folder-1",
     name: "Analytics",

--- a/test/integration/fixtures/index.ts
+++ b/test/integration/fixtures/index.ts
@@ -25,6 +25,7 @@ import {
     labelAssignmentsFixture,
     labelFixture,
     labelsFixture,
+    postInsightResultFixture,
     queryResultFixture,
     reportConfigFixture,
     reportResultsFixture,
@@ -188,6 +189,7 @@ export const fixtures = {
     setActiveTheme: setActiveThemeFixture,
     updateTheme: updateThemeFixture,
     insight: insightFixture,
+    postInsightResult: postInsightResultFixture,
 
     avaAskSync: avaAskSyncFixture,
     avaAskSyncWithConversation: avaAskSyncWithConversationFixture,

--- a/test/integration/mockedDoitApi/index.ts
+++ b/test/integration/mockedDoitApi/index.ts
@@ -415,6 +415,17 @@ export const mockedDoitApiHandlers = [
         return new HttpResponse(null, { status: 404 });
     }),
 
+    // Insights (update an insight's display status) — 204 No Content on success.
+    // Registered before the create/update handler because it is a more specific path.
+    http.put(`${API_BASE}/insights/v1/results/source/:source/insight/:key/status`, () => {
+        return new HttpResponse(null, { status: 204 });
+    }),
+
+    // Insights (create or update a single insight's metadata)
+    http.post(`${API_BASE}/insights/v1/results/source/:source/insight/:key`, () => {
+        return HttpResponse.json(fixtures.postInsightResult);
+    }),
+
     // AVA
     http.post(`${API_BASE}/ava/v1/askSync`, async ({ request }) => {
         const body = (await request.json()) as Record<string, unknown>;

--- a/test/integration/stdio/tools.test.ts
+++ b/test/integration/stdio/tools.test.ts
@@ -256,6 +256,56 @@ describe("MCP Tools Integration", () => {
         });
     });
 
+    describe("post_insight_result", () => {
+        it("creates or updates an insight and returns the insight result", async () => {
+            const result = await client.callTool({
+                name: "post_insight_result",
+                arguments: {
+                    key: "idle-ec2",
+                    title: "Idle EC2 instances",
+                    shortDescription: "Stop idle EC2 instances to save cost.",
+                    cloudProvider: "aws",
+                    categories: ["FinOps"],
+                },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.key).toBe("idle-ec2");
+            expect(parsed.source).toBe("public-api");
+            expect(parsed.displayStatus).toBe("actionable");
+        });
+
+        it("returns a validation error when required fields are missing", async () => {
+            const result = await client.callTool({
+                name: "post_insight_result",
+                arguments: { key: "idle-ec2" },
+            });
+            expect(result.isError).toBe(true);
+        });
+    });
+
+    describe("update_insight_status", () => {
+        it("updates the status of an insight (204 No Content)", async () => {
+            const result = await client.callTool({
+                name: "update_insight_status",
+                arguments: { key: "idle-ec2", status: "acknowledged" },
+            });
+            const text = getTextContent(result);
+            const parsed = JSON.parse(text);
+            expect(parsed.success).toBe(true);
+            expect(parsed.status).toBe("acknowledged");
+            expect(parsed.key).toBe("idle-ec2");
+        });
+
+        it("returns a validation error for an invalid status", async () => {
+            const result = await client.callTool({
+                name: "update_insight_status",
+                arguments: { key: "idle-ec2", status: "bogus" },
+            });
+            expect(result.isError).toBe(true);
+        });
+    });
+
     describe("list_users", () => {
         it("returns users from mock API", async () => {
             const result = await client.callTool({ name: "list_users", arguments: {} });


### PR DESCRIPTION
## Summary

Adds two hand-written MCP tools covering the **write side of the Insights API**, which until now was only exposed through the generic auto-generated fallback (added in #208). Both tools operate on a single insight identified by `source` (constrained to `public-api`, the only source manageable via the public API) and `key`, mirroring the existing read-only `get_insight` tool.

## Endpoints added (2)

| Tool | Method | Path | Reference |
|------|--------|------|-----------|
| `post_insight_result` | `POST` | `/insights/v1/results/source/{sourceID}/insight/{insightKey}` | [postInsightResult](https://developer.doit.com/reference/postinsightresult) |
| `update_insight_status` | `PUT` | `/insights/v1/results/source/{sourceID}/insight/{insightKey}/status` | [updateInsightStatus](https://developer.doit.com/reference/updateinsightstatus) |

- `post_insight_result` — create or update a single custom insight's metadata (title, short/detailed description, cloudProvider, categories [`FinOps`/`Security`], status, remediation links). Returns the insight result body (200).
- `update_insight_status` — update an insight's display status (`actionable`, `acknowledged`, `optimized`, `dismissed`, `in progress`, `upgrade needed`, `permissions needed`), with optional `dismissalDetails` (reason + comment). Returns 204 No Content, so the handler uses `parseResponse: false` and returns a synthetic success object.

Both declare `coversEndpoint` so `generateTools()` suppresses the generic duplicate (see `docs/generated-tools-coverage.md`).

## Registration checklist
- [x] Tool + Zod schema + raw `inputSchema` + handler in `src/tools/insights.ts`
- [x] Dispatch cases in `src/utils/toolsHandler.ts`
- [x] **LOCAL MCP** — added to `HAND_WRITTEN_TOOLS` (`src/tools/handWrittenTools.ts`, spread by `src/server.ts`)
- [x] **REMOTE MCP** — `this.registerTool(...)` in `doit-mcp-server/src/index.ts`
- [x] Unit tests (`src/tools/__tests__/insights.test.ts`)
- [x] Integration: fixture (`test/integration/fixtures/analytics.ts` + `index.ts`), MSW handlers (`test/integration/mockedDoitApi/index.ts`), tool-call tests + auto-derived `tools/list` (`test/integration/stdio/tools.test.ts`)
- [x] `src/__tests__/server.test.ts` kept in sync
- [x] `README.md` updated

## Verification
- `yarn check:dev` ✅
- `yarn test` ✅ (931 passed)
- Integration tests ✅ (179 passed)
- `yarn build` ✅ (`tsc` + widget build; the standalone `widget/ npm install` ERESOLVE is a pre-existing environment issue unrelated to this change)

## Research notes
- No open PR covered these endpoints (checked all open PRs — the snapshot/asset/theme/aws/ticket-tags/invite gaps are already claimed by #211/#212/#213/#209/#203/#197/#136).
- Schema derived from the repo's pre-dereferenced `src/tools/generated/openapi.json` and cross-checked against the live API reference pages above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)