### PR TITLE
fix(api): send customerContext also as x-tenant-id header

### DIFF
--- a/src/tools/cloudflow.ts
+++ b/src/tools/cloudflow.ts
@@ -243,10 +243,11 @@ async function consumeCloudflowBuilderStream(
     body: Record<string, unknown>,
     token: string,
     accumulator: CloudflowBuilderResult,
-    onProgress?: (message: string) => Promise<void>
+    onProgress?: (message: string) => Promise<void>,
+    customerContext?: string
 ): Promise<void> {
     let answerText = "";
-    for await (const { data } of makeDoitSSERequest(url, body, token)) {
+    for await (const { data } of makeDoitSSERequest(url, body, token, customerContext)) {
         let parsed: Record<string, unknown>;
         try {
             parsed = JSON.parse(data);
@@ -303,7 +304,7 @@ export async function handleBuildCloudflowRequest(
         const accumulator: CloudflowBuilderResult = { answer: "", steps: [] };
 
         try {
-            await consumeCloudflowBuilderStream(url, body, token, accumulator, onProgress);
+            await consumeCloudflowBuilderStream(url, body, token, accumulator, onProgress, customerContext);
         } catch (error) {
             // Surface the real underlying error, plus any flow ID the stream emitted before it
             // failed, instead of the generic generated-path "Failed to call POST ...".
@@ -351,7 +352,7 @@ export async function handleRefineCloudflowRequest(
         const accumulator: CloudflowBuilderResult = { answer: "", steps: [] };
 
         try {
-            await consumeCloudflowBuilderStream(url, body, token, accumulator, onProgress);
+            await consumeCloudflowBuilderStream(url, body, token, accumulator, onProgress, customerContext);
         } catch (error) {
             return handleGeneralError(error, "calling refine CloudFlow API");
         }

--- a/src/tools/generated/__tests__/callOperation.test.ts
+++ b/src/tools/generated/__tests__/callOperation.test.ts
@@ -76,6 +76,37 @@ describe("handleGeneratedOperationRequest", () => {
         expect(url).toContain("customerContext=cust-1");
     });
 
+    it("passes customerContext to makeDoitRequest so it is also sent as the tenant header", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue("{}");
+
+        await handleGeneratedOperationRequest(buildTool(), { id: "abc", customerContext: "cust-1" }, mockToken);
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ customerContext: "cust-1" })
+        );
+    });
+
+    it("passes the CUSTOMER_CONTEXT env fallback to makeDoitRequest", async () => {
+        (makeDoitRequest as vi.Mock).mockResolvedValue("{}");
+        const original = process.env.CUSTOMER_CONTEXT;
+        process.env.CUSTOMER_CONTEXT = "env-cust";
+
+        try {
+            await handleGeneratedOperationRequest(buildTool(), { id: "abc" }, mockToken);
+        } finally {
+            if (original === undefined) delete process.env.CUSTOMER_CONTEXT;
+            else process.env.CUSTOMER_CONTEXT = original;
+        }
+
+        expect(makeDoitRequest).toHaveBeenCalledWith(
+            expect.any(String),
+            mockToken,
+            expect.objectContaining({ customerContext: "env-cust" })
+        );
+    });
+
     it("sends leftover fields as a JSON body for non-GET operations", async () => {
         (makeDoitRequest as vi.Mock).mockResolvedValue("{}");
         const tool = buildTool({

--- a/src/tools/generated/callOperation.ts
+++ b/src/tools/generated/callOperation.ts
@@ -99,6 +99,9 @@ export async function handleGeneratedOperationRequest(tool: GeneratedTool, args:
             method: metadata.method.toUpperCase(),
             body,
             appendParams: false,
+            // URL params are built above (appendParams: false), but makeDoitRequest still
+            // needs the context to send the X-Tenant-Id header.
+            customerContext,
             parseAs: "text",
             timeoutMs: GENERATED_REQUEST_TIMEOUT_MS,
             headers: Object.keys(headers).length > 0 ? headers : undefined,

--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     appendUrlParameters,
+    applyTenantIdHeader,
     DebugLevel,
     debugLog,
     formatEnumValues,
     getTrackingContext,
     makeDoitRequest,
+    makeDoitSSERequest,
     runWithTracking,
 } from "../util.js";
 
@@ -206,5 +208,198 @@ describe("makeDoitRequest timeout", () => {
         const result = await makeDoitRequest("https://api.doit.com/test", "test-token");
 
         expect(result).toBeNull();
+    });
+});
+
+describe("applyTenantIdHeader", () => {
+    const originalCustomerContext = process.env.CUSTOMER_CONTEXT;
+
+    afterEach(() => {
+        if (originalCustomerContext === undefined) delete process.env.CUSTOMER_CONTEXT;
+        else process.env.CUSTOMER_CONTEXT = originalCustomerContext;
+    });
+
+    it("sets X-Tenant-Id from the explicit customer context", () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        expect(applyTenantIdHeader({}, "cust-1")).toEqual({ "X-Tenant-Id": "cust-1" });
+    });
+
+    it("falls back to the CUSTOMER_CONTEXT env var", () => {
+        process.env.CUSTOMER_CONTEXT = "env-cust";
+        expect(applyTenantIdHeader({})).toEqual({ "X-Tenant-Id": "env-cust" });
+    });
+
+    it("prefers the explicit customer context over the env var", () => {
+        process.env.CUSTOMER_CONTEXT = "env-cust";
+        expect(applyTenantIdHeader({}, "cust-1")).toEqual({ "X-Tenant-Id": "cust-1" });
+    });
+
+    it("adds no header when there is no customer context", () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        expect(applyTenantIdHeader({ Accept: "application/json" })).toEqual({ Accept: "application/json" });
+    });
+
+    it("keeps an already-set tenant header regardless of casing, so it is never sent twice", () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        const headers = applyTenantIdHeader({ "x-tenant-id": "explicit" }, "cust-1");
+
+        expect(headers).toEqual({ "x-tenant-id": "explicit" });
+        expect(Object.keys(headers).filter((key) => key.toLowerCase() === "x-tenant-id")).toHaveLength(1);
+    });
+});
+
+describe("makeDoitRequest customer context header", () => {
+    const originalCustomerContext = process.env.CUSTOMER_CONTEXT;
+
+    // Captures the headers of the last stubbed fetch call.
+    function stubFetchOk() {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ ok: true }),
+            text: async () => "{}",
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        return fetchMock;
+    }
+
+    function headersOf(fetchMock: ReturnType<typeof stubFetchOk>): Record<string, string> {
+        return fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        if (originalCustomerContext === undefined) delete process.env.CUSTOMER_CONTEXT;
+        else process.env.CUSTOMER_CONTEXT = originalCustomerContext;
+    });
+
+    it("sends the customer context as the X-Tenant-Id header in addition to the query param", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        const fetchMock = stubFetchOk();
+
+        await makeDoitRequest("https://api.doit.com/test", "test-token", { customerContext: "cust-1" });
+
+        expect(headersOf(fetchMock)["X-Tenant-Id"]).toBe("cust-1");
+        expect(fetchMock.mock.calls[0][0]).toContain("customerContext=cust-1");
+    });
+
+    it("sends the X-Tenant-Id header from the CUSTOMER_CONTEXT env var", async () => {
+        process.env.CUSTOMER_CONTEXT = "env-cust";
+        const fetchMock = stubFetchOk();
+
+        await makeDoitRequest("https://api.doit.com/test", "test-token");
+
+        expect(headersOf(fetchMock)["X-Tenant-Id"]).toBe("env-cust");
+    });
+
+    it("sends the X-Tenant-Id header even when URL params are not appended", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        const fetchMock = stubFetchOk();
+
+        await makeDoitRequest("https://api.doit.com/test", "test-token", {
+            appendParams: false,
+            customerContext: "cust-1",
+        });
+
+        expect(headersOf(fetchMock)["X-Tenant-Id"]).toBe("cust-1");
+    });
+
+    it("omits the X-Tenant-Id header when there is no customer context", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        const fetchMock = stubFetchOk();
+
+        await makeDoitRequest("https://api.doit.com/test", "test-token");
+
+        const headers = headersOf(fetchMock);
+        expect(Object.keys(headers).some((key) => key.toLowerCase() === "x-tenant-id")).toBe(false);
+    });
+
+    it("does not override an explicit tenant header passed by the caller", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        const fetchMock = stubFetchOk();
+
+        await makeDoitRequest("https://api.doit.com/test", "test-token", {
+            customerContext: "cust-1",
+            headers: { "X-Tenant-Id": "explicit" },
+        });
+
+        const headers = headersOf(fetchMock);
+        expect(headers["X-Tenant-Id"]).toBe("explicit");
+        expect(Object.keys(headers).filter((key) => key.toLowerCase() === "x-tenant-id")).toHaveLength(1);
+    });
+});
+
+describe("makeDoitSSERequest customer context header", () => {
+    const originalCustomerContext = process.env.CUSTOMER_CONTEXT;
+    const originalTenantId = process.env.TENANT_ID;
+
+    function stubSSEFetch() {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            body: new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode('data: {"answer":"hi"}\n\n'));
+                    controller.close();
+                },
+            }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        return fetchMock;
+    }
+
+    async function drain(generator: AsyncGenerator<{ data: string }>) {
+        for await (const _event of generator) {
+            // consume the stream so the request completes
+        }
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        if (originalCustomerContext === undefined) delete process.env.CUSTOMER_CONTEXT;
+        else process.env.CUSTOMER_CONTEXT = originalCustomerContext;
+        if (originalTenantId === undefined) delete process.env.TENANT_ID;
+        else process.env.TENANT_ID = originalTenantId;
+    });
+
+    it("sends the customer context as the X-Tenant-Id header", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        delete process.env.TENANT_ID;
+        const fetchMock = stubSSEFetch();
+
+        await drain(makeDoitSSERequest("https://api.doit.com/stream", { question: "q" }, "test-token", "cust-1"));
+
+        expect(fetchMock.mock.calls[0][1].headers["X-Tenant-Id"]).toBe("cust-1");
+    });
+
+    it("prefers the customer context over the TENANT_ID env var and sends a single tenant header", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        process.env.TENANT_ID = "env-tenant";
+        const fetchMock = stubSSEFetch();
+
+        await drain(makeDoitSSERequest("https://api.doit.com/stream", { question: "q" }, "test-token", "cust-1"));
+
+        const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+        expect(headers["X-Tenant-Id"]).toBe("cust-1");
+        expect(Object.keys(headers).filter((key) => key.toLowerCase() === "x-tenant-id")).toHaveLength(1);
+    });
+
+    it("falls back to the TENANT_ID env var when there is no customer context", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        process.env.TENANT_ID = "env-tenant";
+        const fetchMock = stubSSEFetch();
+
+        await drain(makeDoitSSERequest("https://api.doit.com/stream", { question: "q" }, "test-token"));
+
+        expect(fetchMock.mock.calls[0][1].headers["X-Tenant-Id"]).toBe("env-tenant");
+    });
+
+    it("omits the tenant header when neither a customer context nor TENANT_ID is set", async () => {
+        delete process.env.CUSTOMER_CONTEXT;
+        delete process.env.TENANT_ID;
+        const fetchMock = stubSSEFetch();
+
+        await drain(makeDoitSSERequest("https://api.doit.com/stream", { question: "q" }, "test-token"));
+
+        const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+        expect(Object.keys(headers).some((key) => key.toLowerCase() === "x-tenant-id")).toBe(false);
     });
 });

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -201,6 +201,40 @@ export function handleGeneralError(error: any, context: string): ReturnType<type
 }
 
 /**
+ * Header the DoiT API reads the customer (tenant) scope from. It is sent in addition to the
+ * `customerContext` query parameter — the API accepts either, and newer endpoints only read
+ * the header.
+ */
+export const TENANT_ID_HEADER = "X-Tenant-Id";
+
+/**
+ * Resolves the customer context for a request: the explicitly passed value first, then the
+ * CUSTOMER_CONTEXT env var (how the stdio server persists a selected customer).
+ */
+export function resolveCustomerContext(customerContextId?: string): string | undefined {
+    return customerContextId || process.env.CUSTOMER_CONTEXT || undefined;
+}
+
+/**
+ * Sets the X-Tenant-Id header from the resolved customer context, mutating and returning
+ * `headers`. An existing tenant header (any casing — e.g. an OpenAPI operation that declares
+ * one explicitly) is left untouched so callers keep control and we never send it twice.
+ */
+export function applyTenantIdHeader(
+    headers: Record<string, string>,
+    customerContextId?: string
+): Record<string, string> {
+    const customerContext = resolveCustomerContext(customerContextId);
+    if (!customerContext) return headers;
+
+    const alreadySet = Object.keys(headers).some((key) => key.toLowerCase() === TENANT_ID_HEADER.toLowerCase());
+    if (alreadySet) return headers;
+
+    headers[TENANT_ID_HEADER] = customerContext;
+    return headers;
+}
+
+/**
  * Helper function to append customer context to URL if available
  * @param baseUrl The base URL to append parameters to
  * @returns URL with maxResults and optional customerContext parameters
@@ -215,7 +249,7 @@ export function appendUrlParameters(baseUrl: string, customerContextId?: string)
         url += `${separator}maxResults=40`;
     }
 
-    const customerContext = customerContextId || process.env.CUSTOMER_CONTEXT;
+    const customerContext = resolveCustomerContext(customerContextId);
 
     if (customerContext) {
         // Use & as separator since we know the URL now has parameters
@@ -301,6 +335,10 @@ export async function makeDoitRequest<T>(
         ...(isFormDataBody ? {} : { "Content-Type": "application/json" }),
         ...extraHeaders,
     };
+
+    // The customer scope goes out as both the customerContext query param (below) and the
+    // X-Tenant-Id header, since the API reads the scope from the header on newer endpoints.
+    applyTenantIdHeader(headers, customerContext);
 
     let requestUrl = appendParams ? appendUrlParameters(resolvedUrl, customerContext) : resolvedUrl;
 
@@ -464,7 +502,8 @@ const DATA_LINE_PREFIX = "data:";
 export async function* makeDoitSSERequest(
     url: string,
     body: object,
-    authToken: string
+    authToken: string,
+    customerContext?: string
 ): AsyncGenerator<{ data: string }> {
     const parsedUrl = new URL(applyRuntimeDoiTApiBase(url));
 
@@ -479,15 +518,21 @@ export async function* makeDoitSSERequest(
     const requestUrl = parsedUrl.href;
     debugLog("SSE request URL:", DebugLevel.VERBOSE, requestUrl);
 
-    const tenantId = process.env.TENANT_ID;
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${authToken}`,
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+    };
+    // Scope the stream to the customer the same way the non-streaming client does; the
+    // standalone TENANT_ID env var stays as a fallback for deployments that set it.
+    applyTenantIdHeader(headers, customerContext);
+    if (!headers[TENANT_ID_HEADER] && process.env.TENANT_ID) {
+        headers[TENANT_ID_HEADER] = process.env.TENANT_ID;
+    }
+
     const response = await fetch(requestUrl, {
         method: "POST",
-        headers: {
-            Authorization: `Bearer ${authToken}`,
-            "Content-Type": "application/json",
-            Accept: "text/event-stream",
-            ...(tenantId ? { "x-tenant-id": tenantId } : {}),
-        },
+        headers,
         body: JSON.stringify(body),
     });
 


### PR DESCRIPTION
Public API reads the x-tenant-id customerContext request param is the legacy format