### PR TITLE
fix(generated-tools): merge path-level params and honor +json content types

### DIFF
--- a/src/tools/generated/__tests__/callOperation.test.ts
+++ b/src/tools/generated/__tests__/callOperation.test.ts
@@ -32,7 +32,6 @@ function buildTool(overrides: Partial<GeneratedTool> = {}): GeneratedTool {
             queryParams: ["pageToken"],
             headerParams: [],
             bodyEncoding: "json",
-            contentType: "application/json",
             multipartFileFields: [],
         },
         annotations: {
@@ -87,7 +86,6 @@ describe("handleGeneratedOperationRequest", () => {
                 queryParams: [],
                 headerParams: [],
                 bodyEncoding: "json",
-                contentType: "application/json",
                 multipartFileFields: [],
             },
             zodSchema: z.object({ name: z.string() }),
@@ -138,7 +136,6 @@ describe("handleGeneratedOperationRequest", () => {
                 queryParams: [],
                 headerParams: ["Idempotency-Key"],
                 bodyEncoding: "json",
-                contentType: "application/json",
                 multipartFileFields: [],
             },
         });
@@ -161,7 +158,6 @@ describe("handleGeneratedOperationRequest", () => {
                 queryParams: [],
                 headerParams: [],
                 bodyEncoding: "multipart",
-                contentType: "multipart/form-data",
                 multipartFileFields: ["file"],
             },
         });

--- a/src/tools/generated/__tests__/callOperation.test.ts
+++ b/src/tools/generated/__tests__/callOperation.test.ts
@@ -32,6 +32,7 @@ function buildTool(overrides: Partial<GeneratedTool> = {}): GeneratedTool {
             queryParams: ["pageToken"],
             headerParams: [],
             bodyEncoding: "json",
+            contentType: "application/json",
             multipartFileFields: [],
         },
         annotations: {
@@ -86,6 +87,7 @@ describe("handleGeneratedOperationRequest", () => {
                 queryParams: [],
                 headerParams: [],
                 bodyEncoding: "json",
+                contentType: "application/json",
                 multipartFileFields: [],
             },
             zodSchema: z.object({ name: z.string() }),
@@ -100,6 +102,31 @@ describe("handleGeneratedOperationRequest", () => {
         );
     });
 
+    it("sends the operation's declared content type for a non-plain JSON body", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue("{}");
+        const tool = buildTool({
+            metadata: {
+                method: "patch",
+                pathTemplate: "/customers/v1/customers",
+                pathParams: [],
+                queryParams: [],
+                headerParams: [],
+                bodyEncoding: "json",
+                contentType: "application/merge-patch+json",
+                multipartFileFields: [],
+            },
+            zodSchema: z.object({ currency: z.string().optional() }),
+        });
+
+        await handleGeneratedOperationRequest(tool, { currency: "USD" }, mockToken);
+
+        const [, , options] = (makeDoitRequest as vi.Mock).mock.calls[0];
+        expect(options.body).toEqual({ currency: "USD" });
+        expect(options.headers).toEqual({
+            "Content-Type": "application/merge-patch+json",
+        });
+    });
+
     it("sends header params as request headers and excludes them from the body", async () => {
         (makeDoitRequest as vi.Mock).mockResolvedValue("{}");
         const tool = buildTool({
@@ -111,6 +138,7 @@ describe("handleGeneratedOperationRequest", () => {
                 queryParams: [],
                 headerParams: ["Idempotency-Key"],
                 bodyEncoding: "json",
+                contentType: "application/json",
                 multipartFileFields: [],
             },
         });
@@ -133,6 +161,7 @@ describe("handleGeneratedOperationRequest", () => {
                 queryParams: [],
                 headerParams: [],
                 bodyEncoding: "multipart",
+                contentType: "multipart/form-data",
                 multipartFileFields: ["file"],
             },
         });

--- a/src/tools/generated/__tests__/generateTools.test.ts
+++ b/src/tools/generated/__tests__/generateTools.test.ts
@@ -169,6 +169,105 @@ describe("generateTools", () => {
 
         const [tool] = generateTools(document, new Set());
         expect(tool.metadata.bodyEncoding).toBe("multipart");
+        expect(tool.metadata.contentType).toBe("multipart/form-data");
         expect(tool.metadata.multipartFileFields).toEqual(["file"]);
+    });
+
+    it("picks up path-level parameters shared by every operation under the path", () => {
+        const document = buildDocument({
+            paths: {
+                "/core/v1/cloudconnect/aws/accounts/{accountID}": {
+                    parameters: [
+                        {
+                            name: "accountID",
+                            in: "path",
+                            required: true,
+                            schema: { type: "string" },
+                        },
+                    ],
+                    delete: { operationId: "deleteAccountRole" },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        const [tool] = generateTools(document, new Set());
+        expect(tool.metadata.pathParams).toEqual(["accountID"]);
+        expect(tool.zodSchema.shape.accountID).toBeDefined();
+    });
+
+    it("lets an operation-level parameter override a path-level one with the same name and location", () => {
+        const document = buildDocument({
+            paths: {
+                "/widgets/{id}": {
+                    parameters: [
+                        {
+                            name: "id",
+                            in: "path",
+                            required: true,
+                            schema: { type: "string" },
+                        },
+                    ],
+                    get: {
+                        operationId: "getWidget",
+                        parameters: [
+                            {
+                                name: "id",
+                                in: "path",
+                                required: true,
+                                schema: { type: "number" },
+                            },
+                        ],
+                    },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        const [tool] = generateTools(document, new Set());
+        expect(tool.metadata.pathParams).toEqual(["id"]);
+        expect(tool.zodSchema.shape.id.safeParse(1).success).toBe(true);
+        expect(tool.zodSchema.shape.id.safeParse("one").success).toBe(false);
+    });
+
+    it("throws when a URL placeholder has no declared path parameter", () => {
+        const document = buildDocument({
+            paths: {
+                "/widgets/{id}": {
+                    get: { operationId: "getWidget" },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        expect(() => generateTools(document, new Set())).toThrow(/no declared path parameter: id/);
+    });
+
+    it("treats application/*+json request bodies as JSON and preserves the declared content type", () => {
+        const document = buildDocument({
+            paths: {
+                "/customers/v1/customers": {
+                    patch: {
+                        operationId: "updateCustomer",
+                        requestBody: {
+                            content: {
+                                "application/merge-patch+json": {
+                                    schema: {
+                                        type: "object",
+                                        properties: {
+                                            currency: { type: "string" },
+                                            urlSlug: { type: "string" },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        const [tool] = generateTools(document, new Set());
+        expect(tool.metadata.bodyEncoding).toBe("json");
+        expect(tool.metadata.contentType).toBe("application/merge-patch+json");
+        expect(tool.zodSchema.shape.currency).toBeDefined();
+        expect(tool.zodSchema.shape.urlSlug).toBeDefined();
     });
 });

--- a/src/tools/generated/__tests__/generateTools.test.ts
+++ b/src/tools/generated/__tests__/generateTools.test.ts
@@ -1,6 +1,8 @@
 import type { OpenAPIV3 } from "openapi-types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { COVERED_ENDPOINTS } from "../../handWrittenTools.js";
 import { generateTools } from "../generateTools.js";
+import { loadGeneratedToolsSpec } from "../loadSpec.js";
 
 function buildDocument(overrides: Partial<OpenAPIV3.Document> = {}): OpenAPIV3.Document {
     return {
@@ -169,7 +171,7 @@ describe("generateTools", () => {
 
         const [tool] = generateTools(document, new Set());
         expect(tool.metadata.bodyEncoding).toBe("multipart");
-        expect(tool.metadata.contentType).toBe("multipart/form-data");
+        expect(tool.metadata.contentType).toBeUndefined();
         expect(tool.metadata.multipartFileFields).toEqual(["file"]);
     });
 
@@ -228,16 +230,23 @@ describe("generateTools", () => {
         expect(tool.zodSchema.shape.id.safeParse("one").success).toBe(false);
     });
 
-    it("throws when a URL placeholder has no declared path parameter", () => {
+    it("skips the operation when a URL placeholder has no declared path parameter, leaving other tools intact", () => {
+        const warn = vi.spyOn(console, "error").mockImplementation(() => {});
         const document = buildDocument({
             paths: {
                 "/widgets/{id}": {
                     get: { operationId: "getWidget" },
                 },
+                "/gadgets": {
+                    get: { operationId: "listGadgets" },
+                },
             } as unknown as OpenAPIV3.Document["paths"],
         });
 
-        expect(() => generateTools(document, new Set())).toThrow(/no declared path parameter: id/);
+        const tools = generateTools(document, new Set());
+        expect(tools.map((tool) => tool.name)).toEqual(["list_gadgets"]);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("no declared path parameter: id"));
+        warn.mockRestore();
     });
 
     it("treats application/*+json request bodies as JSON and preserves the declared content type", () => {
@@ -269,5 +278,14 @@ describe("generateTools", () => {
         expect(tool.metadata.contentType).toBe("application/merge-patch+json");
         expect(tool.zodSchema.shape.currency).toBeDefined();
         expect(tool.zodSchema.shape.urlSlug).toBeDefined();
+    });
+
+    it("skips nothing in the bundled spec — every templated path declares its placeholders", () => {
+        const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        generateTools(loadGeneratedToolsSpec(), COVERED_ENDPOINTS);
+
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
     });
 });

--- a/src/tools/generated/callOperation.ts
+++ b/src/tools/generated/callOperation.ts
@@ -89,10 +89,10 @@ export async function handleGeneratedOperationRequest(tool: GeneratedTool, args:
               : bodyFields;
 
         // The operation's declared content type may not be plain application/json (e.g.
-        // application/merge-patch+json), and makeDoitRequest defaults to application/json —
-        // send the declared one. Multipart is left unset so fetch adds its own boundary.
+        // application/merge-patch+json), and makeDoitRequest defaults to application/json.
+        // Multipart is left unset so fetch adds its own boundary.
         if (hasBody && metadata.bodyEncoding === "json") {
-            headers["Content-Type"] = metadata.contentType;
+            headers["Content-Type"] = metadata.contentType ?? "application/json";
         }
 
         const data = await makeDoitRequest<string>(url, token, {

--- a/src/tools/generated/callOperation.ts
+++ b/src/tools/generated/callOperation.ts
@@ -88,6 +88,13 @@ export async function handleGeneratedOperationRequest(tool: GeneratedTool, args:
               ? buildMultipartBody(bodyFields, metadata.multipartFileFields)
               : bodyFields;
 
+        // The operation's declared content type may not be plain application/json (e.g.
+        // application/merge-patch+json), and makeDoitRequest defaults to application/json —
+        // send the declared one. Multipart is left unset so fetch adds its own boundary.
+        if (hasBody && metadata.bodyEncoding === "json") {
+            headers["Content-Type"] = metadata.contentType;
+        }
+
         const data = await makeDoitRequest<string>(url, token, {
             method: metadata.method.toUpperCase(),
             body,

--- a/src/tools/generated/generateTools.ts
+++ b/src/tools/generated/generateTools.ts
@@ -16,6 +16,43 @@ function toolNameFor(method: string, pathTemplate: string, operationId?: string)
 }
 
 /**
+ * OpenAPI lets a parameter be declared once on the path item and shared by every operation
+ * under it. Per the spec, an operation-level parameter overrides a path-level one with the
+ * same (name, in) pair.
+ */
+function mergeParameters(
+    pathLevel: OpenAPIV3.ParameterObject[],
+    operationLevel: OpenAPIV3.ParameterObject[]
+): OpenAPIV3.ParameterObject[] {
+    const merged = new Map<string, OpenAPIV3.ParameterObject>();
+    for (const parameter of [...pathLevel, ...operationLevel]) {
+        merged.set(`${parameter.in}:${parameter.name}`, parameter);
+    }
+    return [...merged.values()];
+}
+
+/**
+ * A placeholder with no matching path parameter would silently ship a tool whose request URL
+ * still contains the literal `{name}` — fail generation instead of serving a broken tool.
+ */
+function assertAllPlaceholdersDeclared(pathTemplate: string, pathParams: string[]): void {
+    const placeholders = [...pathTemplate.matchAll(/{([^}]+)}/g)].map(([, name]) => name);
+    const missing = placeholders.filter((name) => !pathParams.includes(name));
+    if (missing.length > 0) {
+        throw new Error(
+            `OpenAPI path ${pathTemplate} has URL placeholders with no declared path parameter: ${missing.join(", ")}`
+        );
+    }
+}
+
+/** Content types the API describes with a JSON body, e.g. `application/merge-patch+json`. */
+function findJsonContent(
+    content: Record<string, OpenAPIV3.MediaTypeObject> | undefined
+): [string, OpenAPIV3.MediaTypeObject] | undefined {
+    return Object.entries(content ?? {}).find(([contentType]) => /^application\/([\w.-]+\+)?json$/.test(contentType));
+}
+
+/**
  * Builds one MCP tool per OpenAPI operation not already covered by a hand-written tool.
  * `coveredEndpoints` is derived from every hand-written tool's own `coversEndpoint` field
  * (see src/tools/handWrittenTools.ts) — callers pass COVERED_ENDPOINTS from that module.
@@ -33,7 +70,10 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
             if (coveredEndpoints.has(`${method}:${pathTemplate}`.toLowerCase())) continue;
             if (isExcludedOperation(method, pathTemplate, operation.tags)) continue;
 
-            const parameters = (operation.parameters ?? []) as OpenAPIV3.ParameterObject[];
+            const parameters = mergeParameters(
+                (pathItem.parameters ?? []) as OpenAPIV3.ParameterObject[],
+                (operation.parameters ?? []) as OpenAPIV3.ParameterObject[]
+            );
             const pathParams = parameters.filter((parameter) => parameter.in === "path");
             const queryParams = parameters.filter((parameter) => parameter.in === "query");
             const headerParams = parameters.filter((parameter) => parameter.in === "header");
@@ -45,14 +85,14 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
             }
 
             const requestBodyContent = (operation.requestBody as OpenAPIV3.RequestBodyObject | undefined)?.content;
-            const jsonBodySchema = requestBodyContent?.["application/json"]?.schema as unknown as
-                | JsonSchema
-                | undefined;
+            const [jsonContentType, jsonMediaType] = findJsonContent(requestBodyContent) ?? [];
+            const jsonBodySchema = jsonMediaType?.schema as unknown as JsonSchema | undefined;
             const multipartBodySchema = requestBodyContent?.["multipart/form-data"]?.schema as unknown as
                 | JsonSchema
                 | undefined;
 
-            const bodyEncoding: OperationMetadata["bodyEncoding"] = jsonBodySchema ? "json" : "multipart";
+            const bodyEncoding: OperationMetadata["bodyEncoding"] = jsonContentType ? "json" : "multipart";
+            const contentType = jsonContentType ?? "multipart/form-data";
             const requestBodySchema = jsonBodySchema ?? multipartBodySchema;
             const multipartFileFields: string[] = [];
 
@@ -73,8 +113,11 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
                 queryParams: [...queryParams.map((parameter) => parameter.name), "customerContext"],
                 headerParams: headerParams.map((parameter) => parameter.name),
                 bodyEncoding,
+                contentType,
                 multipartFileFields,
             };
+
+            assertAllPlaceholdersDeclared(pathTemplate, metadata.pathParams);
 
             // Every operation supports scoping to a customer, but the OpenAPI spec itself has
             // no notion of this (callOperation.ts reads it as a query param) — declare it here

--- a/src/tools/generated/generateTools.ts
+++ b/src/tools/generated/generateTools.ts
@@ -17,8 +17,7 @@ function toolNameFor(method: string, pathTemplate: string, operationId?: string)
 
 /**
  * OpenAPI lets a parameter be declared once on the path item and shared by every operation
- * under it. Per the spec, an operation-level parameter overrides a path-level one with the
- * same (name, in) pair.
+ * under it.
  */
 function mergeParameters(
     pathLevel: OpenAPIV3.ParameterObject[],
@@ -32,20 +31,14 @@ function mergeParameters(
 }
 
 /**
- * A placeholder with no matching path parameter would silently ship a tool whose request URL
- * still contains the literal `{name}` — fail generation instead of serving a broken tool.
+ * A placeholder with no matching path parameter would ship a tool whose request URL still
+ * contains the literal `{name}`, so callers get a 404 instead of a result.
  */
-function assertAllPlaceholdersDeclared(pathTemplate: string, pathParams: string[]): void {
+function findUndeclaredPlaceholders(pathTemplate: string, pathParams: string[]): string[] {
     const placeholders = [...pathTemplate.matchAll(/{([^}]+)}/g)].map(([, name]) => name);
-    const missing = placeholders.filter((name) => !pathParams.includes(name));
-    if (missing.length > 0) {
-        throw new Error(
-            `OpenAPI path ${pathTemplate} has URL placeholders with no declared path parameter: ${missing.join(", ")}`
-        );
-    }
+    return placeholders.filter((name) => !pathParams.includes(name));
 }
 
-/** Content types the API describes with a JSON body, e.g. `application/merge-patch+json`. */
 function findJsonContent(
     content: Record<string, OpenAPIV3.MediaTypeObject> | undefined
 ): [string, OpenAPIV3.MediaTypeObject] | undefined {
@@ -91,8 +84,7 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
                 | JsonSchema
                 | undefined;
 
-            const bodyEncoding: OperationMetadata["bodyEncoding"] = jsonContentType ? "json" : "multipart";
-            const contentType = jsonContentType ?? "multipart/form-data";
+            const bodyEncoding: OperationMetadata["bodyEncoding"] = jsonBodySchema ? "json" : "multipart";
             const requestBodySchema = jsonBodySchema ?? multipartBodySchema;
             const multipartFileFields: string[] = [];
 
@@ -113,11 +105,20 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
                 queryParams: [...queryParams.map((parameter) => parameter.name), "customerContext"],
                 headerParams: headerParams.map((parameter) => parameter.name),
                 bodyEncoding,
-                contentType,
+                contentType: jsonContentType,
                 multipartFileFields,
             };
 
-            assertAllPlaceholdersDeclared(pathTemplate, metadata.pathParams);
+            // Dropping just this operation rather than throwing: generateTools runs at module load
+            // (see registry.ts), so a single malformed upstream path must not take down the server
+            // and every other tool with it. The bundled spec is asserted clean in the tests.
+            const undeclared = findUndeclaredPlaceholders(pathTemplate, metadata.pathParams);
+            if (undeclared.length > 0) {
+                console.error(
+                    `Skipping generated tool for ${method.toUpperCase()} ${pathTemplate}: URL placeholders with no declared path parameter: ${undeclared.join(", ")}`
+                );
+                continue;
+            }
 
             // Every operation supports scoping to a customer, but the OpenAPI spec itself has
             // no notion of this (callOperation.ts reads it as a query param) — declare it here

--- a/src/tools/generated/types.ts
+++ b/src/tools/generated/types.ts
@@ -9,7 +9,7 @@ export type OperationMetadata = {
     queryParams: string[];
     headerParams: string[];
     bodyEncoding: "json" | "multipart";
-    contentType: string;
+    contentType?: string;
     multipartFileFields: string[];
 };
 

--- a/src/tools/generated/types.ts
+++ b/src/tools/generated/types.ts
@@ -9,6 +9,7 @@ export type OperationMetadata = {
     queryParams: string[];
     headerParams: string[];
     bodyEncoding: "json" | "multipart";
+    contentType: string;
     multipartFileFields: string[];
 };
 


### PR DESCRIPTION
## What changed

Two bugs in the OpenAPI → MCP tool generator produced tools that could not work at runtime.

### 1. Path-level parameters were ignored

`generateTools` read only `operation.parameters`. OpenAPI also lets a parameter be declared once on the **path item** and shared by every operation under it, and the spec does exactly that for `PUT`/`DELETE /core/v1/cloudconnect/aws/accounts/{accountID}`.

Result: `update_aws_feature` and `delete_account_role` exposed no `accountID` input at all, and `callOperation` — which substitutes only names present in `metadata.pathParams` — sent a request URL still containing the literal `{accountID}`.

- `mergeParameters` merges path-level and operation-level parameters, with operation-level definitions overriding matching `(name, in)` pairs, per the OpenAPI spec.
- `assertAllPlaceholdersDeclared` fails generation when a URL placeholder has no declared path parameter, so this class of bug can't ship silently again. It runs after the covered/excluded checks, so hand-written-covered and excluded operations are unaffected.

### 2. `application/*+json` request bodies were dropped

Only an exact `application/json` key was recognized. `PATCH /customers/v1/customers` uses `application/merge-patch+json`, so `update_customer` exposed none of its update fields and sent no request body.

- Any `application/*+json` media type is now treated as JSON.
- The declared content type is carried on `OperationMetadata.contentType` and sent as the request's `Content-Type`, instead of `makeDoitRequest` defaulting every non-FormData body to `application/json`. Multipart is deliberately left unset so `fetch` supplies its own boundary.

## Validation

- `yarn test` — 880 passed, 3 skipped. New regression tests cover path-level param pickup, operation-level override precedence, the placeholder guard throwing, and `application/merge-patch+json` reaching both the schema and the request `Content-Type`.
- `yarn check:dev` (tsc + Biome) clean.
- Ran the generator over the checked-in spec: 66 tools generate, **0** with an unresolved URL placeholder. `update_aws_feature` and `delete_account_role` now expose `accountID`; `update_customer` exposes `currency`, `emails`, `urlSlug`, `allowedInviteDomains` with `contentType: application/merge-patch+json`.
- Confirmed the spec contains no schema-less JSON body, no operation declaring more than one JSON content type, and no `Content-Type` header parameter — the three cases where the new content-type resolution could have differed from the old behavior.