### PR TITLE
fix: add repository metadata and object-form bin for provenance publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,19 @@
     "mcp-server"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/doitintl/doit-mcp-server.git"
+  },
+  "homepage": "https://github.com/doitintl/doit-mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/doitintl/doit-mcp-server/issues"
+  },
   "author": "",
   "type": "module",
-  "bin": "dist/index.js",
+  "bin": {
+    "doit-mcp-server": "dist/index.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/src/__tests__/packageExports.test.ts
+++ b/src/__tests__/packageExports.test.ts
@@ -5,7 +5,8 @@ describe("package exports", () => {
     it("exposes the CLI root and transport-independent core entry", () => {
         const packageJson = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
 
-        expect(packageJson.bin).toBe("dist/index.js");
+        expect(packageJson.bin).toEqual({ "doit-mcp-server": "dist/index.js" });
+        expect(packageJson.repository?.url).toBe("git+https://github.com/doitintl/doit-mcp-server.git");
         expect(packageJson.exports).toEqual({
             ".": {
                 types: "./dist/index.d.ts",


### PR DESCRIPTION
Second and final blocker for the v0.19.0 OIDC publish: the registry rejected the provenance-verified publish with E422 because package.json has no `repository` field ("repository.url is \"\", expected to match https://github.com/doitintl/doit-mcp-server").

The OIDC handshake itself succeeded (provenance statement was signed and logged) — only this manifest validation failed.

- add `repository` (+ `homepage`, `bugs`) pointing at this repo — required for provenance validation
- normalize `bin` from string to `{ "doit-mcp-server": "dist/index.js" }` — removes the npm auto-correct warnings on publish; the binary name npm derived is unchanged
- update packageExports test accordingly

After merge: delete the empty v0.19.0 release + tag and re-tag (attempt three — nothing has reached the registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)