### PR TITLE
chore: pin yarn 1 to match the committed lockfiles and CI

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-nodeLinker: node-modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,14 @@ Requires Node.js `>=18`. Install dependencies before running any commands:
 yarn install
 ```
 
+**Yarn 1 (classic), pinned.** Both `yarn.lock` files are v1 format and CI resolves `yarn` from the
+runner image, so the version is pinned in `package.json` via `packageManager` (for Corepack) and
+`volta` (for Volta) — in this directory *and* in `test/integration`, which is a separate project
+with its own lockfile. Running a Yarn 2+ binary here fails with "This package doesn't seem to be
+present in your lockfile" or "The lockfile would have been modified by this install"; if you see
+either, your shell resolved an unpinned Yarn. Do not commit a berry-format lockfile or a
+`.yarnrc.yml` without migrating both projects and all four workflows together.
+
 ## Project Overview
 
 DoiT MCP Server is a Model Context Protocol (MCP) server that provides LLMs with access to the DoiT API.

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "packageManager": "yarn@1.22.22",
+  "volta": {
+    "node": "22.21.1",
+    "yarn": "1.22.22"
   }
 }

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -16,5 +16,10 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "packageManager": "yarn@1.22.22",
+  "volta": {
+    "node": "22.21.1",
+    "yarn": "1.22.22"
   }
 }


### PR DESCRIPTION
Every `yarn` command in this repo fails for anyone whose shell provides Yarn 2+:

```
Internal Error: @doitintl/doit-mcp-server@workspace:.: This package doesn't seem to be
present in your lockfile; run "yarn install" to update the lockfile
```

That includes the `yarn type-check` and `yarn lint` **pre-commit hooks**, which are `language: system` and so use whatever `yarn` is on `PATH`.

## Why it happens

The repo is Yarn 1 (classic) and nothing recorded that:

| | |
|---|---|
| `yarn.lock` (both of them) | `# yarn lockfile v1` — classic format |
| All 4 workflows | `setup-node@v4`, no Corepack step → runner's yarn **1.22.x**, and `--frozen-lockfile`, a classic-only flag |
| `package.json` | no `packageManager`, no `volta` — nothing pinning a version |
| `.yarnrc.yml` | `nodeLinker: node-modules` — berry-only config, ignored by classic |

So CI is classic, the lockfiles are classic, and a local shell was free to resolve anything. The stray `.yarnrc.yml` is the residue of a berry migration that was never finished; it did nothing except suggest this repo was on berry when it isn't.

## The fix

Pin the version two ways, so it holds regardless of how Yarn is provisioned — `packageManager` for Corepack, `volta` for Volta. Volta requires a node pin before it will accept a yarn pin, so `volta.node` is set to `22.21.1`, the newest node CI runs.

**`test/integration` needs its own pin.** It's a separate project with its own v1 lockfile, installed separately by CI. Without a pin it resolved to Yarn 4 and failed differently — `The lockfile would have been modified by this install, which is explicitly forbidden` — and a Yarn 4 run there also drops its own `.yarnrc.yml` on disk, which is how the root one probably got committed in the first place.

`AGENTS.md` records the constraint and both error strings, so the next person (or agent) recognises the symptom instead of re-diagnosing it.

## What this does not touch

No lockfile changes. No workflow changes. `git diff` is 4 files, +18/−1.

## Verification

With `yarn 1.22.22`, in both projects:

- `yarn install --frozen-lockfile` → clean, and **both lockfiles byte-identical afterwards** (`git diff --quiet` passes)
- `yarn check:ci` → clean · `yarn test` → 913 + 184 passing · `yarn build` → clean

## Deliberately not done

Yarn 1 is EOL. Migrating to berry means converting both lockfiles and updating all four workflows (Corepack enable, `--frozen-lockfile` → `--immutable`) in one change, including the release pipeline — a separate decision, not a side effect of unbreaking local development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)