### PR TITLE
chore: prepare release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.19.1 (2026-08-18)
+
+**Full diff:** [`v0.19.0...v0.19.1`](../../compare/v0.19.0...v0.19.1)
+
+### Bug Fixes
+
+- fix(generated-tools): merge path-level params and honor +json content types (#225) (`040e63c`)
 ## v0.19.0 (2026-08-17)
 
 **Full diff:** [`v0.16.0...v0.19.0`](../../compare/v0.16.0...v0.19.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doitintl/doit-mcp-server",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "DoiT official MCP Server",
   "keywords": [
     "doit",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,4 +1,4 @@
-export const SERVER_VERSION = "0.19.0";
+export const SERVER_VERSION = "0.19.1";
 export const SERVER_NAME = "doit-mcp-server";
 export const SERVER_NAME_WEB = "Doit"; // for backwards compatibility, consistent name
 export const DEFAULT_MAX_RESULTS = "500";

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doitintl/doit-mcp-server-integration-tests",
-  "version": "0.16.0",
+  "version": "0.19.1",
   "private": true,
   "description": "Integration tests for DoiT MCP Server",
   "type": "module",


### PR DESCRIPTION
Prepares the v0.19.1 patch release.

- Bumps `package.json`, `test/integration/package.json`, and `SERVER_VERSION` to `0.19.1`
- Adds the `v0.19.1` CHANGELOG entry (covers `#225`)

After merge, push the `v0.19.1` tag from `main` to trigger the Release workflow (GitHub Release + npm publish via trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)