### PR TITLE
fix(security): redact sensitive query params from debug-logged URLs

### DIFF
--- a/src/utils/__tests__/util.test.ts
+++ b/src/utils/__tests__/util.test.ts
@@ -8,6 +8,7 @@ import {
     getTrackingContext,
     makeDoitRequest,
     makeDoitSSERequest,
+    redactUrlForLog,
     runWithTracking,
 } from "../util.js";
 
@@ -401,5 +402,46 @@ describe("makeDoitSSERequest customer context header", () => {
 
         const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
         expect(Object.keys(headers).some((key) => key.toLowerCase() === "x-tenant-id")).toBe(false);
+    });
+});
+
+describe("redactUrlForLog", () => {
+    it("masks customerContext, pageToken and filter values", () => {
+        const redacted = redactUrlForLog(
+            "https://api.doit.com/analytics/v1/reports?customerContext=acme-corp&pageToken=abc123&filter=owner:jane@acme.com"
+        );
+
+        expect(redacted).not.toContain("acme-corp");
+        expect(redacted).not.toContain("abc123");
+        expect(redacted).not.toContain("jane@acme.com");
+        expect(redacted).toContain("customerContext=REDACTED");
+        expect(redacted).toContain("pageToken=REDACTED");
+        expect(redacted).toContain("filter=REDACTED");
+    });
+
+    it("leaves the rest of the URL intact", () => {
+        const redacted = redactUrlForLog("https://api.doit.com/v1/cloudflow?maxResults=50&customerContext=acme");
+
+        expect(redacted).toContain("https://api.doit.com/v1/cloudflow");
+        expect(redacted).toContain("maxResults=50");
+        expect(redacted).toContain("customerContext=REDACTED");
+    });
+
+    it("returns a URL without sensitive params unchanged", () => {
+        const url = "https://api.doit.com/v1/reports?maxResults=10";
+
+        expect(redactUrlForLog(url)).toBe(url);
+    });
+
+    it("matches parameter names case-insensitively", () => {
+        expect(redactUrlForLog("https://api.doit.com/v1/x?CustomerContext=acme")).toContain("CustomerContext=REDACTED");
+    });
+
+    it("still redacts when the URL cannot be parsed", () => {
+        const redacted = redactUrlForLog("/v1/reports?customerContext=acme-corp&maxResults=5");
+
+        expect(redacted).not.toContain("acme-corp");
+        expect(redacted).toContain("customerContext=REDACTED");
+        expect(redacted).toContain("maxResults=5");
     });
 });

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -117,6 +117,40 @@ const DOIT_DEBUG_LEVEL = parseDebugLevel();
  * @param level Debug level for this message (default: INFO).
  * @param optionalArgs Optional additional arguments (logged after the message, like console.log)
  */
+/**
+ * Query parameters whose values must never reach the logs. `customerContext`
+ * identifies a tenant, and `pageToken` / `filter` carry request state that can
+ * describe what a customer is querying.
+ */
+export const REDACTED_LOG_PARAMS = ["customerContext", "pageToken", "filter"] as const;
+
+const REDACTED_VALUE = "REDACTED";
+
+/**
+ * Mask sensitive query-parameter values so a request URL can be logged safely.
+ *
+ * Debug logging is off by default, but when `DOIT_DEBUG_LEVEL` raises it the
+ * full URL would otherwise land in aggregated or shared logs.
+ */
+export function redactUrlForLog(url: string): string {
+    const sensitive = new Set<string>(REDACTED_LOG_PARAMS.map((param) => param.toLowerCase()));
+
+    try {
+        const parsed = new URL(url);
+        for (const key of Array.from(parsed.searchParams.keys())) {
+            if (sensitive.has(key.toLowerCase())) {
+                parsed.searchParams.set(key, REDACTED_VALUE);
+            }
+        }
+        return parsed.href;
+    } catch {
+        // Relative or malformed URL: fall back to a textual pass, so a value is
+        // never logged in full merely because the URL could not be parsed.
+        const pattern = new RegExp(`([?&](?:${REDACTED_LOG_PARAMS.join("|")})=)[^&#]*`, "gi");
+        return url.replace(pattern, `$1${REDACTED_VALUE}`);
+    }
+}
+
 export function debugLog(message: unknown, level: DebugLevel = DebugLevel.INFO, ...optionalArgs: unknown[]): void {
     if (DOIT_DEBUG_LEVEL < level) return;
 
@@ -309,8 +343,8 @@ export async function makeDoitRequest<T>(
 
     const resolvedUrl = applyRuntimeDoiTApiBase(url);
     debugLog("Resolved DoiT API URL:", DebugLevel.TRACE, {
-        inputUrl: url,
-        resolvedUrl,
+        inputUrl: redactUrlForLog(url),
+        resolvedUrl: redactUrlForLog(resolvedUrl),
         isDemoToken: token === DEMO_TOKEN,
     });
 
@@ -366,7 +400,7 @@ export async function makeDoitRequest<T>(
             requestUrl += `&sse=true`;
         }
 
-        debugLog("API request URL: ", DebugLevel.VERBOSE, requestUrl);
+        debugLog("API request URL: ", DebugLevel.VERBOSE, redactUrlForLog(requestUrl));
         const response = await fetch(requestUrl, requestOptions);
 
         if (!response.ok) {
@@ -482,7 +516,7 @@ export async function makeConsoleRequest<T>(
         requestOptions.body = JSON.stringify(body);
     }
 
-    debugLog("Console API request URL: ", DebugLevel.VERBOSE, requestUrl);
+    debugLog("Console API request URL: ", DebugLevel.VERBOSE, redactUrlForLog(requestUrl));
     const response = await doFetch(requestUrl, requestOptions);
 
     if (!response.ok) {
@@ -516,7 +550,7 @@ export async function* makeDoitSSERequest(
     if (tracking?.mcpProtocolVersion) parsedUrl.searchParams.set("mcpProtocolVersion", tracking.mcpProtocolVersion);
 
     const requestUrl = parsedUrl.href;
-    debugLog("SSE request URL:", DebugLevel.VERBOSE, requestUrl);
+    debugLog("SSE request URL:", DebugLevel.VERBOSE, redactUrlForLog(requestUrl));
 
     const headers: Record<string, string> = {
         Authorization: `Bearer ${authToken}`,


### PR DESCRIPTION
Closes #83

Picks up the half of #83 that was still open. The unconditional `console.log("url", url)` is already gone and logging is off by default, so the first acceptance criterion was met — but with `DOIT_DEBUG_LEVEL` raised, the full request URL was still logged unredacted, `customerContext` and `pageToken` included.

## Change

Adds `redactUrlForLog()` and uses it at the four sites that log a request URL:

| Site | Level |
| --- | --- |
| `makeDoitRequest` — "API request URL" | VERBOSE |
| Console API helper — "Console API request URL" | VERBOSE |
| SSE helper — "SSE request URL" | VERBOSE |
| "Resolved DoiT API URL" (`inputUrl` / `resolvedUrl`) | TRACE |

The three VERBOSE ones are what the issue's follow-up comment identified. I included the TRACE site too, since it logs the same URLs and the acceptance criterion ("if debug logging exists, sensitive params are redacted") reads as applying wherever a URL is logged. Easy to drop that one if you'd rather keep the change to exactly the three.

Redacted parameters are `customerContext`, `pageToken` and `filter`, exported as `REDACTED_LOG_PARAMS` so the list is in one place.

Two details worth a look:

- **Case-insensitive matching** on parameter names, so a differently-cased `CustomerContext` cannot slip through.
- **Unparseable URLs still get redacted.** `new URL()` throws on a relative URL, and returning the raw string there would leak the value precisely when parsing failed. The fallback does a textual pass over `key=value` pairs instead.

The masked value is `REDACTED` rather than `[REDACTED]`, because `URLSearchParams.set` would percent-encode the brackets into `%5BREDACTED%5D`.

## Tests

Five tests in `src/utils/__tests__/util.test.ts` covering: all three parameters masked, surrounding URL left intact, a URL with no sensitive params returned unchanged, case-insensitive matching, and the unparseable-URL fallback.

- Full suite: **953 passed across 48 files**
- With `redactUrlForLog` reverted: the 5 new tests fail, 38 pass — so they pin the redaction rather than the surrounding code

`tsc --noEmit`, `biome lint` and `biome format` are all clean.
