### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not open a public GitHub issue for security findings.
+
+Report vulnerabilities in this repository, in the published `@doitintl/doit-mcp-server`
+package, or in the hosted `mcp.doit.com` endpoint to **vulnerability-report@doit.com**.
+Reports are handled under DoiT's
+[Vulnerability Reward Program](https://help.doit.com/docs/vendor-information/bug-bounty-program),
+which also defines scope, eligibility, and the disclosure rules that apply to every report.
+
+A useful report includes:
+
+- the affected file, tool name, or endpoint and the version or commit you tested against
+- a description of the impact and the conditions needed to reach it
+- steps or a minimal proof of concept that demonstrates the issue
+
+We acknowledge reports as quickly as we can, keep you updated while we work on a fix, and are
+happy to credit you by name in the changelog once the fix ships, if you would like that.
+
+## Scope notes for this project
+
+This MCP server is a thin client over the [DoiT API](https://developer.doit.com/reference).
+Every call is made with the operator's own API key (or OAuth session on the hosted endpoint),
+and authorization is enforced server-side by the DoiT API for that identity. Findings that
+require the operator's own credentials and stay within that identity's permissions are
+generally treated as hardening issues rather than vulnerabilities, but we still want to hear
+about them. Findings in the DoiT API or Console itself should be reported through the same
+address.
+
+## Supported versions
+
+Only the latest release published to npm receives security fixes. Please upgrade to the
+current version before reporting.


### PR DESCRIPTION
## What changed

Adds a root `SECURITY.md` so GitHub surfaces a "Report a vulnerability" path for this repo. It points researchers at `vulnerability-report@doit.com` and the public Vulnerability Reward Program page, lists what a useful report contains, and explains the scope model of this project (thin client over the DoiT API, authorization enforced server-side per identity).

## Why

An external researcher emailed maintainers directly this week because the repo had no security policy and they could not tell whether the VRP covered a source-repo finding. This removes that ambiguity for the next report.

## How validated

Markdown only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)