### PR TITLE
fix: encode customerContext and anomaly id before building request URLs

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/tmp/doit-mcp-server/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/tmp/doit-mcp-server/node_modules

--- a/src/tools/__tests__/anomalies.test.ts
+++ b/src/tools/__tests__/anomalies.test.ts
@@ -253,6 +253,18 @@ Top SKUs:
             });
         });
 
+        it("encodes reserved characters in the anomaly id so it stays a single path segment", async () => {
+            (makeDoitRequest as vi.Mock).mockResolvedValue({ id: "x" });
+
+            await handleAnomalyRequest({ id: "../cloudincidents/v1?x=1#frag" }, mockToken);
+
+            expect(makeDoitRequest).toHaveBeenCalledWith(
+                "https://api.doit.com/anomalies/v1/..%2Fcloudincidents%2Fv1%3Fx%3D1%23frag",
+                mockToken,
+                { appendParams: true, method: "GET" }
+            );
+        });
+
         it("should handle API request failure", async () => {
             const mockArgs = { id: "anomaly-123" };
             (makeDoitRequest as vi.Mock).mockResolvedValue(null);

--- a/src/tools/anomalies.ts
+++ b/src/tools/anomalies.ts
@@ -208,7 +208,7 @@ export async function handleAnomalyRequest(args: any, token: string) {
     try {
         const { id } = AnomalyArgumentsSchema.parse(args);
         const { customerContext } = args;
-        const anomalyUrl = `${ANOMALIES_BASE_URL}/${id}`;
+        const anomalyUrl = `${ANOMALIES_BASE_URL}/${encodeURIComponent(id)}`;
 
         try {
             // Explicitly set appendParams to true to ensure URL parameters are added

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    appendUrlParameters,
     DebugLevel,
     debugLog,
     formatEnumValues,
@@ -199,6 +200,37 @@ describe("runWithTracking / AsyncLocalStorage propagation", () => {
         });
         // After the call completes, we are back outside any ALS scope
         expect(getTrackingContext()).toBeUndefined();
+    });
+});
+
+describe("appendUrlParameters", () => {
+    const originalCustomerContext = process.env.CUSTOMER_CONTEXT;
+
+    afterEach(() => {
+        if (originalCustomerContext === undefined) delete process.env.CUSTOMER_CONTEXT;
+        else process.env.CUSTOMER_CONTEXT = originalCustomerContext;
+    });
+
+    it("appends maxResults and an encoded customerContext", () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        expect(appendUrlParameters("https://api.doit.com/x", "cust-1")).toBe(
+            "https://api.doit.com/x?maxResults=40&customerContext=cust-1"
+        );
+    });
+
+    it("encodes reserved characters so customerContext cannot inject extra query parameters", () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        const url = appendUrlParameters("https://api.doit.com/x", "abc&maxResults=1000&other=1");
+        expect(url).toBe("https://api.doit.com/x?maxResults=40&customerContext=abc%26maxResults%3D1000%26other%3D1");
+        expect(new URL(url).searchParams.get("customerContext")).toBe("abc&maxResults=1000&other=1");
+        expect(new URL(url).searchParams.get("other")).toBeNull();
+    });
+
+    it("encodes the CUSTOMER_CONTEXT env fallback the same way", () => {
+        process.env.CUSTOMER_CONTEXT = "a/b?c=d";
+        expect(appendUrlParameters("https://api.doit.com/x?maxResults=5")).toBe(
+            "https://api.doit.com/x?maxResults=5&customerContext=a%2Fb%3Fc%3Dd"
+        );
     });
 });
 

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -219,7 +219,7 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
 
     if (customerContext) {
         // Use & as separator since we know the URL now has parameters
-        url += `&customerContext=${customerContext}`;
+        url += `&customerContext=${encodeURIComponent(customerContext)}`;
     }
 
     return url;


### PR DESCRIPTION
## What changed

- `appendUrlParameters` now runs `customerContext` through `encodeURIComponent` before appending it, so a value containing `&` or `=` cannot smuggle extra query parameters into the outbound request.
- `handleAnomalyRequest` encodes the caller-supplied `id` the same way every other hand-written handler already does, so `/`, `?`, `#` and `%` in an id stay inside a single path segment.

The remaining concatenated query params in `makeDoitRequest` (`mcp=true`, `sse=true`, tracking fields) are constants or already encoded and are left as-is.

## Why

Closes #81 and closes #82. Both were flagged in December 2025 and re-confirmed by an external researcher this week. `customerContext` and `id` are LLM-controlled tool arguments, so they must be treated as untrusted when building URLs.

## How validated

- New unit tests in `util.test.ts` cover the injection case (`abc&maxResults=1000&other=1`) and the `CUSTOMER_CONTEXT` env fallback, asserting the decoded value round-trips and no extra parameter appears.
- New unit test in `anomalies.test.ts` covers an id containing `../`, `?`, and `#`.
- `yarn check:dev` and `yarn test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)