### PR TITLE
fix: address MCP reliability issues (CMP-47539)

### DIFF
--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -468,16 +468,6 @@ export class ContextStorage extends DurableObject {
 // and getToken() reads it in preference to props.credential. See applyOAuthSession.
 const LIVE_CREDENTIAL_STORAGE_KEY = "mcp:liveCredential";
 
-// Decode the `exp` claim from a JWT without signature verification.
-// Returns undefined if the token is opaque or malformed.
-function getJwtExp(token: string): number | undefined {
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
-    return typeof payload.exp === "number" ? payload.exp : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 export class DoitMCPAgent extends McpAgent {
   constructor(ctx: DurableObjectState, env: Env) {
@@ -579,7 +569,7 @@ export class DoitMCPAgent extends McpAgent {
     // The auth-service uses zero clock tolerance, so even a 1-second-old token is rejected.
     // Failing early here lets the client refresh the token rather than hitting a cryptic auth error.
     const MCP_TOKEN_EXPIRY_GRACE_SECONDS = 30;
-    const tokenExp = getJwtExp(token);
+    const tokenExp = decodeSessionClaims(token)?.exp;
     if (tokenExp !== undefined && tokenExp < now + MCP_TOKEN_EXPIRY_GRACE_SECONDS) {
       console.warn("[mcp] MCP access token near expiry, rejecting before exchange", {
         exp: tokenExp,
@@ -842,7 +832,7 @@ export class DoitMCPAgent extends McpAgent {
   // registerAppTool() from @modelcontextprotocol/ext-apps normalises.
   private registerTool(tool: any, schema: any) {
     // ZodEffects (produced by .refine()) has no .shape — unwrap to the inner ZodObject.
-    const rawSchema = schema?._def?.schema ?? schema;
+    const rawSchema = typeof schema?.innerType === "function" ? schema.innerType() : schema;
     (this.server as any).registerTool(
       tool.name,
       {
@@ -1535,6 +1525,7 @@ function decodeSessionClaims(token: string): {
   cid: string;
   flowId: string;
   isDoitUser: string;
+  exp?: number;
 } | null {
   try {
     const segment = token.split(".")[1];
@@ -1549,6 +1540,7 @@ function decodeSessionClaims(token: string): {
       cid: typeof c.cid === "string" ? c.cid : "",
       flowId: typeof c.flow_id === "string" ? c.flow_id : "",
       isDoitUser: c.doit_employee === true ? "true" : "false",
+      exp: typeof c.exp === "number" ? c.exp : undefined,
     };
   } catch {
     return null;

--- a/doit-mcp-server/src/index.ts
+++ b/doit-mcp-server/src/index.ts
@@ -468,6 +468,17 @@ export class ContextStorage extends DurableObject {
 // and getToken() reads it in preference to props.credential. See applyOAuthSession.
 const LIVE_CREDENTIAL_STORAGE_KEY = "mcp:liveCredential";
 
+// Decode the `exp` claim from a JWT without signature verification.
+// Returns undefined if the token is opaque or malformed.
+function getJwtExp(token: string): number | undefined {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+    return typeof payload.exp === "number" ? payload.exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export class DoitMCPAgent extends McpAgent {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -562,6 +573,20 @@ export class DoitMCPAgent extends McpAgent {
         now,
       });
       return this.upstreamTokenCache.upstreamAccessToken;
+    }
+
+    // Guard against timing races where the MCP token expires in transit to the auth-service.
+    // The auth-service uses zero clock tolerance, so even a 1-second-old token is rejected.
+    // Failing early here lets the client refresh the token rather than hitting a cryptic auth error.
+    const MCP_TOKEN_EXPIRY_GRACE_SECONDS = 30;
+    const tokenExp = getJwtExp(token);
+    if (tokenExp !== undefined && tokenExp < now + MCP_TOKEN_EXPIRY_GRACE_SECONDS) {
+      console.warn("[mcp] MCP access token near expiry, rejecting before exchange", {
+        exp: tokenExp,
+        now,
+        grace: MCP_TOKEN_EXPIRY_GRACE_SECONDS,
+      });
+      throw new Error("MCP access token has expired or is near expiry; please re-authenticate");
     }
 
     console.info(
@@ -816,11 +841,13 @@ export class DoitMCPAgent extends McpAgent {
   // Both "ui/resourceUri" (flat key) and "ui.resourceUri" (nested) are set to match what
   // registerAppTool() from @modelcontextprotocol/ext-apps normalises.
   private registerTool(tool: any, schema: any) {
+    // ZodEffects (produced by .refine()) has no .shape — unwrap to the inner ZodObject.
+    const rawSchema = schema?._def?.schema ?? schema;
     (this.server as any).registerTool(
       tool.name,
       {
         description: tool.description,
-        inputSchema: schema.shape,
+        inputSchema: rawSchema.shape,
         annotations: tool.annotations,
         _meta: {
           ...tool._meta,

--- a/src/tools/__tests__/reports.test.ts
+++ b/src/tools/__tests__/reports.test.ts
@@ -418,7 +418,7 @@ Cloud Storage,50`;
             expect(makeDoitRequest).toHaveBeenCalledWith(
                 "https://api.doit.com/analytics/v1/reports/report-123",
                 mockToken,
-                { method: "GET" }
+                { method: "GET", timeoutMs: 120_000 }
             );
             expect(createSuccessResponse).toHaveBeenCalledWith(expect.stringContaining("reportName"));
             expect(response).toEqual({
@@ -435,7 +435,7 @@ Cloud Storage,50`;
             expect(makeDoitRequest).toHaveBeenCalledWith(
                 "https://api.doit.com/analytics/v1/reports/report-123",
                 mockToken,
-                { method: "GET" }
+                { method: "GET", timeoutMs: 120_000 }
             );
             expect(response).toEqual({
                 content: [

--- a/src/tools/reports.ts
+++ b/src/tools/reports.ts
@@ -741,14 +741,19 @@ export async function handleRunQueryRequest(args: any, token: string) {
                 body: { config },
                 appendParams: true,
                 customerContext,
+                timeoutMs: 120_000,
             });
 
             if (!queryResponse?.result || queryResponse?.error) {
+                const isCustomRange = rawConfig?.timeRange?.mode === "custom";
+                const customRangeHint = isCustomRange
+                    ? "\n  4. For custom time ranges, ensure customTimeRange has 'from' and 'to' in ISO 8601 format (e.g. '2026-01-01T00:00:00Z')."
+                    : "";
                 return createErrorResponse(
                     `Failed to run query. Try one of the following:
   1. Use 'list_dimensions' with a filter like 'filter:type:fixed' to get relevant dimensions or 'list_allocations' to get relevant allocations
   2. Check the specific error from the API: ${queryResponse?.error || "Unknown error"}
-  3. For a cost report, you need at least: metric, timeRange, and dataSource fields`
+  3. For a cost report, you need at least: metric, timeRange, and dataSource fields${customRangeHint}`
                 );
             }
 
@@ -852,6 +857,7 @@ export async function handleGetReportResultsRequest(args: any, token: string) {
             const reportData = await makeDoitRequest<GetReportResultsResponse>(reportUrl, token, {
                 method: "GET",
                 customerContext,
+                timeoutMs: 120_000,
             });
 
             if (!reportData) {

--- a/src/tools/reports.ts
+++ b/src/tools/reports.ts
@@ -745,16 +745,16 @@ export async function handleRunQueryRequest(args: any, token: string) {
             });
 
             if (!queryResponse?.result || queryResponse?.error) {
-                const isCustomRange = rawConfig?.timeRange?.mode === "custom";
-                const customRangeHint = isCustomRange
-                    ? "\n  4. For custom time ranges, ensure customTimeRange has 'from' and 'to' in ISO 8601 format (e.g. '2026-01-01T00:00:00Z')."
-                    : "";
-                return createErrorResponse(
-                    `Failed to run query. Try one of the following:
+                const base = `Failed to run query. Try one of the following:
   1. Use 'list_dimensions' with a filter like 'filter:type:fixed' to get relevant dimensions or 'list_allocations' to get relevant allocations
   2. Check the specific error from the API: ${queryResponse?.error || "Unknown error"}
-  3. For a cost report, you need at least: metric, timeRange, and dataSource fields${customRangeHint}`
-                );
+  3. For a cost report, you need at least: metric, timeRange, and dataSource fields`;
+                if (rawConfig?.timeRange?.mode === "custom") {
+                    return createErrorResponse(
+                        `${base}\n  4. For custom time ranges, ensure customTimeRange has 'from' and 'to' in ISO 8601 format (e.g. '2026-01-01T00:00:00Z').`
+                    );
+                }
+                return createErrorResponse(base);
             }
 
             return createSuccessResponse(

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -196,6 +196,7 @@ export async function handleCreateTicketRequest(args: any, token: string) {
             method: "POST",
             body: { ticket: parsed.ticket },
             customerContext,
+            timeoutMs: 60_000,
         });
         if (!response) {
             return createErrorResponse("Failed to create ticket: No data returned");


### PR DESCRIPTION
## Summary

Fixes five reliability issues reported by Connatix (CMP-47539) in the DoiT MCP server.

- **Timeouts**: `create_ticket` now times out at 60s; `run_query` and `get_report_results` at 120s — previously these could hang indefinitely, blocking the client for 14–30 minutes
- **Broken parameter schemas**: Worker's `registerTool` unwraps `ZodEffects` (produced by `.refine()`) before accessing `.shape` — tools like `get_report_results` and any schema with `.refine()` were publishing empty `inputSchema` to MCP clients, causing arguments to be silently stripped
- **Token exchange race**: `getToken()` now decodes the MCP token's `exp` claim and rejects early (within 30s of expiry) before calling the auth-service, preventing the timing race that caused ~50 `invalid_token` failures per session
- **Custom time range hint**: `run_query` error message now includes an actionable hint when `timeRange.mode === "custom"`, guiding toward correct `customTimeRange` formatting

## Test plan

- [ ] `create_ticket` with a valid payload returns within 60s or errors cleanly (no indefinite hang)
- [ ] `get_report_results` and `ask_ava_sync` tools expose non-empty `inputSchema` in MCP client tool listings
- [ ] Auth failures no longer occur on every-other call for long-running sessions
- [ ] `run_query` with `mode: "custom"` returns a descriptive error when the upstream rejects it

Closes CMP-47539

🤖 Generated with [Claude Code](https://claude.com/claude-code)