### PR TITLE
chore: prepare release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.19.0 (2026-08-17)
+
+**Full diff:** [`v0.16.0...v0.19.0`](../../compare/v0.16.0...v0.19.0)
+
+### Features
+
+- feat: publish to npm on release tag via trusted publishing (CMP-47733) (`1d2201b`)
+- feat: scheduled OpenAPI snapshot refresh honoring an exclusion policy — snapshot refreshed 130 → 170 operations, adding 31 generated tools (`c1eb459`)
+- feat: expose remote runtime helpers from core (#217) (`3d23ff0`)
+- feat: add transport-independent core API (`4acc4ba`)
+- feat: expose core package subpath (`31b89b9`)
+- feat(insights): add post_insight_result and update_insight_status tools (`d37309c`)
+
+### Bug Fixes
+
+- fix: address MCP reliability issues (CMP-47539) (#215) (`67f6d3b`)
+
+### Other Changes
+
+- docs: add MCP vs public API and CLI coverage research (`b7c9d25`)
+- Remove Cloudflare Worker subdirectory after repo split (#218) (`27721b1`)
+- docs: clarify released core package install (`8d5e328`)
+- test: assert published core artifact boundary (`76dd966`)
+
 ## v0.16.0 (2026-07-13)
 
 **Full diff:** [`v0.15.0...v0.16.0`](../../compare/v0.15.0...v0.16.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doitintl/doit-mcp-server",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "DoiT official MCP Server",
   "keywords": [
     "doit",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,4 +1,4 @@
-export const SERVER_VERSION = "0.16.0";
+export const SERVER_VERSION = "0.19.0";
 export const SERVER_NAME = "doit-mcp-server";
 export const SERVER_NAME_WEB = "Doit"; // for backwards compatibility, consistent name
 export const DEFAULT_MAX_RESULTS = "500";


### PR DESCRIPTION
Release prep for v0.19.0 — the first release through the fully automated pipeline (CMP-47733) and the first to ship the refreshed 170-operation snapshot.

- CHANGELOG entry for v0.19.0 (covers everything since v0.16.0 — 0.17.x/0.18.x were published to npm from laptops without tags or changelog entries, so this section is where that work gets documented)
- package.json 0.18.1 → 0.19.0
- SERVER_VERSION 0.16.0 → 0.19.0 (was never bumped by the untagged releases)

After merge, pushing the `v0.19.0` tag triggers the GitHub Release + the first OIDC npm publish (trusted publisher already configured on npmjs.com).

Highlights shipping in this release: 31 new auto-generated tools (Budget Suggestions, PS4C AWS commitments, Billing Transfer reads, Billing Explainer, Contracts reads, Service Quotas, …), exclusion policy, weekly snapshot refresh automation, npm publish automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)