### PR TITLE
chore: drop Cloudflare worker deps and npm remnants enforce yarn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # This project is Yarn 1 (see the packageManager/volta pins). A committed
+      # npm lockfile means someone ran `npm install`, which silently diverges from
+      # yarn.lock. `|| true` keeps a no-match grep from failing the step.
+      - name: Enforce yarn (no npm lockfiles committed)
+        run: |
+          found="$(git ls-files | grep -E '(^|/)(package-lock\.json|npm-shrinkwrap\.json)$' || true)"
+          if [ -n "$found" ]; then
+            echo "::error::This project uses Yarn 1 - remove the npm lockfile(s): $found"
+            exit 1
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,9 @@ coverage/
 # Optional REPL history
 .node_repl_history
 
-# Package lock files (uncomment if you want to ignore them)
-# package-lock.json
-# yarn.lock
+# npm lockfiles - this project uses Yarn 1; yarn.lock is committed
+package-lock.json
+npm-shrinkwrap.json
 
 # Debug files
 .debug
@@ -61,7 +61,6 @@ coverage/
 _local
 widget-gallery.html
 .yarn/
-package-lock.json
 
 # Local API-coverage loop config (not part of the published server)
 .doit-api-coverage/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: no-npm-lockfiles
+        name: No npm lockfiles (this project uses yarn)
+        entry: This project uses Yarn 1 - commit yarn.lock, never package-lock.json
+        language: fail
+        files: (^|/)(package-lock\.json|npm-shrinkwrap\.json)$
+
       - id: type-check
         name: TypeScript type check
         entry: yarn type-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@ present in your lockfile" or "The lockfile would have been modified by this inst
 either, your shell resolved an unpinned Yarn. Do not commit a berry-format lockfile or a
 `.yarnrc.yml` without migrating both projects and all four workflows together.
 
+**Never run `npm install`.** npm lockfiles are gitignored, rejected by the `no-npm-lockfiles`
+pre-commit hook, and fail the `Enforce yarn` step in `test.yml`. `npm` is still used deliberately
+for *publishing only* — `release.yml`'s `publish-npm` job needs the npm CLI for Trusted Publishing
+(OIDC + provenance), which yarn cannot do, and `yarn deploy` shells out to `npm publish` for the
+same reason. That is registry publication, not dependency management.
+
 ## Project Overview
 
 DoiT MCP Server is a Model Context Protocol (MCP) server that provides LLMs with access to the DoiT API.

--- a/package.json
+++ b/package.json
@@ -52,17 +52,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.3",
-    "cors": "^2.8.5",
     "dotenv": "^16.5.0",
-    "express": "^5.1.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "3.24.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
     "@readme/openapi-parser": "^2.6.0",
-    "@types/cors": "^2.8.17",
-    "@types/express": "^5.0.1",
     "@types/node": "^22",
     "openapi-types": "^12.1.3",
     "shx": "^0.3.4",

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -29,7 +29,8 @@ function applyRuntimeDoiTApiBase(url: string): string {
 // --- MCP tracking context ---
 // Uses AsyncLocalStorage for request-scoped tracking. Module-level globals are unsafe in the
 // SSE/Cloudflare path because Durable Object instances can share module scope on the same isolate.
-// AsyncLocalStorage is supported via the nodejs_compat flag in wrangler.jsonc.
+// AsyncLocalStorage is supported via the nodejs_compat flag in the remote Worker's wrangler
+// config (separate private repo).
 
 export interface TrackingContext {
     mcpTool?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,68 +419,15 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz#23b860113e9f87eea015d1fa3a4240a52b42fcd4"
   integrity sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==
 
-"@types/body-parser@*":
-  version "1.19.6"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
-  integrity sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
-"@types/connect@*":
-  version "3.4.38"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
-  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
-  dependencies:
-    "@types/node" "*"
-
-"@types/cors@^2.8.17":
-  version "2.8.19"
-  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.19.tgz#d93ea2673fd8c9f697367f5eeefc2bbfa94f0342"
-  integrity sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/estree@1.0.8", "@types/estree@^1.0.0":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/express-serve-static-core@^5.0.0":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
-  integrity sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-    "@types/send" "*"
-
-"@types/express@^5.0.1":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
-  integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^5.0.0"
-    "@types/serve-static" "^2"
-
-"@types/http-errors@*":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
-  integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
-
 "@types/json-schema@^7.0.6":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
-
-"@types/node@*":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.5.0.tgz#5c99f37c443d9ccc4985866913f1ed364217da31"
-  integrity sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==
-  dependencies:
-    undici-types "~7.18.0"
 
 "@types/node@^22":
   version "22.19.15"
@@ -488,31 +435,6 @@
   integrity sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==
   dependencies:
     undici-types "~6.21.0"
-
-"@types/qs@*":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.15.0.tgz#963ab61779843fe910639a50661b48f162bc7f79"
-  integrity sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==
-
-"@types/range-parser@*":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
-  integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
-
-"@types/send@*":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@types/send/-/send-1.2.1.tgz#6a784e45543c18c774c049bff6d3dbaf045c9c74"
-  integrity sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/serve-static@^2":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
-  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
-  dependencies:
-    "@types/http-errors" "*"
-    "@types/node" "*"
 
 "@vitest/expect@3.1.4":
   version "3.1.4"
@@ -883,7 +805,7 @@ express-rate-limit@^8.2.1:
   dependencies:
     ip-address "10.1.0"
 
-express@^5.1.0, express@^5.2.1:
+express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -1569,11 +1491,6 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-
-undici-types@~7.18.0:
-  version "7.18.2"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
-  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Splitting the remote transport out (#216 added the /core export, #218 `27721b1` deleted the in-repo Worker subdirectory) never touched the root dependency list, so this pure stdio server still declared the deps only the deleted Express/Hono transport needed. Remove express and cors plus their @types — nothing under src/, test/, or scripts/ imports them. The MCP SDK still pulls express and cors in transitively, so only the declarations and the @types/express-serve-static-core subtree leave yarn.lock.

Also make yarn the enforced package manager: consolidate the contradictory npm-lockfile rules in .gitignore, reject committed npm lockfiles via a no-npm-lockfiles pre-commit hook and a fail-fast CI step, and document in AGENTS.md that npm stays deliberate for publishing only (Trusted Publishing needs the npm CLI). Fix a comment still pointing at the wrangler.jsonc that `27721b1` deleted.