### PR TITLE
feat: publish to npm on release tag via trusted publishing (CMP-47733)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,12 @@ on:
     tags:
       - "v[0-9]*"
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Validate semver tag
         run: |
@@ -35,3 +34,47 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --notes-file /tmp/release-notes.md
+
+  # Publishes via npm Trusted Publishing (OIDC) — no NPM_TOKEN secret involved.
+  # One-time setup: a package maintainer adds a GitHub Actions trusted publisher
+  # (repo doitintl/doit-mcp-server, workflow release.yml) in the package's
+  # settings on npmjs.com. See docs/release.md.
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm (trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "v$PKG_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' does not match package.json version '$PKG_VERSION' — run scripts/release/prepare-release.sh before tagging"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run unit tests
+        run: yarn test
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish
+        run: npm publish --access public

--- a/docs/mcp-vs-api-cli-coverage.md
+++ b/docs/mcp-vs-api-cli-coverage.md
@@ -116,7 +116,7 @@ Computed as (operations in the live spec) minus (operations in the MCP snapshot)
 | Live spec → CLI commands | ✅ Yes (runtime) | restish loads the spec per invocation/cache; zero-lag coverage. |
 | Live spec → MCP snapshot (`openapi.json`) | ❌ Manual at research time | Was `yarn generate:refresh-spec` run by a maintainer (last run 2026-07-13, no CI cron, no drift check). Now automated by `.github/workflows/refresh-spec.yml` (PR #219): weekly cron + `repository_dispatch`, opens a review PR. |
 | Snapshot → MCP tools | ✅ Yes (build/load time) | `generateTools.ts` emits a tool per uncovered operation; hand-written coverage tracked via `coversEndpoint` so nothing double-registers. |
-| MCP release → npm | ❌ Manual | `yarn deploy` (build + `npm publish`); GitHub release workflow only creates the release on tag push. |
+| MCP release → npm | ✅ Yes (on tag) | `release.yml`'s `publish-npm` job publishes via npm Trusted Publishing (OIDC, no token) after verifying the tag matches `package.json`. |
 | npm → hosted worker (`mcp.doit.com`) | ❌ Manual / separate repo | Worker imports `@doitintl/doit-mcp-server/core`; redeploy cadence not visible from the public repo. |
 | MCP docs (help.doit.com tool list) | ❌ Manual | The docs list a curated subset and lag the generated tools. |
 
@@ -127,7 +127,7 @@ Computed as (operations in the live spec) minus (operations in the MCP snapshot)
 1. **Automate the snapshot refresh** — ✅ implemented in PR #219: `.github/workflows/refresh-spec.yml` runs `scripts/refresh-generated-spec.mjs` weekly (plus `workflow_dispatch` and `repository_dispatch` type `openapi-spec-updated`) and opens a review PR when `openapi.json` changes.
 2. **Add a drift alarm** — ✅ covered by the same workflow: the weekly run surfaces divergence as a PR instead of letting it accumulate silently.
 3. **CI hook in omni**: a post-merge step when `services/external-api/openapi.yaml` changes that fires the `repository_dispatch` at this repo (e.g. `gh api repos/doitintl/doit-mcp-server/dispatches -f event_type=openapi-spec-updated`). Not yet implemented.
-4. **Automate npm publish on tag** (the release workflow already validates semver tags) so a refreshed snapshot reaches the stdio users and the worker dependency bump without a maintainer's laptop. Not yet implemented.
+4. **Automate npm publish on tag** — ✅ implemented (CMP-47733): `release.yml` publishes to npm via Trusted Publishing on every semver tag; see `docs/release.md`.
 5. **Docs**: generate the help.doit.com MCP tool list from the same snapshot (or mark it explicitly as a curated highlights list) to avoid a third manually-synced surface. Not yet implemented.
 6. **Decide intentional exclusions explicitly** — ✅ mechanism implemented in PR #219 (`src/tools/generated/excludedOperations.json`, enforced by `generateTools.ts` and guarded by `src/tools/generated/__tests__/excludedOperations.test.ts`). The nine seeded entries (Billing Transfer batch writes, Contracts writes, Contract Templates writes) are **proposals pending a product decision** — delete an entry to expose that operation.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,4 +45,20 @@ git tag v0.10.0
 git push origin v0.10.0
 ```
 
-6. Pushing the tag triggers the [Release workflow](../.github/workflows/release.yml), which extracts the notes from `CHANGELOG.md` and creates a GitHub Release automatically.
+6. Pushing the tag triggers the [Release workflow](../.github/workflows/release.yml), which extracts the notes from `CHANGELOG.md`, creates a GitHub Release, and then publishes the package to npm automatically (the `publish-npm` job re-runs tests and the build, verifies the tag matches `package.json`, and publishes). `yarn deploy` from a laptop is no longer part of the release flow.
+
+## npm publishing (Trusted Publishing / OIDC)
+
+The `publish-npm` job authenticates via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) — GitHub Actions proves its identity to npm with an OIDC token, so **no `NPM_TOKEN` secret exists or needs rotating**. Publishes made this way also carry provenance attestations.
+
+One-time setup (any `@doitintl/doit-mcp-server` maintainer):
+
+1. On npmjs.com → package **Settings** → **Trusted Publisher**, select GitHub Actions.
+2. Set organization `doitintl`, repository `doit-mcp-server`, workflow filename `release.yml` (leave environment empty).
+3. Save. From then on, tag pushes publish without any credentials.
+
+Until that setup is done, the `publish-npm` job fails at the `npm publish` step with an auth error — everything before it (release creation) still works.
+
+## Cloudflare Worker (mcp.doit.com)
+
+Publishing to npm does **not** update the hosted Worker — it consumes this package's `/core` export from its own (private) repo and must bump the dependency and redeploy there. Automating that half is tracked in [CMP-47733](https://doitintl.atlassian.net/browse/CMP-47733).


### PR DESCRIPTION
## What

Adds a `publish-npm` job to the Release workflow: pushing a `vX.Y.Z` tag now publishes `@doitintl/doit-mcp-server` to npm automatically after the GitHub Release is created. `yarn deploy` from a laptop is no longer part of the release flow (docs/release.md updated).

## How it authenticates — no keys to provision

The job uses [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers): GitHub Actions proves its identity to npm via OIDC (`id-token: write`), so there is **no `NPM_TOKEN` secret to create, store, or rotate** — this sidesteps the key-provisioning blocker that stalled CMP-47733. Publishes also carry provenance attestations.

**One-time setup required** (any package maintainer, ~1 minute): npmjs.com → `@doitintl/doit-mcp-server` → Settings → Trusted Publisher → GitHub Actions → org `doitintl`, repo `doit-mcp-server`, workflow `release.yml`. Until then the publish step fails with an auth error (release creation still works).

## Safety rails

- Publishes only after the existing semver tag validation and GitHub Release creation succeed
- Verifies the tag matches `package.json`'s version (fails with a pointer to `prepare-release.sh` otherwise)
- Re-runs unit tests and the build before publishing
- Job has read-only repo contents; the only elevated permission is the OIDC token

## Scope note (CMP-47733)

This automates the **npm** half. The Cloudflare Worker (mcp.doit.com) lives in a separate private repo and still needs its dependency bump + redeploy automated there — that half stays open on [CMP-47733](https://doitintl.atlassian.net/browse/CMP-47733).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CMP-47733]: https://doitintl.atlassian.net/browse/CMP-47733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ