### PR TITLE
fix: consume CloudFlow build SSE stream; exclude & guard SSE-only generated tools

### DIFF
--- a/src/tools/generated/__tests__/generateTools.test.ts
+++ b/src/tools/generated/__tests__/generateTools.test.ts
@@ -290,6 +290,51 @@ describe("generateTools", () => {
         warn.mockRestore();
     });
 
+    it("skips an operation whose only success response is text/event-stream, leaving other tools intact", () => {
+        const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+        const document = buildDocument({
+            paths: {
+                "/streamy": {
+                    post: {
+                        operationId: "streamThings",
+                        responses: {
+                            "200": { description: "stream", content: { "text/event-stream": {} } },
+                            "400": { description: "bad", content: { "application/json": {} } },
+                        },
+                    },
+                },
+                "/gadgets": {
+                    get: { operationId: "listGadgets" },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        const tools = generateTools(document, new Set());
+        expect(tools.map((tool) => tool.name)).toEqual(["list_gadgets"]);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("text/event-stream only"));
+        warn.mockRestore();
+    });
+
+    it("still generates a tool when a success response offers JSON alongside an event stream", () => {
+        const document = buildDocument({
+            paths: {
+                "/hybrid": {
+                    get: {
+                        operationId: "getHybrid",
+                        responses: {
+                            "200": {
+                                description: "ok",
+                                content: { "application/json": {}, "text/event-stream": {} },
+                            },
+                        },
+                    },
+                },
+            } as unknown as OpenAPIV3.Document["paths"],
+        });
+
+        expect(generateTools(document, new Set()).map((tool) => tool.name)).toEqual(["get_hybrid"]);
+    });
+
     it("treats application/*+json request bodies as JSON and preserves the declared content type", () => {
         const document = buildDocument({
             paths: {
@@ -340,5 +385,11 @@ describe("generateTools", () => {
     it("does not generate a tool for build_cloud_flow — it is hand-written to consume the SSE stream", () => {
         const names = new Set(generateTools(loadGeneratedToolsSpec(), COVERED_ENDPOINTS).map((tool) => tool.name));
         expect(names.has("build_cloud_flow")).toBe(false);
+    });
+
+    it("does not generate a streaming ask_ava tool — POST /ava/v1/ask is SSE-only and excluded (ask_ava_sync covers AVA)", () => {
+        const tools = generateTools(loadGeneratedToolsSpec(), COVERED_ENDPOINTS);
+        const keys = new Set(tools.map((tool) => `${tool.metadata.method}:${tool.metadata.pathTemplate}`.toLowerCase()));
+        expect(keys.has("post:/ava/v1/ask")).toBe(false);
     });
 });

--- a/src/tools/generated/excludedOperations.json
+++ b/src/tools/generated/excludedOperations.json
@@ -27,6 +27,10 @@
       "reason": "Admin-grade contract write — proposed exclusion pending product decision (MCP coverage research 2026-08)"
     },
     {
+      "endpoint": "post:/ava/v1/ask",
+      "reason": "SSE-only streaming endpoint (askAvaStreaming; 200 is text/event-stream). The generic generated-tool path sends Accept: application/json and reads one body, so it can only ever fail here. The sync variant ask_ava_sync (post:/ava/v1/askSync) is the MCP-appropriate coverage for asking AVA — a single tool result, no streaming needed."
+    },
+    {
       "endpoint": "post:/billing/v1/contract-templates",
       "reason": "Admin-grade contract-template write — proposed exclusion pending product decision (MCP coverage research 2026-08)"
     },

--- a/src/tools/generated/generateTools.ts
+++ b/src/tools/generated/generateTools.ts
@@ -46,6 +46,23 @@ function findJsonContent(
 }
 
 /**
+ * The generic generated-tool path (callOperation.ts) sends `Accept: application/json` and
+ * reads a single response body, so an operation whose success response is only ever a
+ * text/event-stream (SSE) can't work over it — makeDoitRequest gets a 406/unparseable body,
+ * returns null, and the tool reports an opaque "Failed to call ...". Such endpoints must be
+ * hand-written to consume the stream (see handleBuildCloudflowRequest in src/tools/cloudflow.ts)
+ * or excluded (excludedOperations.json). Skip here — like the undeclared-placeholder guard —
+ * so a future SSE endpoint can't silently ship a generic tool that can only ever fail.
+ */
+function isEventStreamOnlyOperation(operation: OpenAPIV3.OperationObject): boolean {
+    const success = (operation.responses?.["200"] ?? operation.responses?.["201"]) as
+        | OpenAPIV3.ResponseObject
+        | undefined;
+    const contentTypes = Object.keys(success?.content ?? {});
+    return contentTypes.length > 0 && contentTypes.every((type) => type.split(";")[0].trim() === "text/event-stream");
+}
+
+/**
  * DELETE operations are irreversible, so they go through the server-side two-phase approval
  * flow (`approval_required` → `confirm_action`) rather than relying on the client honouring
  * `destructiveHint`, which is advisory only. The summary is the text the user confirms.
@@ -76,6 +93,13 @@ export function generateTools(document: OpenAPIV3.Document, coveredEndpoints: Se
             if (!operation) continue;
             if (coveredEndpoints.has(`${method}:${pathTemplate}`.toLowerCase())) continue;
             if (isExcludedOperation(method, pathTemplate, operation.tags)) continue;
+
+            if (isEventStreamOnlyOperation(operation)) {
+                console.error(
+                    `Skipping generated tool for ${method.toUpperCase()} ${pathTemplate}: response is text/event-stream only (SSE); the generic generated-tool path cannot consume a stream. Hand-write a tool that consumes the stream, or add it to excludedOperations.json.`
+                );
+                continue;
+            }
 
             const parameters = mergeParameters(
                 (pathItem.parameters ?? []) as OpenAPIV3.ParameterObject[],


### PR DESCRIPTION
## Summary

CloudFlow build/refine and Ava's streaming endpoint all answer with `text/event-stream`, which the generic generated-tool path (`callOperation.ts`) can't consume — it sends `Accept: application/json`, reads a single body, and returns the opaque `Failed to call POST ...`. This branch fixes the class of bug end to end.

Two commits:

- **`build_cloud_flow` hand-written to consume the SSE stream** (`767cc3a`) — mirrors the existing refine path: `consumeCloudflowBuilderStream` reads the builder's `text/event-stream` via `makeDoitSSERequest`, surfaces progress steps, recovers a `flowId` emitted before a mid-stream failure, and returns a real error instead of the generic one. Adds `docs/cloudflow-authoring.md`.
- **Exclude the SSE-only `ask_ava` op and guard the generator** (`471f824`):
  - `POST /ava/v1/ask` (`askAvaStreaming`) declares **only** `text/event-stream` on its 200, so the auto-generated tool could only ever fail. The sync variant `ask_ava_sync` (`post:/ava/v1/askSync`) is the MCP-appropriate coverage for asking Ava (a single tool result — no streaming needed), so the streaming op is added to `excludedOperations.json`.
  - `generateTools` now skips (and `console.error`s) any operation whose only success-response content type is `text/event-stream`, mirroring the existing undeclared-placeholder guard — so a future SSE endpoint can't silently ship a broken generic tool.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run` — full suite passes (925 tests), including new `generateTools` cases (guard skips SSE-only ops, still generates when JSON is offered alongside a stream, and `post:/ava/v1/ask` is not exposed from the bundled spec) and the expanded `cloudflow` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)