### PR TITLE
fix(generated-tools): surface the API's error message instead of a generic failure

### DIFF
--- a/src/tools/generated/__tests__/callOperation.test.ts
+++ b/src/tools/generated/__tests__/callOperation.test.ts
@@ -186,4 +186,36 @@ describe("handleGeneratedOperationRequest", () => {
 
         expect(response.isError).toBe(true);
     });
+
+    it("asks makeDoitRequest to throw so the API's error reaches the caller", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue("{}");
+
+        await handleGeneratedOperationRequest(buildTool(), { id: "abc" }, mockToken);
+
+        const [, , options] = (makeDoitRequest as vi.Mock).mock.calls[0];
+        expect(options.throwOnError).toBe(true);
+    });
+
+    it("surfaces the API's error message instead of a generic failure", async () => {
+        (makeDoitRequest as vi.Mock).mockRejectedValue(
+            new Error("HTTP 403: user is missing required permission: Settings")
+        );
+
+        const response = await handleGeneratedOperationRequest(buildTool(), { id: "abc" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("HTTP 403: user is missing required permission: Settings");
+    });
+
+    it("carries the re-auth challenge on a 401 the way hand-written tools do", async () => {
+        (makeDoitRequest as vi.Mock).mockRejectedValue(new Error("HTTP 401: your session has expired"));
+
+        const response = await handleGeneratedOperationRequest(buildTool(), { id: "abc" }, mockToken);
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("HTTP 401: your session has expired");
+        expect((response as { _meta?: Record<string, string> })._meta?.["mcp/www_authenticate"]).toContain(
+            "invalid_token"
+        );
+    });
 });

--- a/src/tools/generated/callOperation.ts
+++ b/src/tools/generated/callOperation.ts
@@ -102,6 +102,7 @@ export async function handleGeneratedOperationRequest(tool: GeneratedTool, args:
             parseAs: "text",
             timeoutMs: GENERATED_REQUEST_TIMEOUT_MS,
             headers: Object.keys(headers).length > 0 ? headers : undefined,
+            throwOnError: true,
         });
 
         if (data === null) {

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -231,4 +231,34 @@ describe("makeDoitRequest timeout", () => {
 
         expect(result).toBeNull();
     });
+
+    it("should return null on an HTTP error when throwOnError is not set", async () => {
+        vi.stubGlobal("fetch", () =>
+            Promise.resolve({
+                ok: false,
+                status: 403,
+                statusText: "Forbidden",
+                text: () => Promise.resolve(JSON.stringify({ error: "user is missing required permission: Settings" })),
+            })
+        );
+
+        const result = await makeDoitRequest("https://api.doit.com/test", "test-token");
+
+        expect(result).toBeNull();
+    });
+
+    it("should throw the API's error detail when throwOnError is set", async () => {
+        vi.stubGlobal("fetch", () =>
+            Promise.resolve({
+                ok: false,
+                status: 403,
+                statusText: "Forbidden",
+                text: () => Promise.resolve(JSON.stringify({ error: "user is missing required permission: Settings" })),
+            })
+        );
+
+        await expect(
+            makeDoitRequest("https://api.doit.com/test", "test-token", { throwOnError: true })
+        ).rejects.toThrow("HTTP 403: user is missing required permission: Settings");
+    });
 });

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -247,6 +247,22 @@ describe("makeDoitRequest timeout", () => {
         expect(result).toBeNull();
     });
 
+    it("should cap an oversized upstream error body instead of forwarding it whole", async () => {
+        const htmlErrorPage = `<html>${"x".repeat(5000)}</html>`;
+        vi.stubGlobal("fetch", () =>
+            Promise.resolve({
+                ok: false,
+                status: 502,
+                statusText: "Bad Gateway",
+                text: () => Promise.resolve(htmlErrorPage),
+            })
+        );
+
+        await expect(
+            makeDoitRequest("https://api.doit.com/test", "test-token", { throwOnError: true })
+        ).rejects.toThrow(/… \(truncated\)$/);
+    });
+
     it("should throw the API's error detail when throwOnError is set", async () => {
         vi.stubGlobal("fetch", () =>
             Promise.resolve({

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -233,6 +233,10 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
  * re-throws a `DOMException` with `name === "TimeoutError"` instead of returning null.
  * Callers that pass `timeoutMs` must handle this case explicitly.
  *
+ * Exception: when `throwOnError` is set, every error is re-thrown instead of returning null,
+ * so the caller can surface the API's own message (see `throwHttpError`) rather than a
+ * generic failure string. Callers that pass it must handle the throw.
+ *
  * @param url The API endpoint URL
  * @param token The authentication token
  * @param options Additional request options
@@ -240,6 +244,7 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
  * @param options.body Request body for POST/PUT requests
  * @param options.appendParams Whether to append URL parameters (maxResults and customerContext)
  * @param options.timeoutMs If set, aborts the request after this many milliseconds and throws TimeoutError
+ * @param options.throwOnError If set, re-throws errors instead of returning null
  * @returns The parsed JSON response or null on error
  */
 export async function makeDoitRequest<T>(

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -260,6 +260,7 @@ export async function makeDoitRequest<T>(
         /** Extra headers to send alongside the default Authorization/Accept/Content-Type
          *  headers (e.g. an OpenAPI operation's required header parameters). */
         headers?: Record<string, string>;
+        throwOnError?: boolean;
     } = {}
 ): Promise<T | null> {
     const {
@@ -271,6 +272,7 @@ export async function makeDoitRequest<T>(
         timeoutMs,
         parseAs = "json",
         headers: extraHeaders,
+        throwOnError = false,
     } = options;
 
     const resolvedUrl = applyRuntimeDoiTApiBase(url);
@@ -341,6 +343,9 @@ export async function makeDoitRequest<T>(
     } catch (error) {
         if (error instanceof DOMException && error.name === "TimeoutError") {
             console.error(`DoiT API ${method} request timed out after ${timeoutMs}ms`);
+            throw error;
+        }
+        if (throwOnError) {
             throw error;
         }
         console.error(`Error making DoiT API ${method} request to ${requestUrl}:`, error);

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -381,6 +381,13 @@ function appendTrackingParams(url: string): string {
     return out;
 }
 
+/**
+ * An upstream error body is not always the short JSON message we hope for — a proxy or load
+ * balancer can return a full HTML page — and this string is surfaced to the MCP client, so it
+ * is capped rather than forwarded whole.
+ */
+const MAX_ERROR_DETAIL_CHARS = 2000;
+
 // throwHttpError reads a non-OK response body, extracts the most specific message available,
 // and throws an Error carrying the HTTP status.
 async function throwHttpError(response: Response): Promise<never> {
@@ -396,7 +403,11 @@ async function throwHttpError(response: Response): Promise<never> {
         // use bodyText as-is
     }
 
-    throw new Error(`HTTP ${response.status}: ${detail || response.statusText}`);
+    const message = detail || response.statusText;
+    if (message.length > MAX_ERROR_DETAIL_CHARS) {
+        throw new Error(`HTTP ${response.status}: ${message.slice(0, MAX_ERROR_DETAIL_CHARS)}… (truncated)`);
+    }
+    throw new Error(`HTTP ${response.status}: ${message}`);
 }
 
 function resolveConsoleBase(): { baseUrl: string; doFetch: typeof fetch } {


### PR DESCRIPTION
## What changed

Generated tools now report the API's actual error instead of a generic one.

`throwHttpError` already extracts a specific message from a non-OK response, but `makeDoitRequest` caught that throw and returned `null` (`src/utils/util.ts`), so `callOperation.ts` fell into its `data === null` branch and emitted `Failed to call GET /customers/v1/customers` — discarding `user is missing required permission: Settings`.

`makeDoitRequest` gains an opt-in `throwOnError`; only the generated operation handler sets it. Its existing `catch` already routes to `handleGeneralError`, which surfaces the message and attaches the `mcp/www_authenticate` challenge on a 401 — the same treatment hand-written tools get. A second commit updates `makeDoitRequest`'s JSDoc, which previously documented a timeout as the only exception to "returns null on error".

## Scope: this fixes the generated tools only

`search_customers` surfaced a clean `HTTP 401: …` because it does not route through `makeDoitRequest` — but that is not true of hand-written tools in general. **30 of the 34 hand-written tool files do use `makeDoitRequest` and still replace the API's message with a generic string** (e.g. `Failed to retrieve alert` at `src/tools/alerts.ts:151-153`).

Those are deliberately left alone here to keep the blast radius small: each is a separate `if (!data)` branch with its own message, and they can opt into `throwOnError` incrementally. This PR closes the gap for the 166 generated tools, which had no per-tool message at all. Worth a follow-up.

## Error-body cap

Forwarding the API's error text means a non-JSON upstream body — an HTML page from a proxy or load balancer — would otherwise reach the client verbatim, since `throwHttpError` falls back to the raw body when it finds no `message`/`error`/`detail` field. It now caps the detail at 2000 characters. The fallback itself is kept: DoiT returns `{"error": "..."}`, which is the field that carries "user is missing required permission".

## Blast radius

`throwOnError` defaults to `false`, so every existing caller keeps the `null`-on-failure contract byte-for-byte. The timeout branch still rethrows ahead of it, unchanged. The field is optional, so the remote Worker that builds against these exported types is unaffected.

## How validated

- Full suite: 887 passed, 3 skipped — 6 new tests covering error propagation, the 401 challenge, the `throwOnError` opt-in, the oversized-body cap, and the preserved `null` default.
- `yarn check:dev` clean (tsc + biome).
- End-to-end against a stub returning `403 {"error":"user is missing required permission: Settings"}`:
  - before: `Failed to call GET /customers/v1/customers`
  - after: `HTTP 403: user is missing required permission: Settings`

Found while verifying the v0.19.1 release; this bug is pre-existing, not from that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)