### PR TITLE
fix: run npm publish job on node 22 with npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Update npm (trusted publishing needs npm >= 11.5.1)
-        run: npm install -g npm@latest
+      # Trusted publishing needs npm >= 11.5.1. Pinned to major 11 because
+      # npm@latest can require a newer Node than this job runs (npm@12 needs
+      # Node >= 22.22, which broke the first publish attempt on Node 20).
+      - name: Update npm
+        run: npm install -g npm@11
 
       - name: Verify tag matches package.json version
         run: |


### PR DESCRIPTION
The first tag-triggered publish (v0.19.0) failed before reaching npm: `npm install -g npm@latest` now resolves to npm@12, which requires Node >= 22.22, while the job pinned Node 20 (EBADENGINE). The GitHub Release was created; nothing was published.

- publish job now runs on Node 22
- npm pinned to major 11 (trusted publishing needs >= 11.5.1) so a future npm major with a higher Node floor can't break the job the same way

After merge, the v0.19.0 release will be redone: delete the existing GitHub Release + tag, re-tag the fixed main (version is still 0.19.0 — nothing reached the registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)