### PR TITLE
feat: require server-side approval for every generated DELETE tool

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -252,7 +252,7 @@ import {
 } from "../tools/cloudflow.js";
 import { cloudIncidentsTool, cloudIncidentTool } from "../tools/cloudIncidents.js";
 import { getCommitmentTool, listCommitmentsTool } from "../tools/commitmentManager.js";
-// import { confirmActionTool } from "../tools/confirmAction.js"; // disabled with the approval gate
+import { confirmActionTool } from "../tools/confirmAction.js";
 import {
     createDatahubDatasetTool,
     getDatahubDatasetTool,
@@ -473,7 +473,7 @@ describe("ListToolsRequestSchema handler", () => {
                 getResourcePermissionsTool,
                 updateResourcePermissionsTool,
                 askAvaSyncTool,
-                // confirmActionTool, // disabled with the approval gate
+                confirmActionTool,
                 ...generatedToolDefinitions,
             ],
         });
@@ -909,14 +909,10 @@ describe("CallToolRequestSchema handler", () => {
         ["ask_ava_sync", "ask_ava_sync", { question: "What is my spend?" }, handleAskAvaSyncRequest],
     ];
 
-    // Tools gated by the server-side approval flow (confirm_action two-phase commit).
-    // POC scope keeps the gated set minimal; see WRITE_GATED_SUMMARIES in toolsHandler.ts.
-    // Approval gating for create_ticket is currently disabled — we rely on the tool's
-    // `destructiveHint: true` annotation instead. Re-add "create_ticket" here when the
-    // WRITE_GATED_SUMMARIES entry is uncommented.
-    const WRITE_GATED_TOOL_NAMES = new Set<string>([
-        /* "create_ticket" */
-    ]);
+    // Hand-written tools gated by the server-side approval flow (confirm_action two-phase
+    // commit) — see WRITE_GATED_SUMMARIES in toolsHandler.ts. Generated DELETE tools are
+    // gated too; that path is covered in toolsHandler.test.ts rather than routed here.
+    const WRITE_GATED_TOOL_NAMES = new Set<string>([]);
 
     it.each(toolRoutingCases)("routes %s to the correct handler", async (_label, toolName, args, handler) => {
         const first = await getCallToolHandler()(mockRequest(toolName, args));

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,9 +61,6 @@ import {
 } from "./tools/cloudflow.js";
 import { handleCloudIncidentRequest, handleCloudIncidentsRequest } from "./tools/cloudIncidents.js";
 import { handleGetCommitmentRequest, handleListCommitmentsRequest } from "./tools/commitmentManager.js";
-// Re-enable alongside the WRITE_GATED_SUMMARIES entry in utils/toolsHandler.ts
-// and the registration in src/tools/handWrittenTools.ts.
-// import { confirmActionTool } from "./tools/confirmAction.js";
 import {
     handleCreateDatahubDatasetRequest,
     handleGetDatahubDatasetRequest,
@@ -162,14 +159,7 @@ export function createServer() {
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
         return {
-            tools: [
-                ...HAND_WRITTEN_TOOLS,
-                // confirm_action is no longer exposed while the approval gate is
-                // disabled — without any write-gated tool minting tokens there is
-                // nothing for clients to confirm. Re-add when the gate returns.
-                // confirmActionTool,
-                ...generatedToolDefinitions,
-            ],
+            tools: [...HAND_WRITTEN_TOOLS, ...generatedToolDefinitions],
         };
     });
 

--- a/src/tools/confirmAction.ts
+++ b/src/tools/confirmAction.ts
@@ -26,6 +26,7 @@ export const ConfirmActionArgumentsSchema = z.object({
  */
 export const confirmActionTool = {
     name: "confirm_action",
+    coversEndpoint: null,
     description:
         "Finalizes a pending write action (e.g. creating, updating, or deleting a resource) " +
         "that was previously staged by another tool. Only call this after the user has " +

--- a/src/tools/generated/__tests__/generateTools.test.ts
+++ b/src/tools/generated/__tests__/generateTools.test.ts
@@ -144,6 +144,47 @@ describe("generateTools", () => {
         expect(tool.zodSchema.shape.name).toBeDefined();
     });
 
+    it("attaches an approval summary to DELETE operations only", () => {
+        const document = buildDocument({
+            paths: {
+                "/widgets/{id}": {
+                    delete: {
+                        operationId: "deleteWidget",
+                        summary: "Delete a widget",
+                        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+                    },
+                    put: {
+                        operationId: "updateWidget",
+                        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+                    },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        const tools = generateTools(document, new Set());
+        const deleteTool = tools.find((tool) => tool.name === "delete_widget");
+        const updateTool = tools.find((tool) => tool.name === "update_widget");
+
+        expect(updateTool?.summary).toBeUndefined();
+        expect(deleteTool?.summary).toBeDefined();
+        expect(deleteTool?.summary?.({ id: "w-1", customerContext: "cust-9" })).toBe(
+            'Delete a widget (id="w-1") for customer cust-9. This cannot be undone: DELETE /widgets/{id}.'
+        );
+        expect(deleteTool?.summary?.({ id: "w-1" })).toBe(
+            'Delete a widget (id="w-1"). This cannot be undone: DELETE /widgets/{id}.'
+        );
+    });
+
+    it("every DELETE operation in the bundled spec is write-gated", () => {
+        const tools = generateTools(loadGeneratedToolsSpec(), COVERED_ENDPOINTS);
+        const deletes = tools.filter((tool) => tool.metadata.method === "delete");
+        expect(deletes.length).toBeGreaterThan(0);
+        for (const tool of deletes) expect(tool.summary, tool.name).toBeDefined();
+        for (const tool of tools.filter((tool) => tool.metadata.method !== "delete")) {
+            expect(tool.summary, tool.name).toBeUndefined();
+        }
+    });
+
     it("detects multipart binary fields", () => {
         const document = buildDocument({
             paths: {

--- a/src/tools/generated/generateTools.ts
+++ b/src/tools/generated/generateTools.ts
@@ -46,6 +46,20 @@ function findJsonContent(
 }
 
 /**
+ * DELETE operations are irreversible, so they go through the server-side two-phase approval
+ * flow (`approval_required` → `confirm_action`) rather than relying on the client honouring
+ * `destructiveHint`, which is advisory only. The summary is the text the user confirms.
+ */
+function buildDeleteSummary(operationSummary: string | undefined, pathTemplate: string, pathParams: string[]) {
+    return (args: Record<string, unknown>) => {
+        const target = pathParams.map((name) => `${name}=${JSON.stringify(String(args?.[name] ?? ""))}`).join(", ");
+        const scope = args?.customerContext ? ` for customer ${String(args.customerContext)}` : "";
+        const label = operationSummary ?? `Delete ${pathTemplate}`;
+        return `${label}${target ? ` (${target})` : ""}${scope}. This cannot be undone: DELETE ${pathTemplate}.`;
+    };
+}
+
+/**
  * Builds one MCP tool per OpenAPI operation not already covered by a hand-written tool.
  * `coveredEndpoints` is derived from every hand-written tool's own `coversEndpoint` field
  * (see src/tools/handWrittenTools.ts) — callers pass COVERED_ENDPOINTS from that module.
@@ -159,6 +173,9 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
                         scopes: isReadOnly ? ["read_data"] : ["read_data", "write_data"],
                     },
                 ],
+                ...(method === "delete"
+                    ? { summary: buildDeleteSummary(operation.summary, pathTemplate, metadata.pathParams) }
+                    : {}),
             });
         }
     }

--- a/src/tools/generated/types.ts
+++ b/src/tools/generated/types.ts
@@ -24,4 +24,10 @@ export type GeneratedTool = {
         openWorldHint: boolean;
     };
     securitySchemes: [{ type: "oauth2"; scopes: string[] }];
+    /**
+     * Set only on write-gated operations (every DELETE). Produces the human-readable
+     * summary the user is asked to confirm before `confirm_action` runs the call — the
+     * generated counterpart of WRITE_GATED_SUMMARIES in src/utils/toolsHandler.ts.
+     */
+    summary?: (args: Record<string, unknown>) => string;
 };

--- a/src/tools/handWrittenTools.ts
+++ b/src/tools/handWrittenTools.ts
@@ -30,6 +30,7 @@ import {
 } from "./cloudflow.js";
 import { cloudIncidentsTool, cloudIncidentTool } from "./cloudIncidents.js";
 import { getCommitmentTool, listCommitmentsTool } from "./commitmentManager.js";
+import { confirmActionTool } from "./confirmAction.js";
 import {
     createDatahubDatasetTool,
     getDatahubDatasetTool,
@@ -193,6 +194,7 @@ export const HAND_WRITTEN_TOOLS: HandWrittenTool[] = [
     getResourcePermissionsTool,
     updateResourcePermissionsTool,
     askAvaSyncTool,
+    confirmActionTool,
 ];
 
 export const COVERED_ENDPOINTS: Set<string> = new Set(

--- a/src/utils/__tests__/toolsHandler.test.ts
+++ b/src/utils/__tests__/toolsHandler.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { GeneratedTool } from "../../tools/generated/types.js";
 import { MemoryApprovalStore } from "../approval.js";
 import { executeToolHandler } from "../toolsHandler.js";
+import { makeDoitRequest } from "../util.js";
 
 // Mock the underlying HTTP layer so "running" a write-gated tool never actually
 // hits the DoiT API. We only want to assert that the approval gate keeps us from
@@ -12,6 +15,7 @@ vi.mock("../util.js", async (importOriginal) => {
 
 beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(makeDoitRequest).mockClear();
 });
 
 afterEach(() => {
@@ -34,62 +38,109 @@ describe("executeToolHandler approval gate", () => {
         },
     } as const;
 
-    // Skipped: approval-token gating for create_ticket is currently disabled
-    // (see WRITE_GATED_SUMMARIES in toolsHandler.ts). Re-enable by removing
-    // `.skip` once the registry entry is uncommented.
-    it.skip("write-gated tools return approval_required without calling the API on the first call", async () => {
-        const { makeDoitRequest } = await import("../util.js");
-        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
+    const deleteWidgetTool: GeneratedTool = {
+        name: "delete_widget",
+        description: "Deletes a widget.",
+        zodSchema: z.object({ id: z.string(), customerContext: z.string().optional() }),
+        metadata: {
+            method: "delete",
+            pathTemplate: "/widgets/{id}",
+            pathParams: ["id"],
+            queryParams: ["customerContext"],
+            headerParams: [],
+            bodyEncoding: "json",
+            multipartFileFields: [],
+        },
+        annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+        securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+        summary: (args) => `Delete a widget (id=${JSON.stringify(String(args.id))}).`,
+    };
+    const createWidgetTool: GeneratedTool = {
+        ...deleteWidgetTool,
+        name: "create_widget",
+        metadata: { ...deleteWidgetTool.metadata, method: "post", pathTemplate: "/widgets", pathParams: [] },
+        summary: undefined,
+    };
+    const generatedTools = new Map<string, GeneratedTool>([
+        [deleteWidgetTool.name, deleteWidgetTool],
+        [createWidgetTool.name, createWidgetTool],
+    ]);
 
+    it("generated DELETE tools return approval_required without calling the API on the first call", async () => {
         const approvalStore = new MemoryApprovalStore();
-        const response = await executeToolHandler("create_ticket", validTicketArgs, apiToken, {
+        const response = await executeToolHandler("delete_widget", { id: "w-1" }, apiToken, {
             userKey,
             approvalStore,
+            generatedTools,
         });
 
-        expect(makeDoitRequest).not.toHaveBeenCalled();
-        expect(response.isError).toBeFalsy();
         const parsed = JSON.parse(response.content[0].text);
         expect(parsed.status).toBe("approval_required");
         expect(parsed.approvalToken).toMatch(/^[0-9a-f-]{36}$/);
-        expect(parsed.summary).toContain("Create support ticket");
+        expect(parsed.summary).toBe('Delete a widget (id="w-1").');
+        expect(makeDoitRequest).not.toHaveBeenCalled();
+        expect(approvalStore.size()).toBe(1);
     });
 
-    // Skipped: approval-token gating for create_ticket is currently disabled.
-    it.skip("confirm_action with a valid token runs the write-gated tool", async () => {
-        const { makeDoitRequest } = await import("../util.js");
-        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockClear();
-        (makeDoitRequest as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "ticket-new-1" });
-
+    it("confirm_action with a valid token runs the staged DELETE exactly once", async () => {
         const approvalStore = new MemoryApprovalStore();
-        const first = await executeToolHandler("create_ticket", validTicketArgs, apiToken, {
+        const first = await executeToolHandler("delete_widget", { id: "w-1" }, apiToken, {
             userKey,
             approvalStore,
+            generatedTools,
         });
         const { approvalToken } = JSON.parse(first.content[0].text);
 
         await executeToolHandler("confirm_action", { token: approvalToken }, apiToken, {
             userKey,
             approvalStore,
+            generatedTools,
         });
 
         expect(makeDoitRequest).toHaveBeenCalledTimes(1);
-        const [url, tokenArg, opts] = (makeDoitRequest as any).mock.calls[0];
-        expect(url).toContain("/tickets");
-        expect(tokenArg).toBe(apiToken);
-        expect(opts.method).toBe("POST");
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("/widgets/w-1"),
+            apiToken,
+            expect.objectContaining({ method: "DELETE" })
+        );
+        expect(approvalStore.size()).toBe(0);
     });
 
-    // Skipped: approval-token gating for create_ticket is currently disabled.
-    it.skip("two un-confirmed write-gated calls mint two distinct tokens", async () => {
+    it("two un-confirmed DELETE calls mint two distinct tokens", async () => {
         const approvalStore = new MemoryApprovalStore();
-
-        const r1 = await executeToolHandler("create_ticket", validTicketArgs, apiToken, { userKey, approvalStore });
-        const r2 = await executeToolHandler("create_ticket", validTicketArgs, apiToken, { userKey, approvalStore });
+        const r1 = await executeToolHandler("delete_widget", { id: "w-1" }, apiToken, {
+            userKey,
+            approvalStore,
+            generatedTools,
+        });
+        const r2 = await executeToolHandler("delete_widget", { id: "w-1" }, apiToken, {
+            userKey,
+            approvalStore,
+            generatedTools,
+        });
 
         const t1 = JSON.parse(r1.content[0].text).approvalToken;
         const t2 = JSON.parse(r2.content[0].text).approvalToken;
         expect(t1).not.toBe(t2);
+        expect(approvalStore.size()).toBe(2);
+    });
+
+    it("generated non-DELETE tools run directly without an approval envelope", async () => {
+        const approvalStore = new MemoryApprovalStore();
+        const response = await executeToolHandler("create_widget", { id: "w-1" }, apiToken, {
+            userKey,
+            approvalStore,
+            generatedTools,
+        });
+
+        expect(String(response.content[0].text)).not.toContain("approval_required");
+        expect(makeDoitRequest).toHaveBeenCalledTimes(1);
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.stringContaining("/widgets"),
+            apiToken,
+            expect.objectContaining({ method: "POST" })
+        );
+        expect(approvalStore.size()).toBe(0);
     });
 
     it("without userKey/approvalStore the gate is bypassed (opt-in enforcement)", async () => {
@@ -102,7 +153,7 @@ describe("executeToolHandler approval gate", () => {
         expect(makeDoitRequest).toHaveBeenCalledTimes(1);
     });
 
-    it("confirm_action called by a stale client returns a clean error (no throw)", async () => {
+    it("confirm_action with an unknown token returns a clean error (no throw)", async () => {
         // `confirm_action` is no longer advertised in the tool list (see src/server.ts
         // and the remote Worker in the separate private repo), but a misbehaving client with cached
         // metadata could still send the call. Verify it returns the canonical
@@ -123,7 +174,7 @@ describe("executeToolHandler approval gate", () => {
         expect(response.content[0].text).toContain("Approval token unknown or expired");
     });
 
-    it("create_ticket runs directly when its WRITE_GATED_SUMMARIES entry is disabled (current default)", async () => {
+    it("create_ticket runs directly — hand-written writes are not gated by default", async () => {
         // Locks in the disabled-approval behavior: even with both userKey and approvalStore
         // supplied (i.e. the gate would fire if `create_ticket` were registered), we expect
         // the handler to call the DoiT API directly and return the API response — not an

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -132,23 +132,24 @@ import {
 } from "./util.js";
 
 /**
- * Registry of write-gated tools that go through the two-phase approval flow.
+ * Registry of hand-written tools that go through the two-phase approval flow
+ * (`approval_required` envelope → user confirms → `confirm_action`).
  *
- * "Write-gated" — not "destructive" — because the gate covers any state-changing call
+ * "Write-gated" — not "destructive" — because the gate can cover any state-changing call
  * that warrants explicit user confirmation, including pure creates like `create_ticket`.
  * (The MCP-spec `destructiveHint` annotation has a narrower meaning — irreversible
- * updates — and is set per-tool independently of this registry.)
+ * updates — is advisory only, and is set per-tool independently of this registry.)
  *
- * POC scope: only `create_ticket` is gated so the demo surface stays small. The mechanism
- * itself (`confirm_action`, {@link ApprovalStore}, single-use tokens) is generic —
- * extending approval to another tool is just (a) adding a `summary(args)` on that tool's
- * definition and (b) adding an entry below. Removing approval enforcement is the inverse.
- * No tool handler code needs to change.
+ * Generated tools are not listed here: every generated DELETE operation carries its own
+ * `summary` (see src/tools/generated/generateTools.ts) and is gated automatically. To gate
+ * a hand-written tool, add a `summary(args)` to its definition and an entry below. No tool
+ * handler code needs to change.
+ *
+ * Hand-written creates/updates are currently left ungated: they are reversible, and MCP
+ * clients already prompt on `destructiveHint`. `create_ticket` was gated during the POC
+ * and deliberately un-gated to avoid a double confirmation on every ticket.
  */
 const WRITE_GATED_SUMMARIES: Record<string, (args: any) => string> = {
-    // Approval-token gating for create_ticket is disabled — we rely on the
-    // tool's `destructiveHint: true` annotation to surface a client-side
-    // confirmation dialog instead. Re-enable by uncommenting the line below.
     // [createTicketTool.name]: createTicketTool.summary,
 };
 
@@ -230,7 +231,7 @@ export async function executeToolHandler(
                     return confirmed;
                 }
 
-                const summaryFn = WRITE_GATED_SUMMARIES[toolName];
+                const summaryFn = WRITE_GATED_SUMMARIES[toolName] ?? generatedTools?.get(toolName)?.summary;
                 if (summaryFn) {
                     const approvalToken = mintApprovalToken();
                     await approvalStore.stash(approvalToken, {

--- a/test/integration/stdio/approvalFlow.test.ts
+++ b/test/integration/stdio/approvalFlow.test.ts
@@ -1,31 +1,26 @@
+import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestClient, getTextContent } from "../helpers.js";
+import { mswServer } from "../setup.js";
 
 // This suite intentionally uses `rawClient` to bypass the test helper's
 // auto-confirm wrapper, so we can observe the two-phase approval envelope
-// emitted by the server directly.
-//
-// Skipped: server-enforced approval gating for `create_ticket` is currently
-// disabled (see WRITE_GATED_SUMMARIES in src/utils/toolsHandler.ts). All five
-// tests below assert behavior of that gate. Remove `.skip` once the registry
-// entry is uncommented.
-describe.skip("Write-gated tool approval flow (stdio)", () => {
+// emitted by the server directly. `delete_alert` is a generated DELETE tool;
+// every generated DELETE operation is write-gated (see generateTools.ts).
+describe("Write-gated tool approval flow (stdio)", () => {
     let rawClient: { callTool: (p: { name: string; arguments: Record<string, unknown> }) => Promise<any> };
     let cleanup: () => Promise<void>;
-
-    const ticketArgs = {
-        ticket: {
-            body: "Need help with billing.",
-            created: "2026-04-22T00:00:00Z",
-            platform: "amazon_web_services",
-            product: "billing",
-            severity: "high",
-            subject: "Gated Ticket",
-        },
-    };
+    let deleteCalls: string[];
 
     beforeEach(async () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
+        deleteCalls = [];
+        mswServer.use(
+            http.delete("https://api.doit.com/analytics/v1/alerts/:id", ({ params }) => {
+                deleteCalls.push(String(params.id));
+                return new HttpResponse(null, { status: 204 });
+            })
+        );
         ({ rawClient, cleanup } = await createTestClient());
     });
 
@@ -34,31 +29,34 @@ describe.skip("Write-gated tool approval flow (stdio)", () => {
         vi.restoreAllMocks();
     });
 
-    it("emits an approval_required envelope on the first call to a write-gated tool", async () => {
-        const result = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
+    it("emits an approval_required envelope on the first call and does not hit the API", async () => {
+        const result = await rawClient.callTool({ name: "delete_alert", arguments: { id: "alert-1" } });
         const body = JSON.parse(getTextContent(result));
 
         expect(body.status).toBe("approval_required");
         expect(body.approvalToken).toMatch(/^[0-9a-f-]{36}$/i);
-        expect(body.summary).toContain("Create support ticket");
+        expect(body.summary).toBe(
+            'Delete an alert (id="alert-1"). This cannot be undone: DELETE /analytics/v1/alerts/{id}.'
+        );
         expect(body.next).toContain("confirm_action");
+        expect(deleteCalls).toEqual([]);
     });
 
-    it("confirm_action with the minted token executes the original write-gated call", async () => {
-        const first = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
+    it("confirm_action with the minted token executes the staged DELETE", async () => {
+        const first = await rawClient.callTool({ name: "delete_alert", arguments: { id: "alert-1" } });
         const { approvalToken } = JSON.parse(getTextContent(first));
 
         const second = await rawClient.callTool({
             name: "confirm_action",
             arguments: { token: approvalToken },
         });
-        const parsed = JSON.parse(getTextContent(second));
-        expect(parsed.id).toBe(99999);
-        expect(parsed.status).toBe("created");
+
+        expect(second.isError).not.toBe(true);
+        expect(deleteCalls).toEqual(["alert-1"]);
     });
 
     it("approval tokens are single-use — replaying a consumed token errors out", async () => {
-        const first = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
+        const first = await rawClient.callTool({ name: "delete_alert", arguments: { id: "alert-1" } });
         const { approvalToken } = JSON.parse(getTextContent(first));
 
         await rawClient.callTool({ name: "confirm_action", arguments: { token: approvalToken } });
@@ -68,6 +66,7 @@ describe.skip("Write-gated tool approval flow (stdio)", () => {
         });
 
         expect(getTextContent(replay)).toContain("Approval token unknown or expired");
+        expect(deleteCalls).toEqual(["alert-1"]);
     });
 
     it("confirm_action with an unknown token returns the canonical error", async () => {
@@ -79,11 +78,23 @@ describe.skip("Write-gated tool approval flow (stdio)", () => {
     });
 
     it("calling a write-gated tool twice mints two distinct tokens (idempotent on LLM misbehavior)", async () => {
-        const r1 = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
-        const r2 = await rawClient.callTool({ name: "create_ticket", arguments: ticketArgs });
+        const r1 = await rawClient.callTool({ name: "delete_alert", arguments: { id: "alert-1" } });
+        const r2 = await rawClient.callTool({ name: "delete_alert", arguments: { id: "alert-1" } });
 
         const t1 = JSON.parse(getTextContent(r1)).approvalToken;
         const t2 = JSON.parse(getTextContent(r2)).approvalToken;
         expect(t1).not.toBe(t2);
+        expect(deleteCalls).toEqual([]);
+    });
+
+    it("the auto-confirm test helper transparently completes a gated DELETE", async () => {
+        const { client, cleanup: cleanupWrapped } = await createTestClient();
+        try {
+            const result = await client.callTool({ name: "delete_alert", arguments: { id: "alert-2" } });
+            expect(result.isError).not.toBe(true);
+            expect(deleteCalls).toEqual(["alert-2"]);
+        } finally {
+            await cleanupWrapped();
+        }
     });
 });


### PR DESCRIPTION
## What changed

- Every auto-generated DELETE tool (17 in the bundled spec, including `delete_user` and `delete_account_role`) now goes through the existing two-phase approval flow: the first call returns an `approval_required` envelope with a human-readable summary and a single-use token, and the call only executes after `confirm_action` is invoked with that token.
- `GeneratedTool` gains an optional `summary(args)`; `generateTools` sets it for DELETE operations only, built from the operation's OpenAPI summary, the resolved path params, and the customer scope (for example `Delete user (id="abc") for customer xyz. This cannot be undone: DELETE /iam/v1/users/{id}.`).
- `executeToolHandler` resolves the gate from `WRITE_GATED_SUMMARIES` or the generated tool's `summary`, so no dispatch code changed.
- `confirm_action` is exposed again. It joins `HAND_WRITTEN_TOOLS` (with `coversEndpoint: null`) so `server.ts` and the integration tool-surface test pick it up without a special case.
- Hand-written creates and updates stay ungated. They are reversible and clients already prompt on `destructiveHint`, which is the reason the `create_ticket` gate was removed in #170. That decision is preserved and documented in the registry comment.

## Why

An external researcher pointed out that the approval mechanism was wired to zero tools while every non-GET generated tool relied on `destructiveHint`, which is an advisory client-side annotation. A prompt-injected agent that ignores the hint could delete a platform user or disconnect an AWS account in one call. This is defense in depth (the API still enforces the caller's own permissions), but deletes are the irreversible subset and are the right place to draw the line. Credit: Syed Anas Mohiuddin.

## Transport notes

The stdio server enforces the gate as before (`MemoryApprovalStore`, `userKey = "stdio-local"`). The remote Worker in the separate private repo already binds `userKey` to the OAuth identity and passes `generatedTools`, so it picks the gate up when it bumps to this version. It must also re-list `confirm_action` in its tool surface, otherwise clients there receive an envelope they cannot confirm. That change is needed before this ships to the hosted endpoint.

## How validated

- `toolsHandler.test.ts`: the three previously skipped gate tests are replaced with live ones against a synthetic generated DELETE tool (envelope without API call, confirm runs exactly once, distinct tokens, non-DELETE generated tools run directly).
- `generateTools.test.ts`: summary shape, and an assertion over the bundled spec that every DELETE has a summary and nothing else does.
- `test/integration/stdio/approvalFlow.test.ts`: un-skipped and rewritten around `delete_alert` with an msw DELETE handler that records hits, proving no request leaves before confirmation and exactly one after.
- `yarn check:dev`, `yarn test` (911 passed), and `yarn test` in `test/integration` (184 passed) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)