### PR TITLE
fix: hand-write build_cloud_flow so it consumes the SSE build stream

### DIFF
--- a/docs/cloudflow-authoring.md
+++ b/docs/cloudflow-authoring.md
@@ -1,0 +1,75 @@
+# CloudFlow authoring over MCP
+
+The CloudFlow tools let an assistant build, inspect, repair, and test-run automation flows.
+The API enforces a few runtime contracts that aren't visible in the tool schemas — get them
+wrong and a flow imports cleanly yet does nothing at run time. This note captures the ones
+that bite. (The `dci` CLI ships a fuller version of this guidance; MCP clients get none of it
+otherwise.)
+
+## The authoring loop
+
+Nothing runs or publishes until a human publishes in the builder, so a draft never has to be
+perfect to be useful. The reliable loop is:
+
+1. **Build or clone.** `build_cloud_flow` creates a new draft from a natural-language
+   `question`; `refine_cloudflow` modifies an existing flow (same `conversationId` to continue
+   a session). Both stream progress and return the created/updated `flowId`, the builder's
+   `answer`, and the `steps` that ran. Prefer cloning the closest existing flow
+   (`list_cloudflows` → `export_cloudflow_flow`) over generating from scratch — a real export
+   is the only ground truth for node parameter shapes and in-node reference syntax.
+2. **Export and inspect.** Always `export_cloudflow_flow` the result and read it before
+   trusting it. A `refine_cloudflow` round can answer with a plan yet save nothing — re-export
+   and diff rather than believing the change happened.
+3. **Dry-run import.** `import_cloudflow_flow` with `dryRun` writes nothing and returns every
+   validation error at once, plus each requirement's resolution and candidate IDs. Fix and
+   repeat until the plan is clean.
+4. **Deep-validate, then test-run.** `test_run_cloudflow_flow` with `dryRun` runs the
+   server-side validator (accepts drafts, returns `valid: true` or a 422 listing every invalid
+   node). The same call without `dryRun` starts one test run.
+5. **Read the run.** `list_cloudflow_flow_runs` lists a flow's runs; `get_cloudflow_flow_run`
+   returns per-node `input`/`output` once each node reaches a terminal status. Only claim "the
+   flow works" after a test run completed and the per-node outputs matched intent. Before that,
+   say it validated and imported.
+
+## Idempotency-key retry semantics
+
+Mutating CloudFlow requests (real import, `test_run_cloudflow_flow`) require an
+`Idempotency-Key` — they are rejected (`idempotency_key_required`) without one. The key is a
+safety line, not a formality:
+
+- Retrying with the **same** key can never start a second run. On a 5xx, the run may have
+  started even though the response failed — check `list_cloudflow_flow_runs` (mode `test`)
+  before minting a new key.
+- A genuine infrastructure failure inside a run (e.g. a transient BigQuery error) is retryable
+  with a **new** key. A flow bug is not — fix the flow first.
+
+## The `codeNode` runtime contract
+
+`codeNode` is where generated flows most often break. The builder's generated code varies run
+to run and has shipped broken conventions, so **expect to repair code nodes** via
+export → edit → import.
+
+- **Upstream data comes only from `nodes`.** `nodes` is a dict keyed by node **name**, whose
+  values are **lists** at run time, e.g. `nodes["getDailyUsage"][0]["results"][0]["data"]`.
+  There is no injected `input` variable — a bare `input` in code is Python's builtin, not
+  upstream data. Node values are never objects with an `.output` attribute.
+- **Return, don't assign.** The platform executes the code *body* directly: write top-level
+  statements ending in a top-level `return {...}`. Defining a function nothing calls (e.g.
+  `def handler(input)`), or assigning to a variable named `output` instead of returning, both
+  leave the node completing with `{message: null}` — no error, no result.
+- **`schema` is required.** `codeNode` needs a `schema` (a JSON Schema *string* describing the
+  node's output); test-run validation rejects a codeNode without one.
+
+## Things a bundle cannot carry
+
+Credentials, tenant IDs, schedule *activation*, execution state, and Slack-channel/policy
+references never travel in an exported bundle (the last two export as `unsupportedReferences`
+and leave nodes flagged incomplete). A schedule trigger's *configuration* (frequency, run
+times, time zone) does travel — it just stays inert until the imported draft is published.
+
+## Tenant scoping caveat
+
+CloudFlow endpoints currently reject customer-context impersonation (`tenant_id_mismatch` —
+the tenant must match the bearer token). A DoiT-employee token still passes `customerContext`
+to scope the request, but flows land in the token's own tenant; direct-customer tokens need no
+`customerContext`.

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -240,6 +240,7 @@ import {
     searchCloudDiagramsTool,
 } from "../tools/cloudDiagrams.js";
 import {
+    buildCloudflowTool,
     createCloudFlowConnectionTool,
     getCloudFlowConnectionTool,
     getCloudFlowTemplateTool,
@@ -422,6 +423,7 @@ describe("ListToolsRequestSchema handler", () => {
                 listCloudFlowTemplatesTool,
                 getCloudFlowTemplateTool,
                 refineCloudflowTool,
+                buildCloudflowTool,
                 listOrganizationsTool,
                 listPlatformsTool,
                 listUsersTool,

--- a/src/core.ts
+++ b/src/core.ts
@@ -85,6 +85,8 @@ export {
     searchCloudDiagramsTool,
 } from "./tools/cloudDiagrams.js";
 export {
+    BuildCloudflowArgumentsSchema,
+    buildCloudflowTool,
     CreateCloudFlowConnectionArgumentsSchema,
     createCloudFlowConnectionTool,
     GetCloudFlowConnectionArgumentsSchema,

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,7 @@ import {
     handleSearchCloudDiagramsRequest,
 } from "./tools/cloudDiagrams.js";
 import {
+    handleBuildCloudflowRequest,
     handleCreateCloudFlowConnectionRequest,
     handleGetCloudFlowConnectionRequest,
     handleGetCloudFlowTemplateRequest,
@@ -265,6 +266,7 @@ export {
     handleAnomalyRequest,
     handleAskAvaSyncRequest,
     handleAssignObjectsToLabelRequest,
+    handleBuildCloudflowRequest,
     handleCloudIncidentRequest,
     handleCloudIncidentsRequest,
     handleCreateAlertRequest,

--- a/src/tools/__tests__/cloudflow.test.ts
+++ b/src/tools/__tests__/cloudflow.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { makeDoitRequest } from "../../utils/util.js";
+import { makeDoitRequest, makeDoitSSERequest } from "../../utils/util.js";
 import {
+    buildCloudflowTool,
     CLOUDFLOW_CONNECTIONS_BASE_URL,
     CLOUDFLOW_TEMPLATES_BASE_URL,
     CLOUDFLOW_TRIGGER_BASE_URL,
     extractCloudFlowId,
     getTriggerCloudFlowURL,
+    handleBuildCloudflowRequest,
     handleCreateCloudFlowConnectionRequest,
     handleGetCloudFlowConnectionRequest,
     handleGetCloudFlowTemplateRequest,
@@ -17,7 +19,7 @@ import {
 
 vi.mock("../../utils/util.js", async (importOriginal) => {
     const actual = await importOriginal();
-    return { ...actual, makeDoitRequest: vi.fn() };
+    return { ...actual, makeDoitRequest: vi.fn(), makeDoitSSERequest: vi.fn() };
 });
 
 beforeEach(() => {
@@ -780,6 +782,94 @@ describe("cloudflow", () => {
                 content: [{ type: "text", text: expect.stringContaining("Failed to retrieve CloudFlow template") }],
                 isError: true,
             });
+        });
+    });
+
+    describe("handleBuildCloudflowRequest", () => {
+        const mockToken = "fake-token";
+
+        // Yields the given event objects as the SSE helper would: each `data` string is the
+        // JSON payload of one `data:` line (see makeDoitSSERequest / the builder stream shape).
+        function sseStreamOf(events: Array<Record<string, unknown>>) {
+            return (async function* () {
+                for (const event of events) {
+                    yield { data: JSON.stringify(event) };
+                }
+            })();
+        }
+
+        it("declares build_cloud_flow and covers the build endpoint so the generator skips it", () => {
+            expect(buildCloudflowTool.name).toBe("build_cloud_flow");
+            expect(buildCloudflowTool.coversEndpoint).toBe("post:/cloudflow/v1/flows/actions/build");
+        });
+
+        it("parses the stream into flowId, conversationId, answer, and steps and forwards progress", async () => {
+            (makeDoitSSERequest as unknown as vi.Mock).mockReturnValue(
+                sseStreamOf([
+                    { answerId: "a1", conversationId: "conv-1" },
+                    { answer: JSON.stringify({ toolStart: "Building nodes" }) },
+                    {
+                        answer: JSON.stringify({
+                            customEvent: { messageId: "cloudflow_created", data: { flowId: "flow-123" } },
+                        }),
+                    },
+                    { answer: "All set." },
+                ])
+            );
+            const onProgress = vi.fn().mockResolvedValue(undefined);
+
+            const response = await handleBuildCloudflowRequest({ question: "make a flow" }, mockToken, onProgress);
+
+            expect(response.isError).toBeUndefined();
+            const result = JSON.parse(response.content[0].text);
+            expect(result).toEqual({
+                flowId: "flow-123",
+                conversationId: "conv-1",
+                answer: "All set.",
+                steps: ["Building nodes"],
+            });
+            expect(onProgress).toHaveBeenCalledWith("Building nodes");
+        });
+
+        it("surfaces the real error instead of an opaque 'Failed to call POST ...' when the stream fails", async () => {
+            // Faithful to makeDoitSSERequest, which throws on a non-2xx (e.g. the 406 the build
+            // endpoint returns for an application/json Accept) as the stream is first read.
+            (makeDoitSSERequest as unknown as vi.Mock).mockReturnValue({
+                [Symbol.asyncIterator]() {
+                    return { next: () => Promise.reject(new Error("HTTP 406: Not Acceptable")) };
+                },
+            });
+
+            const response = await handleBuildCloudflowRequest({ question: "make a flow" }, mockToken);
+
+            expect(response.isError).toBe(true);
+            expect(response.content[0].text).toContain("HTTP 406: Not Acceptable");
+            expect(response.content[0].text).not.toContain("Failed to call POST");
+        });
+
+        it("reports the recoverable flow ID the stream emitted before it failed", async () => {
+            (makeDoitSSERequest as unknown as vi.Mock).mockImplementation(async function* () {
+                yield {
+                    data: JSON.stringify({
+                        answer: JSON.stringify({
+                            customEvent: { messageId: "cloudflow_created", data: { flowId: "flow-partial" } },
+                        }),
+                    }),
+                };
+                throw new Error("HTTP 500: boom");
+            });
+
+            const response = await handleBuildCloudflowRequest({ question: "make a flow" }, mockToken);
+
+            expect(response.isError).toBe(true);
+            expect(response.content[0].text).toContain("flow-partial");
+            expect(response.content[0].text).toContain("HTTP 500");
+        });
+
+        it("rejects a missing question via schema validation", async () => {
+            const response = await handleBuildCloudflowRequest({}, mockToken);
+            expect(response.isError).toBe(true);
+            expect(makeDoitSSERequest as unknown as vi.Mock).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/tools/cloudflow.ts
+++ b/src/tools/cloudflow.ts
@@ -150,6 +150,185 @@ export const refineCloudflowTool = {
     securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
 };
 
+export const BuildCloudflowArgumentsSchema = z.object({
+    question: z.string().describe("Natural language description of the CloudFlow to build from scratch."),
+    conversationId: z.string().optional().describe("Optional conversation ID to continue an existing build session."),
+});
+
+export const buildCloudflowTool = {
+    name: "build_cloud_flow",
+    coversEndpoint: "post:/cloudflow/v1/flows/actions/build",
+    description:
+        "Use this when the user wants to build a brand-new CloudFlow automation from scratch using natural language. Streams real-time progress while the AI builds the flow, then returns the newly created flow's ID, the builder's answer, and the build steps that ran. Use refine_cloudflow to change an existing flow; use this only to create a new one.",
+    inputSchema: {
+        type: "object",
+        properties: {
+            question: {
+                type: "string",
+                description: "Natural language description of the CloudFlow to build from scratch.",
+            },
+            conversationId: {
+                type: "string",
+                description: "Optional conversation ID to continue an existing build session.",
+            },
+        },
+        required: ["question"],
+    },
+    annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: true,
+    },
+    _meta: {
+        "openai/toolInvocation/invoking": "Building CloudFlow...",
+        "openai/toolInvocation/invoked": "CloudFlow built",
+    },
+    securitySchemes: [{ type: "oauth2", scopes: ["read_data", "write_data"] }],
+};
+
+/**
+ * The CloudFlow NL builder (build and refine) answers with a text/event-stream of build
+ * events rather than a single JSON body: tool-lifecycle markers, token-by-token assistant
+ * text, and a custom event carrying the created flow's ID. The generic generated-tool path
+ * (callOperation.ts) sends `Accept: application/json` and reads one response body, so on
+ * these endpoints it gets a 406/parse failure and reports an opaque "Failed to call
+ * POST ..." — which is why build and refine are hand-written and consume the stream here.
+ *
+ * parseBuilderLifecycleEvent distinguishes the stream's embedded lifecycle JSON
+ * (toolStart/toolEnd/llmStart/llmEnd/customEvent) from plain assistant text: a token that
+ * merely looks like JSON stays text unless it carries one of the lifecycle keys.
+ */
+function parseBuilderLifecycleEvent(token: string): Record<string, unknown> | null {
+    if (!token.startsWith("{")) return null;
+    let event: Record<string, unknown>;
+    try {
+        event = JSON.parse(token);
+    } catch {
+        return null;
+    }
+    if (!event || typeof event !== "object") return null;
+    for (const key of ["toolStart", "toolEnd", "llmStart", "llmEnd", "customEvent"]) {
+        if (key in event) return event;
+    }
+    return null;
+}
+
+/** Extracts the created flow's ID from a `cloudflow_created` custom event, if this is one. */
+function builderCreatedFlowId(lifecycle: Record<string, unknown>): string | undefined {
+    const custom = lifecycle.customEvent as Record<string, unknown> | undefined;
+    if (!custom || custom.messageId !== "cloudflow_created") return undefined;
+    const data = custom.data as Record<string, unknown> | undefined;
+    const flowId = data?.flowId;
+    return typeof flowId === "string" && flowId ? flowId : undefined;
+}
+
+type CloudflowBuilderResult = {
+    answer: string;
+    conversationId?: string;
+    flowId?: string;
+    steps: string[];
+};
+
+/**
+ * Consumes the NL builder's SSE stream, mutating `accumulator` as events arrive and
+ * forwarding progress steps to `onProgress`. The accumulator is passed in (rather than
+ * returned) so a caller can still report the flow ID the stream emitted before an error
+ * interrupted it — a partially built flow is recoverable.
+ */
+async function consumeCloudflowBuilderStream(
+    url: string,
+    body: Record<string, unknown>,
+    token: string,
+    accumulator: CloudflowBuilderResult,
+    onProgress?: (message: string) => Promise<void>
+): Promise<void> {
+    let answerText = "";
+    for await (const { data } of makeDoitSSERequest(url, body, token)) {
+        let parsed: Record<string, unknown>;
+        try {
+            parsed = JSON.parse(data);
+        } catch {
+            continue;
+        }
+
+        if (typeof parsed.conversationId === "string" && parsed.conversationId) {
+            accumulator.conversationId = parsed.conversationId;
+        }
+
+        const answer = parsed.answer;
+        if (typeof answer !== "string") continue;
+
+        const lifecycle = parseBuilderLifecycleEvent(answer);
+        if (!lifecycle) {
+            answerText += answer;
+            continue;
+        }
+
+        const step = lifecycle.toolStart;
+        if (typeof step === "string" && step) {
+            accumulator.steps.push(step);
+            await onProgress?.(step);
+        }
+        const createdFlowId = builderCreatedFlowId(lifecycle);
+        if (createdFlowId) accumulator.flowId = createdFlowId;
+    }
+    accumulator.answer = answerText;
+}
+
+/** makeDoitSSERequest preserves existing query params, so append customerContext here so
+ *  the builder endpoints can be scoped to a customer (required for DoiT-employee tokens). */
+function buildCustomerContextUrl(baseUrl: string, customerContext?: string): string {
+    if (!customerContext) return baseUrl;
+    const url = new URL(baseUrl);
+    url.searchParams.set("customerContext", customerContext);
+    return url.href;
+}
+
+export async function handleBuildCloudflowRequest(
+    args: any,
+    token: string,
+    onProgress?: (message: string) => Promise<void>
+) {
+    try {
+        const { question, conversationId } = BuildCloudflowArgumentsSchema.parse(args);
+        const customerContext = (args?.customerContext as string | undefined) || process.env.CUSTOMER_CONTEXT;
+
+        const url = buildCustomerContextUrl(`${CLOUDFLOW_FLOWS_BASE_URL}/actions/build`, customerContext);
+        const body: Record<string, unknown> = { question };
+        if (conversationId) body.conversationId = conversationId;
+
+        const accumulator: CloudflowBuilderResult = { answer: "", steps: [] };
+
+        try {
+            await consumeCloudflowBuilderStream(url, body, token, accumulator, onProgress);
+        } catch (error) {
+            // Surface the real underlying error, plus any flow ID the stream emitted before it
+            // failed, instead of the generic generated-path "Failed to call POST ...".
+            const detail = error instanceof Error ? error.message : String(error);
+            const recovered = accumulator.flowId
+                ? ` A flow was created before the stream failed (flowId: ${accumulator.flowId}); inspect it with export_cloudflow_flow or delete it if unusable.`
+                : "";
+            return createErrorResponse(`CloudFlow build stream failed: ${detail}.${recovered}`);
+        }
+
+        if (!accumulator.answer && !accumulator.flowId && !accumulator.conversationId) {
+            return createErrorResponse("No result received from CloudFlow build stream");
+        }
+
+        const result: Record<string, unknown> = {};
+        if (accumulator.flowId) result.flowId = accumulator.flowId;
+        if (accumulator.conversationId) result.conversationId = accumulator.conversationId;
+        if (accumulator.answer) result.answer = accumulator.answer;
+        if (accumulator.steps.length > 0) result.steps = accumulator.steps;
+        return createSuccessResponse(JSON.stringify(result, null, 2));
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return createErrorResponse(formatZodError(error));
+        }
+        return handleGeneralError(error, "handling build CloudFlow request");
+    }
+}
+
 export async function handleRefineCloudflowRequest(
     args: any,
     token: string,
@@ -157,59 +336,31 @@ export async function handleRefineCloudflowRequest(
 ) {
     try {
         const { flowId, question, conversationId } = RefineCloudflowArgumentsSchema.parse(args);
+        const customerContext = (args?.customerContext as string | undefined) || process.env.CUSTOMER_CONTEXT;
 
-        const url = `${CLOUDFLOW_BASE_URL}/flows/${encodeURIComponent(flowId)}/actions/refine`;
+        const url = buildCustomerContextUrl(
+            `${CLOUDFLOW_BASE_URL}/flows/${encodeURIComponent(flowId)}/actions/refine`,
+            customerContext
+        );
         const body: Record<string, unknown> = { question };
         if (conversationId) body.conversationId = conversationId;
 
-        let answerText = "";
-        let responseConversationId: string | undefined;
+        const accumulator: CloudflowBuilderResult = { answer: "", steps: [] };
 
         try {
-            for await (const { data } of makeDoitSSERequest(url, body, token)) {
-                let parsed: Record<string, unknown>;
-                try {
-                    parsed = JSON.parse(data);
-                } catch {
-                    continue;
-                }
-
-                if (parsed.conversationId) {
-                    responseConversationId = parsed.conversationId as string;
-                    continue;
-                }
-
-                const answer = parsed.answer;
-                if (typeof answer !== "string") continue;
-
-                // Lifecycle events have answer values that are JSON objects (llmStart, llmEnd, toolStart, toolEnd)
-                let isLifecycle = false;
-                try {
-                    const inner = JSON.parse(answer);
-                    if (inner && typeof inner === "object") {
-                        isLifecycle = true;
-                        const label =
-                            (inner as any).toolStart ?? (inner as any).toolEnd ?? (inner as any).value ?? null;
-                        if (label) await onProgress?.(String(label));
-                    }
-                } catch {
-                    // not JSON — plain text chunk
-                }
-
-                if (!isLifecycle) {
-                    answerText += answer;
-                }
-            }
+            await consumeCloudflowBuilderStream(url, body, token, accumulator, onProgress);
         } catch (error) {
             return handleGeneralError(error, "calling refine CloudFlow API");
         }
 
-        if (!answerText) {
+        if (!accumulator.answer) {
             return createErrorResponse("No result received from CloudFlow build stream");
         }
 
-        const result: Record<string, unknown> = { answer: answerText };
-        if (responseConversationId) result.conversationId = responseConversationId;
+        const result: Record<string, unknown> = { answer: accumulator.answer };
+        if (accumulator.conversationId) result.conversationId = accumulator.conversationId;
+        if (accumulator.flowId) result.flowId = accumulator.flowId;
+        if (accumulator.steps.length > 0) result.steps = accumulator.steps;
         return createSuccessResponse(JSON.stringify(result, null, 2));
     } catch (error) {
         if (error instanceof z.ZodError) {

--- a/src/tools/generated/__tests__/generateTools.test.ts
+++ b/src/tools/generated/__tests__/generateTools.test.ts
@@ -329,4 +329,16 @@ describe("generateTools", () => {
         expect(warn).not.toHaveBeenCalled();
         warn.mockRestore();
     });
+
+    it("exposes the three CloudFlow run tools from the bundled spec", () => {
+        const names = new Set(generateTools(loadGeneratedToolsSpec(), COVERED_ENDPOINTS).map((tool) => tool.name));
+        expect(names.has("test_run_cloudflow_flow")).toBe(true);
+        expect(names.has("list_cloudflow_flow_runs")).toBe(true);
+        expect(names.has("get_cloudflow_flow_run")).toBe(true);
+    });
+
+    it("does not generate a tool for build_cloud_flow — it is hand-written to consume the SSE stream", () => {
+        const names = new Set(generateTools(loadGeneratedToolsSpec(), COVERED_ENDPOINTS).map((tool) => tool.name));
+        expect(names.has("build_cloud_flow")).toBe(false);
+    });
 });

--- a/src/tools/handWrittenTools.ts
+++ b/src/tools/handWrittenTools.ts
@@ -18,6 +18,7 @@ import {
     searchCloudDiagramsTool,
 } from "./cloudDiagrams.js";
 import {
+    buildCloudflowTool,
     createCloudFlowConnectionTool,
     getCloudFlowConnectionTool,
     getCloudFlowTemplateTool,
@@ -143,6 +144,7 @@ export const HAND_WRITTEN_TOOLS: HandWrittenTool[] = [
     listCloudFlowTemplatesTool,
     getCloudFlowTemplateTool,
     refineCloudflowTool,
+    buildCloudflowTool,
     listOrganizationsTool,
     listPlatformsTool,
     listUsersTool,

--- a/src/utils/toolsHandler.ts
+++ b/src/utils/toolsHandler.ts
@@ -39,6 +39,7 @@ import {
     handleSearchCloudDiagramsRequest,
 } from "../tools/cloudDiagrams.js";
 import {
+    handleBuildCloudflowRequest,
     handleCreateCloudFlowConnectionRequest,
     handleGetCloudFlowConnectionRequest,
     handleGetCloudFlowTemplateRequest,
@@ -407,6 +408,9 @@ async function runOriginalDispatch(
             break;
         case "get_cloudflow_template":
             result = await handleGetCloudFlowTemplateRequest(args, token);
+            break;
+        case "build_cloud_flow":
+            result = await handleBuildCloudflowRequest(args, token, options?.onProgress);
             break;
         case "refine_cloudflow":
             result = await handleRefineCloudflowRequest(args, token, options?.onProgress);


### PR DESCRIPTION
## Problem

`build_cloud_flow` returned an opaque `{"isError":true,"text":"Failed to call POST /cloudflow/v1/flows/actions/build"}` — no flow ID, nothing to recover — while the same build via the CLI succeeded.

Root cause: the `buildCloudFlow` operation responds with `text/event-stream`, but unlike `refineCloudFlow` it had **no** hand-written tool, so it fell through to the generic generated-tool path (`callOperation.ts`). That path sends `Accept: application/json` and reads a single response body, so the streaming endpoint returns 406, `makeDoitRequest` swallows it to `null`, and the tool reports the generic "Failed to call POST …". `refine_cloudflow` (also SSE) worked only because it was already hand-written to consume the stream.

## Fix

- Add a hand-written **`build_cloud_flow`** tool (`coversEndpoint: post:/cloudflow/v1/flows/actions/build`, which removes it from the generic path) that consumes the builder SSE stream, extracting `flowId` (from the `cloudflow_created` custom event), `conversationId`, `answer`, and `steps` — parsing modeled on the `dci` CLI's builder.
- On failure it surfaces the **real** underlying error (e.g. `HTTP 406: …`) plus any `flowId` the stream emitted before failing, instead of the opaque string — a partially built flow is recoverable (export/inspect/refine/delete).
- Refactor `refine_cloudflow` onto the same shared stream consumer; both now scope to `customerContext`.
- Wired through `handWrittenTools.ts`, `toolsHandler.ts`, `core.ts`, `server.ts`.

## Also in this PR

- **Regression test** asserting the three CloudFlow run tools (`test_run_cloudflow_flow`, `list_cloudflow_flow_runs`, `get_cloudflow_flow_run`) generate from the bundled spec — they're present at HEAD and callable; a stale deployed build lacking them is a redeploy/dependency-bump issue, not a code gap.
- **`docs/cloudflow-authoring.md`** — the runtime authoring contract for MCP users: the `codeNode` `nodes`-not-`input` / return-don't-assign rule, idempotency-key retry semantics, and the export→edit→import repair loop.

## Follow-up (not in this PR)

`askAvaStreaming` (POST `/ava/v1/ask`) is the same bug class — a generated SSE tool on the broken generic path, with only the sync variant hand-written. Worth either excluding it (the sync variant is the MCP-appropriate one) or hand-writing a streaming tool, plus a generator-level guard so a future SSE endpoint can't silently ship a broken generic tool.

## Testing

- `tsc --noEmit` clean, Biome clean.
- Full suite: **922/922 pass**, including new `build_cloud_flow` SSE tests (success, real-error surfacing, recoverable-flow-ID-on-failure, schema validation) and the run-tools regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)