### PR TITLE
ci: open the release PR with a GitHub App token so its checks run

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Mint a GitHub App token
         if: steps.version.outputs.tag != ''
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_CLIENT_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create or update pull request

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Mint a GitHub App token
         if: steps.version.outputs.tag != ''
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v2
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
+          app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create or update pull request

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -60,19 +60,22 @@ jobs:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: ./scripts/release/prepare-release.sh --tag "$RELEASE_TAG" --yes
 
-      # Pull requests opened by GITHUB_TOKEN do not trigger the Test workflow,
-      # so the same checks run here before the PR is opened.
-      - name: Validate the prepared release (lint, tests, build)
+      # The PR is opened with a GitHub App token instead of GITHUB_TOKEN —
+      # events created by GITHUB_TOKEN do not trigger other workflows, so the
+      # PR's CI checks (Test, Commit Messages) would never run.
+      - name: Mint a GitHub App token
         if: steps.version.outputs.tag != ''
-        run: |
-          yarn check:ci
-          yarn test
-          yarn build
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create or update pull request
         if: steps.version.outputs.tag != ''
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.app-token.outputs.token }}
           branch: chore/release
           title: "chore: prepare release ${{ steps.version.outputs.tag }}"
           commit-message: "chore: prepare release ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
PRs created with `GITHUB_TOKEN` cannot trigger other workflows, so the release PR's checks (**Test on Pull Request**, **Commit Messages**) never ran and showed as red "action required" (verified in a sandbox repo: the same PR opened with an app/PAT token runs its checks normally).

This mints a GitHub App installation token (`actions/create-github-app-token`) and passes it to `create-pull-request`, so the release PR gets normal CI. The in-workflow lint/test/build step existed only to compensate for the missing checks, so it is removed.

**Do not merge until** the GitHub App is installed on this repo and `vars.APP_CLIENT_ID` + `secrets.APP_PRIVATE_KEY` exist — the token step fails without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)