### PR TITLE
CMP-45611: Expose transport-independent core package API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Applications that provide their own MCP transport can reuse the published,
 transport-independent implementation:
 
 ```bash
-npm install @doitintl/doit-mcp-server
+npm install @doitintl/doit-mcp-server@latest
 ```
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -128,6 +128,30 @@ yarn build
 node dist/index.js
 ```
 
+## Core package API
+
+Applications that provide their own MCP transport can reuse the published,
+transport-independent implementation:
+
+```bash
+npm install @doitintl/doit-mcp-server
+```
+
+```ts
+import {
+    COVERED_ENDPOINTS,
+    executeToolHandler,
+    generateTools,
+    generatedToolsOpenApiSpec,
+    HAND_WRITTEN_TOOLS,
+} from "@doitintl/doit-mcp-server/core";
+```
+
+The `/core` entry includes the tool and prompt definitions, generated-tool
+utilities, request handling, and shared configuration APIs. It does not initialize
+the stdio transport or include the Cloudflare Worker, OAuth, Durable Objects, or
+widget implementation.
+
 ## Tools
 
 This MCP server provides many tools including the following:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,16 @@
   "author": "",
   "type": "module",
   "bin": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "import": "./dist/core.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/src/__tests__/core.test.ts
+++ b/src/__tests__/core.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+describe("core package API", () => {
+    it("exposes transport-independent MCP building blocks", async () => {
+        const coreModulePath = "../core.js";
+
+        await expect(import(/* @vite-ignore */ coreModulePath)).resolves.toMatchObject({
+            cloudOverviewTool: expect.objectContaining({ name: "get_cloud_overview" }),
+            CloudOverviewArgumentsSchema: expect.any(Object),
+            generateTools: expect.any(Function),
+            COVERED_ENDPOINTS: expect.any(Set),
+            executeToolHandler: expect.any(Function),
+            promptsIncludingLegacyNames: expect.any(Array),
+            resolvePromptMessages: expect.any(Function),
+            configureDoiTApiBase: expect.any(Function),
+            runWithConsoleEnv: expect.any(Function),
+            runWithTracking: expect.any(Function),
+            SERVER_NAME_WEB: "Doit",
+            SERVER_VERSION: expect.any(String),
+            DEMO_TOKEN: "demo_key",
+            generatedToolsOpenApiSpec: expect.objectContaining({
+                openapi: expect.stringMatching(/^3\./),
+            }),
+        });
+    });
+});

--- a/src/__tests__/packageExports.test.ts
+++ b/src/__tests__/packageExports.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("package exports", () => {
+    it("exposes the CLI root and transport-independent core entry", () => {
+        const packageJson = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
+
+        expect(packageJson.bin).toBe("dist/index.js");
+        expect(packageJson.exports).toEqual({
+            ".": {
+                types: "./dist/index.d.ts",
+                import: "./dist/index.js",
+            },
+            "./core": {
+                types: "./dist/core.d.ts",
+                import: "./dist/core.js",
+            },
+        });
+        expect(packageJson.scripts.prepare).toBeUndefined();
+        expect(packageJson.scripts.deploy).toBe("yarn build && npm publish --access public");
+    });
+});

--- a/src/__tests__/packageExports.test.ts
+++ b/src/__tests__/packageExports.test.ts
@@ -16,6 +16,7 @@ describe("package exports", () => {
                 import: "./dist/core.js",
             },
         });
+        expect(packageJson.files).toEqual(["dist"]);
         expect(packageJson.scripts.prepare).toBeUndefined();
         expect(packageJson.scripts.deploy).toBe("yarn build && npm publish --access public");
     });

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,252 @@
+import generatedToolsOpenApiSpec from "./tools/generated/openapi.json" with { type: "json" };
+
+export * from "./prompts/index.js";
+export { ListAccountTeamArgumentsSchema, listAccountTeamTool } from "./tools/accountTeam.js";
+export {
+    CreateAlertArgumentsSchema,
+    createAlertTool,
+    GetAlertArgumentsSchema,
+    getAlertTool,
+    ListAlertsArgumentsSchema,
+    listAlertsTool,
+    UpdateAlertArgumentsSchema,
+    updateAlertTool,
+} from "./tools/alerts.js";
+export {
+    CreateAllocationArgumentsSchema,
+    createAllocationTool,
+    GetAllocationArgumentsSchema,
+    getAllocationTool,
+    ListAllocationsArgumentsSchema,
+    listAllocationsTool,
+    UpdateAllocationArgumentsSchema,
+    updateAllocationTool,
+} from "./tools/allocations.js";
+export {
+    CreateAnnotationArgumentsSchema,
+    createAnnotationTool,
+    GetAnnotationArgumentsSchema,
+    getAnnotationTool,
+    ListAnnotationsArgumentsSchema,
+    listAnnotationsTool,
+    UpdateAnnotationArgumentsSchema,
+    updateAnnotationTool,
+} from "./tools/annotations.js";
+export {
+    AnomaliesArgumentsSchema,
+    AnomalyArgumentsSchema,
+    anomaliesTool,
+    anomalyTool,
+} from "./tools/anomalies.js";
+export {
+    GetAssetArgumentsSchema,
+    getAssetTool,
+    ListAssetsArgumentsSchema,
+    listAssetsTool,
+} from "./tools/assets.js";
+export { AskAvaSyncArgumentsSchema, askAvaSyncTool } from "./tools/ava.js";
+export {
+    GetAwsAccountArgumentsSchema,
+    GetCloudConnectSupportedFeaturesArgumentsSchema,
+    getAwsAccountTool,
+    getCloudConnectSupportedFeaturesTool,
+} from "./tools/awsAccounts.js";
+export {
+    CreateBudgetArgumentsSchema,
+    createBudgetTool,
+    GetBudgetArgumentsSchema,
+    getBudgetTool,
+    ListBudgetsArgumentsSchema,
+    listBudgetsTool,
+    UpdateBudgetArgumentsSchema,
+    updateBudgetTool,
+} from "./tools/budgets.js";
+export { ChangeCustomerArgumentsSchema, changeCustomerTool } from "./tools/changeCustomer.js";
+export {
+    FindCloudDiagramsArgumentsSchema,
+    findCloudDiagramsTool,
+    GetCloudDiagramComponentsArgumentsSchema,
+    GetCloudDiagramCostSnapshotArgumentsSchema,
+    GetCloudDiagramResourceRelationshipsArgumentsSchema,
+    GetCloudDiagramsStatsArgumentsSchema,
+    getCloudDiagramComponentsTool,
+    getCloudDiagramCostSnapshotTool,
+    getCloudDiagramResourceRelationshipsTool,
+    getCloudDiagramsStatsTool,
+    ListCloudDiagramActivityGroupsArgumentsSchema,
+    ListCloudDiagramNodeActivitiesArgumentsSchema,
+    listCloudDiagramActivityGroupsTool,
+    listCloudDiagramNodeActivitiesTool,
+    SearchCloudDiagramsArgumentsSchema,
+    searchCloudDiagramsTool,
+} from "./tools/cloudDiagrams.js";
+export {
+    CreateCloudFlowConnectionArgumentsSchema,
+    createCloudFlowConnectionTool,
+    GetCloudFlowConnectionArgumentsSchema,
+    GetCloudFlowTemplateArgumentsSchema,
+    getCloudFlowConnectionTool,
+    getCloudFlowTemplateTool,
+    ListCloudFlowConnectionsArgumentsSchema,
+    ListCloudFlowsArgumentsSchema,
+    ListCloudFlowTemplatesArgumentsSchema,
+    listCloudFlowConnectionsTool,
+    listCloudFlowsTool,
+    listCloudFlowTemplatesTool,
+    RefineCloudflowArgumentsSchema,
+    refineCloudflowTool,
+    TriggerCloudFlowArgumentsSchema,
+    triggerCloudFlowTool,
+    UpdateCloudFlowConnectionArgumentsSchema,
+    updateCloudFlowConnectionTool,
+} from "./tools/cloudflow.js";
+export {
+    CloudIncidentArgumentsSchema,
+    CloudIncidentsArgumentsSchema,
+    cloudIncidentsTool,
+    cloudIncidentTool,
+} from "./tools/cloudIncidents.js";
+export {
+    GetCommitmentArgumentsSchema,
+    getCommitmentTool,
+    ListCommitmentsArgumentsSchema,
+    listCommitmentsTool,
+} from "./tools/commitmentManager.js";
+export {
+    CreateDatahubDatasetArgumentsSchema,
+    createDatahubDatasetTool,
+    GetDatahubDatasetArgumentsSchema,
+    getDatahubDatasetTool,
+    ListDatahubDatasetsArgumentsSchema,
+    listDatahubDatasetsTool,
+    UpdateDatahubDatasetArgumentsSchema,
+    updateDatahubDatasetTool,
+} from "./tools/datahubDatasets.js";
+export { SendDatahubEventsArgumentsSchema, sendDatahubEventsTool } from "./tools/datahubEvents.js";
+export { DimensionArgumentsSchema, dimensionTool } from "./tools/dimension.js";
+export { DimensionsArgumentsSchema, dimensionsTool } from "./tools/dimensions.js";
+export {
+    CreateFolderArgumentsSchema,
+    createFolderTool,
+    GetFolderArgumentsSchema,
+    getFolderTool,
+    ListFoldersArgumentsSchema,
+    listFoldersTool,
+    UpdateFolderArgumentsSchema,
+    updateFolderTool,
+} from "./tools/folders.js";
+export { generateTools } from "./tools/generated/generateTools.js";
+export type { GeneratedTool } from "./tools/generated/types.js";
+export { COVERED_ENDPOINTS, HAND_WRITTEN_TOOLS } from "./tools/handWrittenTools.js";
+export {
+    GetInsightArgumentsSchema,
+    GetInsightResourcesArgumentsSchema,
+    getInsightResourcesTool,
+    getInsightTool,
+    ListInsightsArgumentsSchema,
+    listOptimizationRecommendationsTool,
+    PostInsightResultArgumentsSchema,
+    postInsightResultTool,
+    UpdateInsightStatusArgumentsSchema,
+    updateInsightStatusTool,
+} from "./tools/insights.js";
+export {
+    GetInvoiceArgumentsSchema,
+    getInvoiceTool,
+    ListInvoicesArgumentsSchema,
+    listInvoicesTool,
+} from "./tools/invoices.js";
+export {
+    AssignObjectsToLabelArgumentsSchema,
+    assignObjectsToLabelTool,
+    CreateLabelArgumentsSchema,
+    createLabelTool,
+    GetLabelArgumentsSchema,
+    GetLabelAssignmentsArgumentsSchema,
+    getLabelAssignmentsTool,
+    getLabelTool,
+    ListLabelsArgumentsSchema,
+    listLabelsTool,
+    UpdateLabelArgumentsSchema,
+    updateLabelTool,
+} from "./tools/labels.js";
+export { ListOrganizationsArgumentsSchema, listOrganizationsTool } from "./tools/organizations.js";
+export { CloudOverviewArgumentsSchema, cloudOverviewTool } from "./tools/overview.js";
+export {
+    GetResourcePermissionsArgumentsSchema,
+    getResourcePermissionsTool,
+    UpdateResourcePermissionsArgumentsSchema,
+    updateResourcePermissionsTool,
+} from "./tools/permissions.js";
+export { ListPlatformsArgumentsSchema, listPlatformsTool } from "./tools/platforms.js";
+export { ListProductsArgumentsSchema, listProductsTool } from "./tools/products.js";
+export {
+    CompareSpendArgumentsSchema,
+    CostBreakdownArgumentsSchema,
+    CostTrendArgumentsSchema,
+    compareSpendTool,
+    costBreakdownTool,
+    costTrendTool,
+} from "./tools/queryHelpers.js";
+export {
+    CreateReportArgumentsSchema,
+    createReportTool,
+    GetReportConfigArgumentsSchema,
+    GetReportResultsArgumentsSchema,
+    getReportConfigTool,
+    getReportResultsTool,
+    ReportsArgumentsSchema,
+    RunQueryArgumentsSchema,
+    reportsTool,
+    runQueryTool,
+    UpdateReportArgumentsSchema,
+    updateReportTool,
+} from "./tools/reports.js";
+export { ListRolesArgumentsSchema, listRolesTool } from "./tools/roles.js";
+export { SearchCustomersArgumentsSchema, searchCustomersTool } from "./tools/searchCustomers.js";
+export {
+    GetActiveThemeArgumentsSchema,
+    GetThemeArgumentsSchema,
+    getActiveThemeTool,
+    getThemeTool,
+    ListThemesArgumentsSchema,
+    listThemesTool,
+    SetActiveThemeArgumentsSchema,
+    setActiveThemeTool,
+    UpdateThemeArgumentsSchema,
+    updateThemeTool,
+} from "./tools/themes.js";
+export {
+    CreateTicketArgumentsSchema,
+    CreateTicketCommentArgumentsSchema,
+    createTicketCommentTool,
+    createTicketTool,
+    GetTicketArgumentsSchema,
+    getTicketTool,
+    ListTicketCommentsArgumentsSchema,
+    ListTicketsArgumentsSchema,
+    listTicketCommentsTool,
+    listTicketsTool,
+} from "./tools/tickets.js";
+export {
+    InviteUserArgumentsSchema,
+    inviteUserTool,
+    ListUsersArgumentsSchema,
+    listUsersTool,
+    UpdateUserArgumentsSchema,
+    updateUserTool,
+} from "./tools/users.js";
+export { ValidateUserArgumentsSchema, validateUserTool } from "./tools/validateUser.js";
+export * from "./utils/approval.js";
+export { SERVER_NAME, SERVER_NAME_WEB, SERVER_VERSION } from "./utils/consts.js";
+export { DEMO_TOKEN } from "./utils/demoData.js";
+export { executeToolHandler, type ToolHandlerOptions } from "./utils/toolsHandler.js";
+export {
+    type ConsoleRequestEnv,
+    configureDoiTApiBase,
+    runWithConsoleEnv,
+    runWithTracking,
+    type TrackingContext,
+} from "./utils/util.js";
+
+export { generatedToolsOpenApiSpec };


### PR DESCRIPTION
## Summary

- expose `@doitintl/doit-mcp-server/core` with the transport-independent symbols used by the remote server
- publish compiled JavaScript and declarations for the `/core` subpath while keeping the existing stdio CLI entry unchanged
- consume released npm artifacts without running repository build scripts during dependency installation
- document the supported library import and add package-contract and core-API tests

## Verification

- `yarn check:ci`
- `yarn test` — 933 passed, 3 skipped
- `yarn build`
- `npm pack --dry-run --json` contains `dist/core.js`, `dist/core.d.ts`, and the generated OpenAPI document
- packed tarball installed and imported from a clean temporary npm consumer

https://doitintl.atlassian.net/browse/CMP-45611